### PR TITLE
Allow stdout and stderr in output reports

### DIFF
--- a/dnf-docker-test/launch-test
+++ b/dnf-docker-test/launch-test
@@ -2,4 +2,4 @@
 set -xeuo pipefail
 
 httpd -k start
-behave-2 -i $1 -D dnf_command_version=$2 --junit --junit-directory /junit/ /behave/
+behave-2 -i $1 --no-capture --no-capture-stderr -D dnf_command_version=$2 --junit --junit-directory /junit/ /behave/


### PR DESCRIPTION
Behave as default captures outputs including output from print function. But for
debuging issue, it is important to get some additional information.

Down-site is that test description will be interrupted by these messages.