### PR TITLE
Change test condition according with relocation of repoquery

### DIFF
--- a/dnf-docker-test/features/plugin-path-1.feature
+++ b/dnf-docker-test/features/plugin-path-1.feature
@@ -1,11 +1,12 @@
 Feature: DNF/Behave test (pluginspath and pluginsconfpath test)
 
 Scenario: Redirect host pluginspath
-  When I execute "dnf" command "repoquery TestA" with "success"
+  Given I use the repository "test-1"
+  When I execute "dnf" command "download TestA" with "success"
   And I execute "dnf" command "copr list rpmsoftwaremanagement" with "success"
-  When I copy plugin module "repoquery.py" from default plugin path into "/test/plugins"
+  When I copy plugin module "download.py" from default plugin path into "/test/plugins"
   And I create a file "/etc/dnf/dnf.conf" with content: "[main]\npluginpath=/test/plugins"
-  Then I execute "dnf" command "repoquery TestA" with "success"
+  Then I execute "dnf" command "download TestA" with "success"
   And I execute "dnf" command "copr list rpmsoftwaremanagement" with "fail"
   When I copy plugin module "copr.py" from default plugin path into "/test/plugins"
   Then I execute "dnf" command "copr list rpmsoftwaremanagement" with "success"

--- a/dnf-docker-test/features/plugin-path-2.feature
+++ b/dnf-docker-test/features/plugin-path-2.feature
@@ -1,12 +1,13 @@
 Feature: DNF/Behave test (pluginspath and pluginsconfpath test)
 
 Scenario: Redirect installroot pluginspath
-  When I execute "dnf" command "--installroot=/dockertesting repoquery TestA" with "success"
+  Given I use the repository "test-1"
+  When I execute "dnf" command "--installroot=/dockertesting download TestA" with "success"
   And I execute "dnf" command "--installroot=/dockertesting copr list rpmsoftwaremanagement" with "success"
   And I execute "dnf" command "--installroot=/dockertesting config-manager" with "success"
-  When I copy plugin module "repoquery.py, copr.py" from default plugin path into "/test/plugins2"
+  When I copy plugin module "download.py, copr.py" from default plugin path into "/test/plugins2"
   And I create a file "/dockertesting/etc/dnf/dnf.conf" with content: "[main]\npluginpath=/test/plugins2"
-  Then I execute "dnf" command "--installroot=/dockertesting repoquery TestA" with "success"
+  Then I execute "dnf" command "--installroot=/dockertesting download TestA" with "success"
   And I execute "dnf" command "--installroot=/dockertesting copr list rpmsoftwaremanagement" with "success"
   And I execute "dnf" command "--installroot=/dockertesting config-manager" with "fail"
   When I create a file "/etc/dnf/dnf.conf" with content: "[main]"


### PR DESCRIPTION
The incorporation of repoquery into dnf caused the fail of two test according to
missing repoquery.py file. Therefore it is important to merge this commit at the
same time or earlier than repoquery-incorporation PR will be merged into
upstream.