### PR TITLE
Dockerfile: do autoremove after installation of local RPM(s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ ENV LANG C
 
 RUN dnf -y update
 RUN dnf -y install httpd /usr/bin/behave-2
-RUN dnf -y autoremove
 COPY dnf-docker-test/repo /var/www/html/repo/
 COPY dnf-docker-test/features /behave/
 
 COPY rpms /rpms/
 # TODO: COPR broken, drop --allowerasing
 RUN dnf -y install /rpms/*.rpm --allowerasing
+RUN dnf -y autoremove
 RUN dnf -y clean all
 RUN mkdir /tmp/repos.d && mv /etc/yum.repos.d/* /tmp/repos.d/
 


### PR DESCRIPTION
Since libhif#ac7172488f2f618100dad3a1520a2f43fdf9424b in minimal
system hawkey (C lib) is still present, but it's not needed anymore
as pythonX-hawkey is getting obsoleted by one from libdnf, so hawkey
is candidate for autoremove which breaks our tests.