### PR TITLE
overlays/dnf-master: libhif -> libdnf

### DIFF
--- a/overlays/dnf-master/overlay.yml
+++ b/overlays/dnf-master/overlay.yml
@@ -37,7 +37,7 @@ components:
     distgit:
       src: fedorapkgs:libcomps.git
 
-  - name: libhif
+  - name: libdnf
     git:
       src: github:rpm-software-management/libhif.git
 


### PR DESCRIPTION
References: https://github.com/rpm-software-management/libhif/pull/166
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>