### PR TITLE
jobs: reuse existing connection when downloading RPMs

### DIFF
--- a/jobs/github-testers-macros.yaml
+++ b/jobs/github-testers-macros.yaml
@@ -209,12 +209,11 @@
           #!/bin/bash
           set -xeuo pipefail
 
+          join() { local IFS="$1"; shift; echo "$*"; }
+          RPMS=($RPMS)
           pushd ci-dnf-stack
             pushd rpms
-              echo "$RPMS" | xargs -n 1 curl -L -O
-              if ! ls *.rpm; then
-                exit 1
-              fi
+              join , "{{${{RPMS[@]}}}}" | xargs curl -O
             popd
             TESTS=($(./dnf-testing.sh list))
             CONTAINER=$(./dnf-testing.sh build)


### PR DESCRIPTION
Before:
real	1m20.110s
user	0m1.833s
sys	0m10.261s

After:
real	0m15.899s
user	0m0.218s
sys	0m0.565s

Unfortunately, cURL doesn't like arguments like: -O url1 url2 url3
But it can handle style like: -O "{url1,url2,url3}"

P.S. quotes are also important

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>