### PR TITLE
repoquery-1: expect md expiration msg in stderr

### DIFF
--- a/dnf-docker-test/features/repoquery-1.feature
+++ b/dnf-docker-test/features/repoquery-1.feature
@@ -4,11 +4,11 @@ Scenario: Repoquery formated output plus --available, --installed, -Cq, -qC opti
   Given I use the repository "test-1"
   When I execute "dnf" command "repoquery --available -Cq --queryformat %{name}-%{version}-%{release}" with "success"
   Then line from "stdout" should "not start" with "TestB-1.0.0-1"
-  Then line from "stdout" should "not start" with "Last metadata expiration check"
+  Then line from "stderr" should "not start" with "Last metadata expiration check"
   Then line from "stderr" should "start" with "Cache-only enabled but no cache for"
   When I execute "dnf" command "repoquery --available -qC --queryformat %{name}-%{version}-%{release}" with "success"
   Then line from "stdout" should "not start" with "TestB-1.0.0-1"
-  Then line from "stdout" should "not start" with "Last metadata expiration check"
+  Then line from "stderr" should "not start" with "Last metadata expiration check"
   Then line from "stderr" should "start" with "Cache-only enabled but no cache for"
   When I execute "dnf" command "makecache" with "success"
   When I execute "dnf" command "repoquery --available -Cq --queryformat %{name}-%{version}-%{release}" with "success"
@@ -18,7 +18,7 @@ Scenario: Repoquery formated output plus --available, --installed, -Cq, -qC opti
   Then line from "stdout" should "not start" with "TestB-1.0.0-1"
   When I execute "dnf" command "repoquery -C --queryformat %{name}-%{version}-%{release}" with "success"
   Then line from "stdout" should "start" with "TestB-1.0.0-1"
-  Then line from "stdout" should "start" with "Last metadata expiration check"
+  Then line from "stderr" should "start" with "Last metadata expiration check"
   When I execute "dnf" command "install -y TestB" with "success"
   Then transaction changes are as follows
     | State        | Packages   |


### PR DESCRIPTION
In dnf#a9f70757b7d2f23e48b265662ba95a8dae202730 we moved message about
metadata expiration to the stderr as it's not supposed to be parseable.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>