### PR TITLE
jobs: stop doing nightlies for F23

### DIFF
--- a/jobs/nightly.yaml
+++ b/jobs/nightly.yaml
@@ -21,8 +21,6 @@
       - "{name}-{chroot}"
     chroot:
       - epel-7-x86_64
-      - fedora-23-x86_64
-      - fedora-23-i386
       - fedora-24-x86_64
       - fedora-24-i386
       - fedora-25-x86_64


### PR DESCRIPTION
It's outdated and will be EOL in 1 month. Since officially DNF is coming
only in F26 it's fine to stop producing RPMs for such system.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>