### PR TITLE
Eneble extras in docker plus docker image reduction by 50%

### DIFF
--- a/Dockerfile.jjb
+++ b/Dockerfile.jjb
@@ -15,7 +15,7 @@ COPY dnf-docker-test/features /behave/
 
 COPY rpms /rpms/
 # prevent installation of dnf-plugins-extras
-RUN rm /rpms/*extras*.rpm
+RUN rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm
 RUN dnf -y install /rpms/*.rpm
 RUN dnf -y autoremove
 RUN dnf -y clean all

--- a/Dockerfile.jjb
+++ b/Dockerfile.jjb
@@ -1,27 +1,36 @@
 FROM fedora:24
 ENV LANG C
 
-RUN echo "deltarpm=0" >> /etc/dnf/dnf.conf
-RUN dnf -y update
-# behave: core
-# httpd: old-style repos
-# six: py2/py3
-# enum34: rpmdb State
-# whichcraft: shutil.which() for py2
-# jinja2: rpmspec template
-RUN dnf -y install httpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect
 COPY dnf-docker-test/repo /var/www/html/repo/
 COPY dnf-docker-test/features /behave/
-
 COPY rpms /rpms/
-# prevent installation of dnf-plugins-extras
-RUN rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm
-RUN dnf -y install /rpms/*.rpm
-RUN dnf -y autoremove
-RUN dnf -y clean all
-RUN mkdir /tmp/repos.d && mv /etc/yum.repos.d/* /tmp/repos.d/
+
+RUN echo $'\necho "deltarpm=0" >> /etc/dnf/dnf.conf' \
+    && echo "deltarpm=0" >> /etc/dnf/dnf.conf \
+    && echo "dnf -y update" \
+    && dnf -y update \
+
+    # behave: core
+    # httpd: old-style repos
+    # six: py2/py3
+    # enum34: rpmdb State
+    # whichcraft: shutil.which() for py2
+    # jinja2: rpmspec template
+    && echo "dnf -y install httpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect" \
+    && dnf -y install httpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect \
+    # prevent installation of dnf-plugins-extras (versionlock, local, torproxy)
+    && echo "rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm" \
+    && rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm
+    && echo "dnf -y install /rpms/*.rpm" \
+    && dnf -y install /rpms/*.rpm \
+    && echo "dnf -y autoremove" \
+    && dnf -y autoremove \
+    && echo "dnf -y clean all" \
+    && dnf -y clean all \
+    && echo "mkdir /tmp/repos.d && mv /etc/yum.repos.d/* /tmp/repos.d/" \
+    && mkdir /tmp/repos.d && mv /etc/yum.repos.d/* /tmp/repos.d/ \
+    && echo "mkdir /repo" \
+    && mkdir /repo
 
 ADD dnf-docker-test/launch-test /usr/bin/
-RUN mkdir /repo
-
 VOLUME ["/junit"]

--- a/Dockerfile.jjb
+++ b/Dockerfile.jjb
@@ -7,8 +7,6 @@ COPY rpms /rpms/
 
 RUN echo $'\necho "deltarpm=0" >> /etc/dnf/dnf.conf' \
     && echo "deltarpm=0" >> /etc/dnf/dnf.conf \
-    && echo "dnf -y update" \
-    && dnf -y update \
 
     # behave: core
     # httpd: old-style repos

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -15,6 +15,8 @@ COPY dnf-docker-test/features /behave/
 # Allows to run test with rpms from only single component in rpms/
 RUN dnf -y copr enable rpmsoftwaremanagement/dnf-nightly
 COPY rpms /rpms/
+# prevent installation of dnf-plugins-extras (versionlock, local, torproxy)
+RUN rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm || (>&2 echo "RPMs files do not exist")
 RUN dnf -y update
 RUN if ls /rpms/*.rpm 1> /dev/null 2>&1; then dnf -y install /rpms/*.rpm; else (>&2 echo "RPMs files do not exist"); fi
 RUN dnf -y mark install $(dnf repoquery --unneeded -q)

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,29 +1,39 @@
 FROM fedora:24
 ENV LANG C
 
-RUN echo "deltarpm=0" >> /etc/dnf/dnf.conf
-# behave: core
-# httpd: old-style repos
-# six: py2/py3
-# enum34: rpmdb State
-# whichcraft: shutil.which() for py2
-# jinja2: rpmspec template
-RUN dnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd python2-behave python2-six python-enum34 https://kojipkgs.fedoraproject.org//packages/python-whichcraft/0.4.0/2.fc24/noarch/python2-whichcraft-0.4.0-2.fc24.noarch.rpm python2-jinja2 rpm-build createrepo_c python2-pexpect
 COPY dnf-docker-test/repo /var/www/html/repo/
 COPY dnf-docker-test/features /behave/
-
-# Allows to run test with rpms from only single component in rpms/
-RUN dnf -y copr enable rpmsoftwaremanagement/dnf-nightly
 COPY rpms /rpms/
-# prevent installation of dnf-plugins-extras (versionlock, local, torproxy)
-RUN rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm || (>&2 echo "RPMs files do not exist")
-RUN dnf -y update
-RUN if ls /rpms/*.rpm 1> /dev/null 2>&1; then dnf -y install /rpms/*.rpm; else (>&2 echo "RPMs files do not exist"); fi
-RUN dnf -y mark install $(dnf repoquery --unneeded -q)
-RUN dnf -y clean all
-RUN mkdir /tmp/repos.d && mv /etc/yum.repos.d/* /tmp/repos.d/
+
+RUN echo $'\necho "deltarpm=0" >> /etc/dnf/dnf.conf' \
+    && echo "deltarpm=0" >> /etc/dnf/dnf.conf \
+    # behave: core
+    # httpd: old-style repos
+    # six: py2/py3
+    # enum34: rpmdb State
+    # whichcraft: shutil.which() for py2
+    # jinja2: rpmspec template
+    && echo $'\ndnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd python2-behave python2-six python-enum34 https://kojipkgs.fedoraproject.org//packages/python-whichcraft/0.4.0/2.fc24/noarch/python2-whichcraft-0.4.0-2.fc24.noarch.rpm python2-jinja2 rpm-build createrepo_c python2-pexpect' \
+    && dnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd python2-behave python2-six python-enum34 https://kojipkgs.fedoraproject.org//packages/python-whichcraft/0.4.0/2.fc24/noarch/python2-whichcraft-0.4.0-2.fc24.noarch.rpm python2-jinja2 rpm-build createrepo_c python2-pexpect \
+    # Allows to run test with rpms from only single component in rpms/
+    && echo $'\ndnf -y copr enable rpmsoftwaremanagement/dnf-nightly' \
+    && dnf -y copr enable rpmsoftwaremanagement/dnf-nightly \
+    # prevent installation of dnf-plugins-extras (versionlock, local, torproxy)
+    && echo $'\nrm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm || (>&2 echo "RPMs files do not exist")' \
+    && rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm || (>&2 echo "RPMs files do not exist") \
+    && echo $'\ndnf -y update' \
+    && dnf -y update \
+    && echo $'\nif ls /rpms/*.rpm 1> /dev/null 2>&1; then dnf -y install /rpms/*.rpm; else (>&2 echo "RPMs files do not exist"); fi' \
+    && if ls /rpms/*.rpm 1> /dev/null 2>&1; then dnf -y install /rpms/*.rpm; else (>&2 echo "RPMs files do not exist"); fi \
+    && echo $'\ndnf -y mark install $(dnf repoquery --unneeded -q)' \
+    && dnf -y mark install $(dnf repoquery --unneeded -q) \
+    && echo $'\ndnf -y clean all' \
+    && dnf -y clean all \
+    && echo $'\nmkdir /tmp/repos.d && mv /etc/yum.repos.d/* /tmp/repos.d/' \
+    && mkdir /tmp/repos.d && mv /etc/yum.repos.d/* /tmp/repos.d/ \
+    && echo $'\nmkdir /repo' \
+    && mkdir /repo
 
 ADD dnf-docker-test/launch-test /usr/bin/
-RUN mkdir /repo
 
 VOLUME ["/junit"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -14,7 +14,7 @@ RUN echo $'\necho "deltarpm=0" >> /etc/dnf/dnf.conf' \
     # whichcraft: shutil.which() for py2
     # jinja2: rpmspec template
     && echo $'\ndnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd python2-behave python2-six python-enum34 https://kojipkgs.fedoraproject.org//packages/python-whichcraft/0.4.0/2.fc24/noarch/python2-whichcraft-0.4.0-2.fc24.noarch.rpm python2-jinja2 rpm-build createrepo_c python2-pexpect' \
-    && dnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd python2-behave python2-six python-enum34 https://kojipkgs.fedoraproject.org//packages/python-whichcraft/0.4.0/2.fc24/noarch/python2-whichcraft-0.4.0-2.fc24.noarch.rpm python2-jinja2 rpm-build createrepo_c python2-pexpect \
+    && dnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd python2-behave python2-six python-enum34 python2-whichcraft python2-jinja2 rpm-build createrepo_c python2-pexpect \
     # Allows to run test with rpms from only single component in rpms/
     && echo $'\ndnf -y copr enable rpmsoftwaremanagement/dnf-nightly' \
     && dnf -y copr enable rpmsoftwaremanagement/dnf-nightly \


### PR DESCRIPTION
It installs extras except versionlock, local, and torproxy plugins.

It requires: 
https://github.com/rpm-software-management/dnf-plugins-extras/pull/78
https://github.com/rpm-software-management/dnf-plugins-extras/pull/77