### PR TITLE
Allow to match regexps in cmd outputs

### DIFF
--- a/dnf-docker-test/features/steps/command_steps.py
+++ b/dnf-docker-test/features/steps/command_steps.py
@@ -46,3 +46,10 @@ def step_the_command_stream_should_contain_exactly(ctx, stream):
 def step_the_command_stream_should_be_empty(ctx, stream):
     ctx.text = ""
     step_the_command_stream_should_contain_exactly(ctx, stream)
+
+@then("the command {stream:stdout_stderr} should match regexp")
+def step_the_command_stream_should_match_regexp(ctx, stream):
+    ctx.assertion.assertIsNotNone(ctx.text, "Multiline text is not provided")
+    text = getattr(ctx.cmd_result, stream)
+    ctx.assertion.assertRegexpMatches(text, ctx.text)
+

--- a/dnf-docker-test/features/steps/command_steps.py
+++ b/dnf-docker-test/features/steps/command_steps.py
@@ -52,4 +52,3 @@ def step_the_command_stream_should_match_regexp(ctx, stream):
     ctx.assertion.assertIsNotNone(ctx.text, "Multiline text is not provided")
     text = getattr(ctx.cmd_result, stream)
     ctx.assertion.assertRegexpMatches(text, ctx.text)
-

--- a/dnf-docker-test/features/steps/command_steps.py
+++ b/dnf-docker-test/features/steps/command_steps.py
@@ -47,8 +47,8 @@ def step_the_command_stream_should_be_empty(ctx, stream):
     ctx.text = ""
     step_the_command_stream_should_contain_exactly(ctx, stream)
 
-@then("the command {stream:stdout_stderr} should match regexp")
-def step_the_command_stream_should_match_regexp(ctx, stream):
-    ctx.assertion.assertIsNotNone(ctx.text, "Multiline text is not provided")
+
+@then('the command {stream:stdout_stderr} should match regexp "{regexp}"')
+def step_the_command_stream_should_match_regexp(ctx, stream, regexp):
     text = getattr(ctx.cmd_result, stream)
-    ctx.assertion.assertRegexpMatches(text, ctx.text)
+    ctx.assertion.assertRegexpMatches(text, regexp)

--- a/dnf-docker-test/features/steps/command_steps.py
+++ b/dnf-docker-test/features/steps/command_steps.py
@@ -52,3 +52,9 @@ def step_the_command_stream_should_be_empty(ctx, stream):
 def step_the_command_stream_should_match_regexp(ctx, stream, regexp):
     text = getattr(ctx.cmd_result, stream)
     ctx.assertion.assertRegexpMatches(text, regexp)
+
+
+@then('the command {stream:stdout_stderr} should not match regexp "{regexp}"')
+def step_the_command_stream_should_not_match_regexp(ctx, stream, regexp):
+    text = getattr(ctx.cmd_result, stream)
+    ctx.assertion.assertNotRegexpMatches(text, regexp)


### PR DESCRIPTION
only exact multiline outputs can be matched now, this allows to match also regexps