### PR TITLE
dnf-testing.sh: ability to reserve a running container

### DIFF
--- a/dnf-docker-test/launch-test
+++ b/dnf-docker-test/launch-test
@@ -1,5 +1,19 @@
 #!/bin/bash
 set -xeuo pipefail
 
+RESERVE=0
+RET=0
+
+if [ "$1" == "-r" ]; then
+    RESERVE=1
+    shift
+fi
+
 httpd -k start
-behave-2 -i $1 -D dnf_cmd=$2 --junit --junit-directory /junit/ /behave/
+behave-2 -i $1 -D dnf_cmd=$2 --junit --junit-directory /junit/ /behave/ || RET=$?
+
+if [ "$RESERVE" == "1" ]; then
+  bash || :
+fi
+
+exit $RET


### PR DESCRIPTION
This commit adds 1 command and 1 option to ease debugging
 -r, --reserve  to open a bash session in a running container after the test is execution
 shell to simply run a bash session in a container, no tests are executed in this case