### PR TITLE
make shell_commands.py follow CommandResult format

### DIFF
--- a/dnf-docker-test/features/shell-1.feature
+++ b/dnf-docker-test/features/shell-1.feature
@@ -14,7 +14,11 @@ Feature: Installing updating and removing a package in dnf shell
          | State     | Packages     |
          | installed | TestA, TestB |
      When I run dnf shell command "exit"
-     Then the command output should contain "Leaving Shell"
+     Then the command stdout should contain exactly
+          """
+          Leaving Shell
+
+          """
 
   Scenario: Updating package using the upgrade command
     Given repository "TestRepoB" with packages
@@ -29,7 +33,11 @@ Feature: Installing updating and removing a package in dnf shell
          | State   | Packages |
          | updated | TestA    |
      When I run dnf shell command "exit"
-     Then the command output should contain "Leaving Shell"
+     Then the command stdout should contain exactly
+          """
+          Leaving Shell
+
+          """
 
   Scenario: Updating package using the update command
     Given repository "TestRepoC" with packages
@@ -44,7 +52,11 @@ Feature: Installing updating and removing a package in dnf shell
          | State   | Packages |
          | updated | TestB    |
      When I run dnf shell command "exit"
-     Then the command output should contain "Leaving Shell"
+     Then the command stdout should contain exactly
+          """
+          Leaving Shell
+
+          """
 
   Scenario: Removing a package
     Given I have dnf shell session opened with parameters "-y"
@@ -55,7 +67,11 @@ Feature: Installing updating and removing a package in dnf shell
          | State     | Packages |
          | removed   | TestA    |
      When I run dnf shell command "exit"
-     Then the command output should contain "Leaving Shell"
+     Then the command stdout should contain exactly
+          """
+          Leaving Shell
+
+          """
 
   Scenario: Installing and removing a package within one transaction
     Given I have dnf shell session opened with parameters "-y"
@@ -69,5 +85,8 @@ Feature: Installing updating and removing a package in dnf shell
          | installed | TestA    |
          | removed   | TestB    |
      When I run dnf shell command "exit"
-     Then the command output should contain "Leaving Shell"
+     Then the command stdout should contain exactly
+          """
+          Leaving Shell
 
+          """

--- a/dnf-docker-test/features/shell-3.feature
+++ b/dnf-docker-test/features/shell-3.feature
@@ -28,5 +28,8 @@ Feature: Switching conflicting packages in dnf shell
          | removed   | TestB    |
          | installed | TestC    |
      When I run dnf shell command "quit"
-     Then the command output should contain "Leaving Shell"
+     Then the command stdout should contain exactly
+          """
+          Leaving Shell
 
+          """


### PR DESCRIPTION
This commit changes step_i_run_dnf_shell_command() so it uses CommandResult() object to store the command line output. Therefore newly added functions 
  step_the_command_output_shoud_contain()
  step_the_command_output_shoud_not_contain()
are not needed any more as the previously existing step
  "the command stdout should contain exactly"
could be used.

This commit also updates dnf shell tests accordingly.