### PR TITLE
add support for http and ftp repository types

### DIFF
--- a/Dockerfile.jjb
+++ b/Dockerfile.jjb
@@ -16,8 +16,8 @@ RUN echo $'\necho "deltarpm=0" >> /etc/dnf/dnf.conf' \
     # enum34: rpmdb State
     # whichcraft: shutil.which() for py2
     # jinja2: rpmspec template
-    && echo "dnf -y install httpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect" \
-    && dnf -y install httpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect \
+    && echo "dnf -y install httpd vsftpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect" \
+    && dnf -y install httpd vsftpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect \
     # prevent installation of dnf-plugins-extras (versionlock, local, torproxy)
     && echo "rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm" \
     && rm /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm \

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -13,8 +13,8 @@ RUN echo $'\necho "deltarpm=0" >> /etc/dnf/dnf.conf' \
     # enum34: rpmdb State
     # whichcraft: shutil.which() for py2
     # jinja2: rpmspec template
-    && echo $'\ndnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd python2-behave python2-six python-enum34 https://kojipkgs.fedoraproject.org//packages/python-whichcraft/0.4.0/2.fc24/noarch/python2-whichcraft-0.4.0-2.fc24.noarch.rpm python2-jinja2 rpm-build createrepo_c python2-pexpect' \
-    && dnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd python2-behave python2-six python-enum34 python2-whichcraft python2-jinja2 rpm-build createrepo_c python2-pexpect \
+    && echo $'\ndnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd vsftpd python2-behave python2-six python-enum34 https://kojipkgs.fedoraproject.org//packages/python-whichcraft/0.4.0/2.fc24/noarch/python2-whichcraft-0.4.0-2.fc24.noarch.rpm python2-jinja2 rpm-build createrepo_c python2-pexpect' \
+    && dnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core httpd vsftpd python2-behave python2-six python-enum34 python2-whichcraft python2-jinja2 rpm-build createrepo_c python2-pexpect \
     # Allows to run test with rpms from only single component in rpms/
     && echo $'\ndnf -y copr enable rpmsoftwaremanagement/dnf-nightly' \
     && dnf -y copr enable rpmsoftwaremanagement/dnf-nightly \


### PR DESCRIPTION
Updates current step 'Given repository "reponame" with packages' to optionally define a repository type.
Currently implemented types are local (default), http and ftp.