### PR TITLE
add support for http and ftp repository types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ RUN echo -e '\necho "deltarpm=0" >> /etc/dnf/dnf.conf' \
     # enum34: rpmdb State
     # whichcraft: shutil.which() for py2
     # jinja2: rpmspec template
-    && echo -e '\ndnf -y install httpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect' \
-    && dnf -y install httpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect \
+    && echo -e '\ndnf -y install httpd vsftpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect' \
+    && dnf -y install httpd vsftpd python2-behave python2-six python-enum34 python2-whichcraft python-jinja2 python2-pexpect \
     && if [ $type = "local" ] ; then \
         # Allows to run test with rpms from only single component in rpms/
         echo -e '\ndnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core rpm-build createrepo_c' \

--- a/dnf-docker-test/features/steps/file_utils.py
+++ b/dnf-docker-test/features/steps/file_utils.py
@@ -7,6 +7,8 @@ import os
 import six
 from six.moves import configparser
 
+from command_steps import step_i_successfully_run_command
+
 def readline_generator(f):
     line = f.readline()
     while line:
@@ -51,3 +53,14 @@ def read_ini_file(filename):
         else:
             conf.read_file(readline_generator(instream))
     return conf
+
+def set_dir_content_ownership(ctx, directory, user=None):
+    if not user:
+        if directory.startswith('/var/www/html'):
+            user = 'apache'
+        elif directory.startswith('/var/ftp'):
+            user = 'ftp'
+        else:
+            user = 'root'
+    cmd = 'chown -R {!s} {!s}'.format(user, directory)
+    step_i_successfully_run_command(ctx, cmd)

--- a/dnf-docker-test/features/steps/repo_steps.py
+++ b/dnf-docker-test/features/steps/repo_steps.py
@@ -83,6 +83,18 @@ def parse_enable_disable(text):
 
 register_type(enable_disable=parse_enable_disable)
 
+@parse.with_pattern(r"local |http |ftp |")
+def parse_repo_type(text):
+    if text == "http ":
+        return "http"
+    elif text == "ftp ":
+        return "ftp"
+    elif text == 'local ' or text == '':
+        return "file"
+    assert False
+
+register_type(repo_type=parse_repo_type)
+
 @when('I remove all repositories')
 def step_i_remove_all_repositories(ctx):
     """
@@ -91,10 +103,11 @@ def step_i_remove_all_repositories(ctx):
     for f in glob.glob("/etc/yum.repos.d/*.repo"):
         os.remove(f)
 
-@given('repository "{repository}" with packages')
-def given_repository_with_packages(ctx, repository):
+@given('{rtype:repo_type}repository "{repository}" with packages')
+def given_repository_with_packages(ctx, rtype, repository):
     """
     Builds dummy noarch packages, creates repo and *.repo* file.
+    Supported repo types are http, ftp or local (default).
 
     .. note::
 
@@ -136,7 +149,7 @@ def given_repository_with_packages(ctx, repository):
        Feature: Working with repositories
 
          Background: Repository base with dummy package
-               Given repository base with packages
+               Given http repository base with packages
                   | Package | Tag | Value |
                   | foo     |     |       |
 
@@ -152,7 +165,15 @@ def given_repository_with_packages(ctx, repository):
     createrepo = which("createrepo_c")
     ctx.assertion.assertIsNotNone(createrepo, "createrepo_c is required")
 
-    tmpdir = tempfile.mkdtemp()
+    if rtype == 'http':
+        tmpdir = tempfile.mkdtemp(dir='/var/www/html')
+        repopath = os.path.join('localhost', os.path.basename(tmpdir))
+    elif rtype == 'ftp':
+        tmpdir = tempfile.mkdtemp(dir='/var/ftp/pub')
+        repopath = os.path.join('localhost/pub', os.path.basename(tmpdir))
+    else:
+        tmpdir = tempfile.mkdtemp()
+        repopath = tmpdir
     template = JINJA_ENV.from_string(PKG_TMPL)
     for name, settings in packages.items():
         settings = {k.lower(): v for k, v in settings.items()}
@@ -165,12 +186,15 @@ def given_repository_with_packages(ctx, repository):
     cmd = "{!s} {!s}".format(createrepo, tmpdir)
     step_i_successfully_run_command(ctx, cmd)
 
+    # set proper directory content ownership
+    file_utils.set_dir_content_ownership(ctx, tmpdir)
+
     repofile = REPO_TMPL.format(repository)
     ctx.table = Table(HEADINGS_INI)
     ctx.table.add_row([repository, "name",     repository])
     ctx.table.add_row(["",         "enabled",  "False"])
     ctx.table.add_row(["",         "gpgcheck", "False"])
-    ctx.table.add_row(["",         "baseurl",  "file://{!s}".format(tmpdir)])
+    ctx.table.add_row(["",         "baseurl",  "{!s}://{!s}".format(rtype, repopath)])
     step_an_ini_file_filepath_with(ctx, repofile)
 
 @given('empty repository "{repository}"')
@@ -180,7 +204,7 @@ def given_empty_repository(ctx, repository):
     packages (empty).
     """
     ctx.table = Table(HEADINGS_REPO)
-    given_repository_with_packages(ctx, repository)
+    given_repository_with_packages(ctx, "file", repository)
 
 @when('I {state:enable_disable} repository "{repository}"')
 def i_enable_disable_repository(ctx, state, repository):

--- a/dnf-docker-test/launch-test
+++ b/dnf-docker-test/launch-test
@@ -2,6 +2,7 @@
 set -xeuo pipefail
 
 httpd -k start
+vsftpd
 new_name=${1}-${2}
 mv /behave/${1}.feature /behave/${new_name}.feature
 behave-2 -i $new_name -D dnf_cmd=$2 --junit --junit-directory /junit/ /behave/


### PR DESCRIPTION
Updates current step 'Given repository "reponame" with packages' to optionally define a repository type.
Currently implemented types are local (default), http and ftp.
local repo remains under /tmp, http repos are located under /var/www/html, ftp repos under /var/ftp/pub.
vsftpd is added to Dockerfile and started later to serve as ftp server.

file_utils.py have been updated with a new function set_dir_content_ownership() that is used to change file ownership of html or ftp content to respective users (or to a user passed as an argument).

If this gets merged, I will also provide fixes for updateinfo.xml and comps.xml creation where the directory ownership has to be changed to root before calling modifyrepo_c or createrepo_c and later restored, otherwise it won't work properly for http|ftp repositories.
