### PR TITLE
implements step for adding updateinfo.xml into a repository

### DIFF
--- a/dnf-docker-test/features/steps/repo_steps.py
+++ b/dnf-docker-test/features/steps/repo_steps.py
@@ -20,6 +20,7 @@ from file_steps import step_a_file_filepath_with
 from file_steps import step_an_ini_file_filepath_with
 import file_utils
 import table_utils
+import repo_utils
 
 PKG_TMPL = """
 Name:           {{ name }}
@@ -216,3 +217,93 @@ def i_enable_disable_repository(ctx, state, repository):
     conf.set(repository, "enabled", str(state))
     ctx.table = conf2table(conf)
     step_an_ini_file_filepath_with(ctx, repofile)
+
+@given('updateinfo defined in repository "{repository}"')
+def step_updateinfo_defined_in_repository(ctx, repository):
+    """
+    For a given repository creates updateinfo.xml file with described
+    updates and recreates the repo
+
+    .. note::
+
+       Requires *modifyrepo_c* and the repo to be already created.
+
+    Requires table with following headers:
+
+    ==== ===== =======
+     Id   Tag   Value
+    ==== ===== =======
+
+    *Tag* is describing attributes of the respective update.
+    Supported tags are:
+
+    ============ =========================
+         Tag      Default value
+    ============ =========================
+    Title        Default title of Id
+    Type         security
+    Description  Default description of Id
+    Summary      Default summary of Id
+    Severity     Low
+    Solution     Default solution of Id
+    Rights       nobody
+    Issued       2017-01-01 00:00:01
+    Updated      2017-01-01 00:00:01
+    Reference    none
+    Package      none
+    ============ =========================
+
+    Examples:
+
+    .. code-block:: gherkin
+
+       Feature: Defining updateinfo in a repository
+
+         @setup
+         Scenario: Repository base with updateinfo defined
+              Given repository "base" with packages
+                 | Package | Tag     | Value |
+                 | foo     | Version | 2     |
+                 | bar     | Version | 2     |
+              And updateinfo defined in repository "base"
+                 | Id            | Tag         | Value                     |
+                 | RHSA-2017-001 | Title       | foo bar security update   |
+                 |               | Type        | security                  |
+                 |               | Description | Fixes buffer overflow     |
+                 |               | Summary     | Critical bug is fixed     |
+                 |               | Severity    | Critical                  |
+                 |               | Solution    | Update to the new version |
+                 |               | Rights      | Copyright 2017 Baz Inc    |
+                 |               | Reference   | CVE-2017-0001             |
+                 |               | Reference   | BZ123456                  |
+                 |               | Package     | foo-2                     |
+                 |               | Package     | bar-2                     |
+
+    .. note::
+
+       Specifying Version or Release in Package tag is not necessary, however
+       when multiple RPMs matches the string the last one from the sorted
+       list is used.
+    """
+    HEADINGS_GROUP = ['Id', 'Tag', 'Value']
+    UPDATEINFO_TAGS_REPEATING = ['Package', 'Reference']
+    UPDATEINFO_TAGS = ['Title', 'Type', 'Description', 'Solution', 'Summary', 'Severity', 'Rights', 'Issued', 'Updated'] + \
+                      UPDATEINFO_TAGS_REPEATING
+    updateinfo_table = table_utils.parse_skv_table(ctx, HEADINGS_GROUP, UPDATEINFO_TAGS, UPDATEINFO_TAGS_REPEATING)
+
+    # verify that modifyrepo_c is present
+    modifyrepo = which("modifyrepo_c")
+    ctx.assertion.assertIsNotNone(modifyrepo, "modifyrepo_c is required")
+
+    # prepare updateinfo.xml content
+    repodir = repo_utils.get_repo_dir(repository)
+    updateinfo_xml = repo_utils.get_updateinfo_xml(repository, updateinfo_table)
+
+    # save it to the updateinfo.xml file and recreate the repodata
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, "updateinfo.xml"), 'w') as fw:
+        fw.write(updateinfo_xml)
+    file_utils.set_dir_content_ownership(ctx, repodir, 'root')   # change file ownership to root so we can change it
+    cmd = "{!s} {!s} {!s}".format(modifyrepo, os.path.join(tmpdir, 'updateinfo.xml'), os.path.join(repodir, 'repodata'))
+    step_i_successfully_run_command(ctx, cmd)
+    file_utils.set_dir_content_ownership(ctx, repodir)   # restore file ownership

--- a/dnf-docker-test/features/steps/repo_utils.py
+++ b/dnf-docker-test/features/steps/repo_utils.py
@@ -1,0 +1,177 @@
+import os
+import re
+import gzip
+import xml.dom.minidom
+from six.moves import configparser
+
+REPO_TMPL = "/etc/yum.repos.d/{!s}.repo"
+
+
+def get_repo_dir(repository):
+    repo_prefixes = {'file://': '', 'http://localhost': '/var/www/html', 'ftp://localhost': '/var/ftp'}
+    repofile = REPO_TMPL.format(repository)
+    config = configparser.ConfigParser()
+    config.read(repofile)
+    baseurl = config.get(config.sections()[0], 'baseurl')
+    for prefix in repo_prefixes:
+        if baseurl.startswith(prefix):
+            return baseurl.replace(prefix, repo_prefixes[prefix])
+    return None
+
+
+def get_repodata_file_path(regexp, repository):
+    repodir = get_repo_dir(repository)
+    if repodir:
+        repodata_dir = os.path.join(repodir, "repodata")
+        filenames = os.listdir(repodata_dir)
+        for filename in filenames:
+            if re.match(regexp, filename):
+                return os.path.join(repodir, "repodata", filename)
+    return None
+
+
+def parse_pkg_details_from_primary_xml_gz(filename):
+    with gzip.open(filename, 'rb') as f:
+        doc = xml.dom.minidom.parse(f)
+    pkg_dict = {}
+    for pkg in doc.getElementsByTagName('package'):
+        d = {}
+        d['pkg_filename'] = pkg.getElementsByTagName("location")[0].getAttribute("href").split("/")[-1]
+        d['pkg_name'] = pkg.getElementsByTagName("name")[0].firstChild.data
+        d['pkg_version'] = pkg.getElementsByTagName("version")[0].getAttribute("ver")
+        d['pkg_release'] = pkg.getElementsByTagName("version")[0].getAttribute("rel")
+        d['pkg_epoch'] = pkg.getElementsByTagName("version")[0].getAttribute("epoch")
+        d['pkg_arch'] = pkg.getElementsByTagName("arch")[0].firstChild.data
+        d['pkg_src'] = pkg.getElementsByTagName("rpm:sourcerpm")[0].firstChild.data
+        d['pkg_sum'] = pkg.getElementsByTagName("checksum")[0].firstChild.data
+        d['pkg_sumtype'] = pkg.getElementsByTagName("checksum")[0].getAttribute("type")
+        pkg_dict[d['pkg_filename']] = d
+    return pkg_dict
+
+
+def build_updateinfo_xml_elem_update(update, pkg_details):
+    doc = xml.dom.minidom.Document()
+    elem_update = doc.createElement("update")
+    elem_update.setAttribute("from", "nobody@dnf.baseurl.org")
+    elem_update.setAttribute("status", "final")
+    elem_update.setAttribute("type", update.get('Type', 'security'))
+    elem_update.setAttribute("version", "1")
+    # id
+    elem = doc.createElement("id")
+    cnt = doc.createTextNode(update['Id'])
+    elem.appendChild(cnt)
+    elem_update.appendChild(elem)
+    # title
+    elem = doc.createElement("title")
+    cnt = doc.createTextNode(update.get('Title', 'Default title of %s' % update['Id']))
+    elem.appendChild(cnt)
+    elem_update.appendChild(elem)
+    # severity
+    elem = doc.createElement("severity")
+    cnt = doc.createTextNode(update.get('Severity', 'Low'))
+    elem.appendChild(cnt)
+    elem_update.appendChild(elem)
+    # issued
+    elem = doc.createElement("issued")
+    elem.setAttribute("date", update.get('Issued', '2017-01-01 00:00:01'))
+    elem_update.appendChild(elem)
+    # updated
+    elem = doc.createElement("updated")
+    elem.setAttribute("date", update.get('Updated', '2017-01-01 00:00:01'))
+    elem_update.appendChild(elem)
+    # rights
+    elem = doc.createElement("rights")
+    cnt = doc.createTextNode(update.get('Rights', 'nobody'))
+    elem.appendChild(cnt)
+    elem_update.appendChild(elem)
+    # summary
+    elem = doc.createElement("summary")
+    cnt = doc.createTextNode(update.get('Summary', 'Default summary of %s' % update['Id']))
+    elem.appendChild(cnt)
+    elem_update.appendChild(elem)
+    # description
+    elem = doc.createElement("description")
+    cnt = doc.createTextNode(update.get('Description', 'Default description of %s' % update['Id']))
+    elem.appendChild(cnt)
+    elem_update.appendChild(elem)
+    # solution
+    elem = doc.createElement("solution")
+    cnt = doc.createTextNode(update.get('Solution', 'Default solution of %s' % update['Id']))
+    elem.appendChild(cnt)
+    elem_update.appendChild(elem)
+    # references
+    references = doc.createElement("references")
+    cnt = doc.createElement("reference")
+    cnt.setAttribute("href", "www.path.to/nowhere")
+    cnt.setAttribute("type", "self")
+    cnt.setAttribute("title", update['Id'])
+    references.appendChild(cnt)
+    if 'Reference' in update:
+        for ref in update['Reference']:
+            cnt = doc.createElement("reference")
+            cnt.setAttribute("href", "www.path.to/%s" % ref)
+            cnt.setAttribute("title", ref)
+            if ref.startswith('BZ'):
+                cnt.setAttribute("id", ref[2:])
+                cnt.setAttribute("type", 'bugzilla')
+            if ref.startswith('CVE'):
+                cnt.setAttribute("id", ref)
+                cnt.setAttribute("type", 'cve')
+            references.appendChild(cnt)
+    elem_update.appendChild(references)
+    # pkglist
+    pkglist = doc.createElement("pkglist")
+    elem_update.appendChild(pkglist)
+    # collection
+    collection = doc.createElement("collection")
+    collection.setAttribute("short", update.get('Collection', 'Default collection'))
+    pkglist.appendChild(collection)
+    # collection <name>
+    elem = doc.createElement("name")
+    cnt = doc.createTextNode(update.get('Collection', 'Default collection'))
+    elem.appendChild(cnt)
+    collection.appendChild(elem)
+    # now for every package I need to prepare this based on the details obtained from primary.xml
+    # <package name="PKG_NAME" version="3.0.33" release="3.29.el5_5.1" epoch="0" arch="i386" src="samba-3.0.33-3.29.el5_5.1.src.rpm">
+    # <filename>libsmbclient-3.0.33-3.29.el5_5.1.i386.rpm</filename>
+    # <sum type="md5">b5ea308c42fa07a4e59dd7b00c6a9db8</sum>
+    # </package>
+    for pkg in update['Package']:
+        # find the best match in available rpms stored in pkg_details dict
+        rpms = [rpm for rpm in pkg_details.keys() if rpm.startswith(pkg)]
+        rpms.sort()
+        rpm = rpms[-1]  # take the last one as that should be the _latest_ version
+        # create new package element
+        package = doc.createElement("package")
+        package.setAttribute("name", pkg_details[rpm]['pkg_name'])
+        package.setAttribute("version", pkg_details[rpm]['pkg_version'])
+        package.setAttribute("release", pkg_details[rpm]['pkg_release'])
+        package.setAttribute("epoch", pkg_details[rpm]['pkg_epoch'])
+        package.setAttribute("arch", pkg_details[rpm]['pkg_arch'])
+        package.setAttribute("src", pkg_details[rpm]['pkg_src'])
+        elem = doc.createElement("filename")
+        cnt = doc.createTextNode(rpm)
+        elem.appendChild(cnt)
+        package.appendChild(elem)
+        elem = doc.createElement("sum")
+        elem.setAttribute("type", pkg_details[rpm]['pkg_sumtype'])
+        cnt = doc.createTextNode(pkg_details[rpm]['pkg_sum'])
+        elem.appendChild(cnt)
+        package.appendChild(elem)
+        # add package into collection
+        collection.appendChild(package)
+    return elem_update
+
+
+def get_updateinfo_xml(repository, updateinfo_table):
+    primary_xml = get_repodata_file_path('.*primary.xml.gz$', repository)
+    pkg_details = parse_pkg_details_from_primary_xml_gz(primary_xml)
+    # prepare updateinfo.xml document
+    doc = xml.dom.minidom.Document()
+    updates = doc.createElement("updates")
+    doc.appendChild(updates)
+    for id in updateinfo_table:
+        updateinfo_table[id]['Id'] = id
+        elem = build_updateinfo_xml_elem_update(updateinfo_table[id], pkg_details)
+        updates.appendChild(elem)
+    return doc.toxml()

--- a/dnf-docker-test/features/updateinfo-1.feature
+++ b/dnf-docker-test/features/updateinfo-1.feature
@@ -1,0 +1,49 @@
+Feature: Listing available updates using the dnf updateinfo command
+
+  @setup
+  Scenario: setup
+    Given repository "base" with packages
+         | Package | Tag     | Value |
+         | TestA   |         |       |
+         | TestB   |         |       |
+         | TestC   |         |       |
+      And repository "updates" with packages
+         | Package | Tag     | Value |
+         | TestA   | Version | 2     |
+         | TestB   | Version | 2     |
+         | TestC   | Version | 2     |
+      And updateinfo defined in repository "updates"
+         | Id             | Tag          | Value                                   |
+         | RHSA-2016:007  | Title        | TestA and TestB security update         |
+         |                | Type         | security                                |
+         |                | Description  | James Bond rocks                        |
+         |                | Solution     | Live and let die                        |
+         |                | Summary      | SPECTRE infiltrated the organization    |
+         |                | Severity     | Important                               |
+         |                | Rights       | License to kill                         |
+         |                | Issued       | 2016-09-07 00:00:00                     |
+         |                | Updated      | 2016-12-20 22:26:32                     |
+         |                | Reference    | CVE-2016-0001                           |
+         |                | Reference    | CVE-2016-0002                           |
+         |                | Package      | TestA-2                                 |
+         |                | Package      | TestB-2                                 |
+         | RHBA-2016:101  | Title        | TestC bugfix update                     |
+         |                | Type         | bugfix                                  |
+         |                | Description  | Miss Moneypenny's nails needs polishing |
+         |                | Solution     | Apply the red fingernail polish         |
+         |                | Summary      | Miss Moneypenny's nails should be red   |
+         |                | Severity     | Low                                     |
+         |                | Rights       | Beauty salon license                    |
+         |                | Issued       | 2016-10-07 00:00:00                     |
+         |                | Updated      | 2016-11-20 22:26:32                     |
+         |                | Reference    | BZ12345                                 |
+         |                | Package      | TestC-2                                 |
+     When I enable repository "base"
+      And I successfully run "dnf -y install TestA TestB TestC"
+
+  Scenario: Listing available updates
+     When I enable repository "updates"
+      And I run "dnf updateinfo list"
+     Then the command stdout should match regexp "RHSA-2016:007 security TestA-2"
+      And the command stdout should match regexp "RHSA-2016:007 security TestB-2"
+      And the command stdout should match regexp "RHBA-2016:101 bugfix   TestC-2"


### PR DESCRIPTION
Implements step
Given updateinfo defined in repository "{repository}"
that let's you describe the content of updateinfo.xml file which is then
added to an existing (baseurl=file://) repository.

This new version includes support for http and ftp repositories 
along with a simple test case testing the added functionality.