### PR TITLE
renamed step 'contain exactly' to 'match exactly'

### DIFF
--- a/dnf-docker-test/features/deplist-1.feature
+++ b/dnf-docker-test/features/deplist-1.feature
@@ -5,7 +5,7 @@ Feature: Deplist as commmand and option
 
   Scenario: Deplist as command
        When I successfully run "yum deplist TestA"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             package: TestA-1.0.0-1.noarch
               dependency: TestB
@@ -19,7 +19,7 @@ Feature: Deplist as commmand and option
 
   Scenario: Deplist as repoquery option
        When I successfully run "dnf repoquery --deplist TestA"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             package: TestA-1.0.0-1.noarch
               dependency: TestB
@@ -33,7 +33,7 @@ Feature: Deplist as commmand and option
 
   Scenario: Deplist as repoquery option but using dnf bin
        When I successfully run "sh -c 'dnf repoquery --deplist TestA'"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             package: TestA-1.0.0-1.noarch
               dependency: TestB
@@ -47,7 +47,7 @@ Feature: Deplist as commmand and option
 
   Scenario: Deplist with --latest-limit
        When I successfully run "dnf repoquery --deplist --latest-limit 1 TestA"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             package: TestA-1.0.0-2.noarch
               dependency: TestB

--- a/dnf-docker-test/features/protected_packages.feature
+++ b/dnf-docker-test/features/protected_packages.feature
@@ -17,7 +17,7 @@ Feature: Protected packages
        When I save rpmdb
         And I run "dnf -y remove TestA --setopt=protected_packages=TestA"
        Then the command should fail
-        And the command stderr should contain exactly
+        And the command stderr should match exactly
             """
             Error: The operation would result in removing the following protected packages: TestA
 
@@ -29,7 +29,7 @@ Feature: Protected packages
         And I run "dnf -y remove TestB --setopt=protected_packages=TestA"
        Then the command should fail
 # FIXME: Error: package TestA-1-1.fc24.noarch requires TestB, but none of the providers can be installed
-#       And the command stderr should contain exactly
+#       And the command stderr should match exactly
 #           """
 #           Error: The operation would result in removing the following protected packages: TestA
 #
@@ -40,7 +40,7 @@ Feature: Protected packages
        When I save rpmdb
         And I run "dnf -y remove dnf"
        Then the command should fail
-        And the command stderr should contain exactly
+        And the command stderr should match exactly
             """
             Error: The operation would result in removing the following protected packages: dnf
 
@@ -55,7 +55,7 @@ Feature: Protected packages
        When I save rpmdb
         And I run "dnf -y remove TestA"
        Then the command should fail
-        And the command stderr should contain exactly
+        And the command stderr should match exactly
             """
             Error: The operation would result in removing the following protected packages: TestA
 

--- a/dnf-docker-test/features/repolist-disabled.feature
+++ b/dnf-docker-test/features/repolist-disabled.feature
@@ -16,7 +16,7 @@ Feature: Repolist when all repositories are disabled
 
   Scenario: Repolist with "disabled"
        When I successfully run "dnf repolist disabled"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             repo id                                  repo name                              
             TestA                                    TestA                                  
@@ -27,7 +27,7 @@ Feature: Repolist when all repositories are disabled
 
   Scenario: Repolist with "all"
        When I successfully run "dnf repolist all"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             repo id                              repo name                          status
             TestA                                TestA                              disabled

--- a/dnf-docker-test/features/repolist-enabled-disabled.feature
+++ b/dnf-docker-test/features/repolist-enabled-disabled.feature
@@ -14,7 +14,7 @@ Feature: Repolist with enabled/disabled repositories
 
   Scenario: Repolist without arguments
        When I successfully run "dnf repolist"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             repo id                               repo name                           status
             TestB                                 TestB                               0
@@ -24,7 +24,7 @@ Feature: Repolist with enabled/disabled repositories
 
   Scenario: Repolist with "enabled"
        When I successfully run "dnf repolist enabled"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             repo id                               repo name                           status
             TestB                                 TestB                               0
@@ -34,7 +34,7 @@ Feature: Repolist with enabled/disabled repositories
 
   Scenario: Repolist with "disabled"
        When I successfully run "dnf repolist disabled"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             repo id                                  repo name                              
             TestA                                    TestA                                  
@@ -43,7 +43,7 @@ Feature: Repolist with enabled/disabled repositories
 
   Scenario: Repolist with "all"
        When I successfully run "dnf repolist all"
-       Then the command stdout should contain exactly
+       Then the command stdout should match exactly
             """
             repo id                             repo name                         status
             TestA                               TestA                             disabled

--- a/dnf-docker-test/features/shell-1.feature
+++ b/dnf-docker-test/features/shell-1.feature
@@ -14,7 +14,7 @@ Feature: Installing updating and removing a package in dnf shell
          | State     | Packages     |
          | installed | TestA, TestB |
      When I run dnf shell command "exit"
-     Then the command stdout should contain exactly
+     Then the command stdout should match exactly
           """
           Leaving Shell
 
@@ -33,7 +33,7 @@ Feature: Installing updating and removing a package in dnf shell
          | State   | Packages |
          | updated | TestA    |
      When I run dnf shell command "exit"
-     Then the command stdout should contain exactly
+     Then the command stdout should match exactly
           """
           Leaving Shell
 
@@ -52,7 +52,7 @@ Feature: Installing updating and removing a package in dnf shell
          | State   | Packages |
          | updated | TestB    |
      When I run dnf shell command "exit"
-     Then the command stdout should contain exactly
+     Then the command stdout should match exactly
           """
           Leaving Shell
 
@@ -67,7 +67,7 @@ Feature: Installing updating and removing a package in dnf shell
          | State     | Packages |
          | removed   | TestA    |
      When I run dnf shell command "exit"
-     Then the command stdout should contain exactly
+     Then the command stdout should match exactly
           """
           Leaving Shell
 
@@ -85,7 +85,7 @@ Feature: Installing updating and removing a package in dnf shell
          | installed | TestA    |
          | removed   | TestB    |
      When I run dnf shell command "exit"
-     Then the command stdout should contain exactly
+     Then the command stdout should match exactly
           """
           Leaving Shell
 

--- a/dnf-docker-test/features/shell-3.feature
+++ b/dnf-docker-test/features/shell-3.feature
@@ -28,7 +28,7 @@ Feature: Switching conflicting packages in dnf shell
          | removed   | TestB    |
          | installed | TestC    |
      When I run dnf shell command "quit"
-     Then the command stdout should contain exactly
+     Then the command stdout should match exactly
           """
           Leaving Shell
 

--- a/dnf-docker-test/features/steps/command_steps.py
+++ b/dnf-docker-test/features/steps/command_steps.py
@@ -34,8 +34,8 @@ def step_the_command_should_pass(ctx):
 def step_the_command_should_fail(ctx):
     ctx.assertion.assertNotEqual(ctx.cmd_result.returncode, 0)
 
-@then("the command {stream:stdout_stderr} should contain exactly")
-def step_the_command_stream_should_contain_exactly(ctx, stream):
+@then("the command {stream:stdout_stderr} should match exactly")
+def step_the_command_stream_should_match_exactly(ctx, stream):
     ctx.assertion.assertIsNotNone(ctx.text, "Multiline text is not provided")
     text = getattr(ctx.cmd_result, stream)
     ctx.assertion.assertMultiLineEqual(text, ctx.text)
@@ -43,7 +43,7 @@ def step_the_command_stream_should_contain_exactly(ctx, stream):
 @then("the command {stream:stdout_stderr} should be empty")
 def step_the_command_stream_should_be_empty(ctx, stream):
     ctx.text = ""
-    step_the_command_stream_should_contain_exactly(ctx, stream)
+    step_the_command_stream_should_match_exactly(ctx, stream)
 
 @then('the command {stream:stdout_stderr} should match regexp "{regexp}"')
 def step_the_command_stream_should_match_regexp(ctx, stream, regexp):


### PR DESCRIPTION
The name of the step
   Then the command {stream:stdout_stderr} should contain exactly
defined in command_steps.py is confusing

Renamed to "...match exactly"