### PR TITLE
ability to reserve a running container

### DIFF
--- a/dnf-docker-test/launch-test
+++ b/dnf-docker-test/launch-test
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -xeuo pipefail
 
+RESERVE=0
+if [ "$1" == "-r" -o "$1" == "-R" ]; then
+    RESERVE="$1"
+    shift
+fi
+
 httpd -k start
 vsftpd
 new_name=${1}-${2}
@@ -10,4 +16,11 @@ if [ "$EXIT_STATUS" = 1 ]; then
     >&2 echo "Feature file ${1}.feature not found"
     exit 1
 fi
-behave-2 -i $new_name -D dnf_cmd=$2 --junit --junit-directory /junit/ /behave/
+
+TEST_EXIT=0
+behave-2 -i $new_name -D dnf_cmd=$2 --junit --junit-directory /junit/ /behave/ || TEST_EXIT=$?
+
+if [ "$RESERVE" == "-r" ] || [ "$RESERVE" == "-R" -a $TEST_EXIT -ne 0 ]; then
+    bash || :
+fi
+exit $TEST_EXIT


### PR DESCRIPTION
This commit adds 1 command and 2 options to ease debugging
-r, --reserve - to open a bash session in a running container after every test executed
-R, --reserveonfail -  to open a bash session in a running container upon test failure
shell to simply run a bash session in a container, no tests are executed in this case