### PR TITLE
utilize also erase command in the dnf shell test

### DIFF
--- a/dnf-docker-test/features/shell-1.feature
+++ b/dnf-docker-test/features/shell-1.feature
@@ -73,12 +73,12 @@ Feature: Installing updating and removing a package in dnf shell
 
           """
 
-  Scenario: Installing and removing a package within one transaction
+  Scenario: Installing and erasing a package within one transaction
     Given I have dnf shell session opened with parameters "-y"
      When I save rpmdb
       And I run dnf shell command "repo enable TestRepoA"
       And I run dnf shell command "install TestA"
-      And I run dnf shell command "remove TestB"
+      And I run dnf shell command "erase TestB"
       And I run dnf shell command "run"
      Then rpmdb changes are
          | State     | Packages |


### PR DESCRIPTION
We are missing a test for the erase command for dnf shell, this commit is replacing one appearance of the remove cmd with the erase cmd.