### PR TITLE
Change names of rpms for removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN set -x && \
         dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
     fi && \
     # prevent installation of dnf-plugins-extras (versionlock, local, torproxy)
-    rm -vf /rpms/*extras-versionlock*.rpm /rpms/*extras-local*.rpm /rpms/*extras-torproxy*.rpm && \
+    rm -vf /rpms/*dnf-plugin-versionlock*.rpm /rpms/*dnf-plugin-local*.rpm /rpms/*dnf-plugin-torproxy*.rpm && \
     # update dnf
     dnf -y --best upgrade dnf && \
     if [ $type = "local" ]; then \


### PR DESCRIPTION
The change is required according changes between extras and core plugins, where
local and versionlock plugins were removed from extras and added into core as
pythonX-dnf-plugin-* sub-package.