### PR TITLE
Do not create arch specific subdirectories in repos

### DIFF
--- a/dnf-docker-test/features/steps/repo_steps.py
+++ b/dnf-docker-test/features/steps/repo_steps.py
@@ -224,12 +224,13 @@ def given_repository_with_packages(ctx, rtype, repository):
         ctx.text = template.render(name=name, **settings)
         fname = "{!s}/{!s}.spec".format(tmpdir, name)
         step_a_file_filepath_with(ctx, fname)
+        buildname = '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}.rpm'
         if 'arch' not in settings or settings['arch'] == 'noarch':
-            cmd = "{!s} --define '_rpmdir {!s}' -bb {!s}".format(
-                rpmbuild, tmpdir, fname)
+            cmd = "{!s} --define '_rpmdir {!s}' --define '_build_name_fmt {!s}' -bb {!s}".format(
+                rpmbuild, tmpdir, buildname, fname)
         else:
-            cmd = "setarch {!s} {!s} --define '_rpmdir {!s}' --target {!s} -bb {!s}".format(
-                settings['arch'], rpmbuild, tmpdir, settings['arch'], fname)
+            cmd = "setarch {!s} {!s} --define '_rpmdir {!s}' --define '_build_name_fmt {!s}' --target {!s} -bb {!s}".format(
+                settings['arch'], rpmbuild, tmpdir, buildname, settings['arch'], fname)
         step_i_successfully_run_command(ctx, cmd)
 
     cmd = "{!s} {!s}".format(createrepo, tmpdir)


### PR DESCRIPTION
This patch changes the test generated repositories to have all rpms in single directory instead of arch specific subdirectories. This would a prerequisite for 'When I run "{command}" in directory of "{repository}" repository'.
