### PR TITLE
don't fail when whole input was read

### DIFF
--- a/dnf-docker-test/features/steps/shell_steps.py
+++ b/dnf-docker-test/features/steps/shell_steps.py
@@ -25,7 +25,7 @@ def step_i_run_dnf_shell_command(context, command):
         sys.stdout.write(context.pexpect_session.before)
         context.pexpect_session = None
     else:
-        context.pexpect_session.expect('\r\n[^ \r-]*> ')
+        context.pexpect_session.expect(['\r\n[^ \r-]*> ', pexpect.EOF])
         # in the dnf shell command output we need to replace ^M characters added by pexpect
         context.cmd_result.stdout = context.pexpect_session.before[len(command) + 2:].replace('\r\n', '\n')
         sys.stdout.write("{}{}".format(context.pexpect_session.before, context.pexpect_session.match.group()))


### PR DESCRIPTION
fixing
Traceback (most recent call last):
   File "/usr/lib/python2.7/site-packages/behave/model.py", line 1456, in run
     match.run(runner.context)
   File "/usr/lib/python2.7/site-packages/behave/model.py", line 1903, in run
     self.func(context, *args, **kwargs)
   File "behave/steps/shell_steps.py", line 28, in step_i_run_dnf_shell_command
     context.pexpect_session.expect('
 [^
 -]*> ')
   File "/usr/lib/python2.7/site-packages/pexpect/spawnbase.py", line 321, in expect
     timeout, searchwindowsize, async)
   File "/usr/lib/python2.7/site-packages/pexpect/spawnbase.py", line 345, in expect_list
     return exp.expect_loop(timeout)
   File "/usr/lib/python2.7/site-packages/pexpect/expect.py", line 105, in expect_loop
     return self.eof(e)
   File "/usr/lib/python2.7/site-packages/pexpect/expect.py", line 50, in eof
     raise EOF(msg)
 EOF: End Of File (EOF). Exception style platform.