### PR TITLE
make get_repo_dir() return None for incorrect repofile

### DIFF
--- a/dnf-docker-test/features/steps/repo_utils.py
+++ b/dnf-docker-test/features/steps/repo_utils.py
@@ -11,11 +11,11 @@ def get_repo_dir(repository):
     repo_prefixes = {'file://': '', 'http://localhost': '/var/www/html', 'https://localhost': '/var/www/html', 'ftp://localhost': '/var/ftp'}
     repofile = REPO_TMPL.format(repository)
     config = configparser.ConfigParser()
-    config.read(repofile)
-    baseurl = config.get(config.sections()[0], 'baseurl')
-    for prefix in repo_prefixes:
-        if baseurl.startswith(prefix):
-            return baseurl.replace(prefix, repo_prefixes[prefix])
+    if config.read(repofile) and config.sections():  # if there is some content to process
+        baseurl = config.get(config.sections()[0], 'baseurl')
+        for prefix in repo_prefixes:
+            if baseurl.startswith(prefix):
+                return baseurl.replace(prefix, repo_prefixes[prefix])
     return None
 
 


### PR DESCRIPTION
When repo file path was wrong there was one not really descriptive error:
  IndexError: list index out of range
Probably better to return None in this case too.