### PR TITLE
test shell quit

### DIFF
--- a/dnf-docker-test/features/shell-5.feature
+++ b/dnf-docker-test/features/shell-5.feature
@@ -22,3 +22,6 @@ Scenario: Enabling and disabling a repository in dnf shell
        And I run dnf shell command "repolist"
       Then the command stdout should match regexp "TestRepoA"
        And the command stdout should not match regexp "TestRepoB"
+
+      When I run dnf shell command "quit"
+      Then the command stdout should match regexp "Leaving Shell"


### PR DESCRIPTION
this should workaround failures of shell enable/disable test
which sometime fails with pexpect.EOF exception