### PR TITLE
Update test where Available Group: string is used

### DIFF
--- a/dnf-docker-test/features/group-1.feature
+++ b/dnf-docker-test/features/group-1.feature
@@ -4,24 +4,24 @@ Scenario: Install TestB first with RPM, then install TestA with DNF and observe 
   Given I use the repository "test-1"
 # Initial check
   When I execute "dnf" command "group list Testgroup" with "success"
-  Then line from "stdout" should "not start" with "Installed groups:"
-  And line from "stdout" should "start" with "Available groups:"
+  Then line from "stdout" should "not start" with "Installed Groups:"
+  And line from "stdout" should "start" with "Available Groups:"
 # Exclude of dependency of mandatory package
 # When I execute "dnf" command "group install -y --exclude=TestB Testgroup" with "fail"
 # Then I execute "dnf" command "group list Testgroup" with "success"
-# And line from "stdout" should "not start" with "Installed groups:"
-# And line from "stdout" should "start" with "Available groups:"
+# And line from "stdout" should "not start" with "Installed Groups:"
+# And line from "stdout" should "start" with "Available Groups:"
   When I execute "dnf" command "group install -y --exclude=TestC Testgroup" with "success"
   Then transaction changes are as follows
   | State        | Packages                   |
   | installed    | TestA, TestB |
   And I execute "dnf" command "group list Testgroup" with "success"
-  And line from "stdout" should "start" with "Installed groups:"
-  And line from "stdout" should "not start" with "Available groups:"
+  And line from "stdout" should "start" with "Installed Groups:"
+  And line from "stdout" should "not start" with "Available Groups:"
   When I execute "dnf" command "-y group remove Testgroup" with "success"
   Then transaction changes are as follows
   | State        | Packages            |
   | removed      | TestA, TestB |
   And I execute "dnf" command "group list Testgroup" with "success"
-  And line from "stdout" should "not start" with "Installed groups:"
-  And line from "stdout" should "start" with "Available groups:"
+  And line from "stdout" should "not start" with "Installed Groups:"
+  And line from "stdout" should "start" with "Available Groups:"

--- a/dnf-docker-test/features/group-2.feature
+++ b/dnf-docker-test/features/group-2.feature
@@ -4,29 +4,29 @@ Scenario: Install TestB first with RPM, then install TestA with DNF and observe 
   Given I use the repository "test-1"
 # Initial check
   When I execute "dnf" command "group list Testgroup" with "success"
-  Then line from "stdout" should "not start" with "Installed groups:"
-  And line from "stdout" should "start" with "Available groups:"
+  Then line from "stdout" should "not start" with "Installed Groups:"
+  And line from "stdout" should "start" with "Available Groups:"
 # Exclude of mandatory package
 # When I execute "dnf" command "group install -y --exclude=TestA Testgroup" with "fail"
 # Then I execute "dnf" command "group list Testgroup" with "success"
-# And line from "stdout" should "not start" with "Installed groups:"
-# And line from "stdout" should "start" with "Available groups:"
+# And line from "stdout" should "not start" with "Installed Groups:"
+# And line from "stdout" should "start" with "Available Groups:"
 # Test with "--assumeno"
   When I execute "dnf" command "group install --assumeno Testgroup" with "fail"
   Then I execute "dnf" command "group list Testgroup" with "success"
-  And line from "stdout" should "not start" with "Installed groups:"
-  And line from "stdout" should "start" with "Available groups:"
+  And line from "stdout" should "not start" with "Installed Groups:"
+  And line from "stdout" should "start" with "Available Groups:"
   When I execute "dnf" command "group install -y --exclude=TestC Testgroup" with "success"
   Then transaction changes are as follows
   | State        | Packages      |
   | installed    | TestA, TestB  |
   And I execute "dnf" command "group list Testgroup" with "success"
-  And line from "stdout" should "start" with "Installed groups:"
-  And line from "stdout" should "not start" with "Available groups:"
+  And line from "stdout" should "start" with "Installed Groups:"
+  And line from "stdout" should "not start" with "Available Groups:"
   When I execute "dnf" command "group -y remove Testgroup" with "success"
   Then transaction changes are as follows
   | State        | Packages     |
   | removed      | TestA, TestB |
   And I execute "dnf" command "group list Testgroup" with "success"
-  And line from "stdout" should "not start" with "Installed groups:"
-  And line from "stdout" should "start" with "Available groups:"
+  And line from "stdout" should "not start" with "Installed Groups:"
+  And line from "stdout" should "start" with "Available Groups:"

--- a/dnf-docker-test/features/install_remove-1.feature
+++ b/dnf-docker-test/features/install_remove-1.feature
@@ -115,15 +115,15 @@ Scenario: Install *.rpm from local path
 Scenario: Group Install Remove
  Given I use the repository "test-1"
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "install -y @Testgroup" with "success"
  Then transaction changes are as follows
    | State        | Packages             |
    | installed    | TestA, TestB, TestC  |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "start" with "Installed groups:"
- And line from "stdout" should "not start" with "Available groups:"
+ Then line from "stdout" should "start" with "Installed Groups:"
+ And line from "stdout" should "not start" with "Available Groups:"
  When I execute "dnf" command "install -y TestD" with "success"
  Then transaction changes are as follows
    | State        | Packages      |
@@ -133,8 +133,8 @@ Scenario: Group Install Remove
    | State        | Packages             |
    | removed      | TestA, TestB, TestC  |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "remove -y TestD, TestE" with "success"
  Then transaction changes are as follows
    | State        | Packages      |
@@ -143,51 +143,51 @@ Scenario: Group Install Remove
 Scenario: Group Install Remove List with with-optional option
  Given I use the repository "test-1"
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "group install -y --with-optional Testgroup" with "success"
  Then transaction changes are as follows
    | State        | Packages                           |
    | installed    | TestA, TestB, TestC, TestD, TestE  |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "start" with "Installed groups:"
- And line from "stdout" should "not start" with "Available groups:"
+ Then line from "stdout" should "start" with "Installed Groups:"
+ And line from "stdout" should "not start" with "Available Groups:"
  When I execute "dnf" command "remove -y @Testgroup" with "success"
  Then transaction changes are as follows
    | State        | Packages                           |
    | removed      | TestA, TestB, TestC, TestD, TestE  |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
 
 Scenario: Group Install Remove List if package with dependency is installed before group install
  Given I use the repository "test-1"
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "install -y TestA" with "success"
  Then transaction changes are as follows
    | State        | Packages      |
    | installed    | TestA, TestB  |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "install -y @Testgroup" with "success"
  Then transaction changes are as follows
    | State        | Packages      |
    | installed    | TestC         |
    | present      | TestA, TestB  |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "start" with "Installed groups:"
- And line from "stdout" should "not start" with "Available groups:"
+ Then line from "stdout" should "start" with "Installed Groups:"
+ And line from "stdout" should "not start" with "Available Groups:"
  When I execute "dnf" command "group remove -y Testgroup" with "success"
  Then transaction changes are as follows
    | State        | Packages      |
    | removed      | TestC         |
    | present      | TestA, TestB  |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "remove -y TestA" with "success"
  Then transaction changes are as follows
    | State        | Packages      |
@@ -196,30 +196,30 @@ Scenario: Group Install Remove List if package with dependency is installed befo
 Scenario: Group Install Remove List if package is installed before group install
  Given I use the repository "test-1"
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "install -y TestC" with "success"
  Then transaction changes are as follows
    | State        | Packages   |
    | installed    | TestC      |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "install -y @Testgroup" with "success"
  Then transaction changes are as follows
    | State        | Packages      |
    | installed    | TestA, TestB  |
    | present      | TestC         |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "start" with "Installed groups:"
- And line from "stdout" should "not start" with "Available groups:"
+ Then line from "stdout" should "start" with "Installed Groups:"
+ And line from "stdout" should "not start" with "Available Groups:"
  When I execute "dnf" command "group remove -y Testgroup" with "success"
  Then transaction changes are as follows
    | State        | Packages      |
    | removed      | TestA, TestB  |
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "remove -y TestC" with "success"
  Then transaction changes are as follows
    | State        | Packages   |

--- a/dnf-docker-test/features/mark-3.feature
+++ b/dnf-docker-test/features/mark-3.feature
@@ -3,20 +3,20 @@ Feature: DNF/Behave test (dnf group mark command)
 Scenario: Mark group as installed and unmark group as installed
  Given I use the repository "test-1"
  When I execute "dnf" command "group list Testgroup" with "success"
- Then line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ Then line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"
  When I execute "dnf" command "group mark install Testgroup" with "success"
  # TestA-mandatory, TestC-defaults, TestD-optional
  Then transaction changes are as follows
    | State       | Packages             |
    | absent      | TestA, TestC, TestD  |
  And I execute "dnf" command "group list Testgroup" with "success"
- And line from "stdout" should "start" with "Installed groups:"
- And line from "stdout" should "not start" with "Available groups:"
+ And line from "stdout" should "start" with "Installed Groups:"
+ And line from "stdout" should "not start" with "Available Groups:"
  When I execute "dnf" command "group mark remove Testgroup" with "success"
  Then transaction changes are as follows
    | State       | Packages             |
    | absent      | TestA, TestC, TestD  |
  And I execute "dnf" command "group list Testgroup" with "success"
- And line from "stdout" should "not start" with "Installed groups:"
- And line from "stdout" should "start" with "Available groups:"
+ And line from "stdout" should "not start" with "Installed Groups:"
+ And line from "stdout" should "start" with "Available Groups:"


### PR DESCRIPTION
It reflect change in dnf where strings "Installed group:" and "Available group"
were replaced by  "Installed Group:" and "Available Group:"