### PR TITLE
raise exception when updateinfo.xml is refering to wrong package

### DIFF
--- a/dnf-docker-test/features/steps/repo_utils.py
+++ b/dnf-docker-test/features/steps/repo_utils.py
@@ -139,6 +139,8 @@ def build_updateinfo_xml_elem_update(update, pkg_details):
     for pkg in update['Package']:
         # find the best match in available rpms stored in pkg_details dict
         rpms = [rpm for rpm in pkg_details.keys() if rpm.startswith(pkg)]
+        if not rpms:  # the package is not in the given repository, make the error more obvious
+            raise Exception('Package {!r} in not present in the repository'.format(pkg))
         rpms.sort()
         rpm = rpms[-1]  # take the last one as that should be the _latest_ version
         # create new package element


### PR DESCRIPTION
This change raises an exception with more descriptive error message when a user refers to a wrong package in the updateinfo definition.

 ```
   And repository "sec-err-2" with packages            # behave/steps/repo_steps.py:150
      | Package | Tag     | Value |
      | TestA   | Version | 3     |
    And updateinfo defined in repository "sec-err-2"    # behave/steps/repo_steps.py:306
      | Id            | Tag       | Value                 |
      | RHSA-2999-002 | Title     | TestB security update |
      |               | Type      | security              |
      |               | Severity  | Moderate              |
      |               | Reference | CVE-2017-0001         |
      |               | Package   | TestB-2               |
      Traceback (most recent call last):
        File "/usr/lib/python2.7/site-packages/behave/model.py", line 1456, in run
          match.run(runner.context)
        File "/usr/lib/python2.7/site-packages/behave/model.py", line 1903, in run
          self.func(context, *args, **kwargs)
        File "behave/steps/repo_steps.py", line 385, in step_updateinfo_defined_in_repository
          updateinfo_xml = repo_utils.get_updateinfo_xml(repository, updateinfo_table)
        File "/behave/steps/repo_utils.py", line 177, in get_updateinfo_xml
          elem = build_updateinfo_xml_elem_update(updateinfo_table[id], pkg_details)
        File "/behave/steps/repo_utils.py", line 144, in build_updateinfo_xml_elem_update
          raise Exception('Could not find package {} in the given repository'.format(pkg))
      Exception: Could not find package TestB-2 in the given repository

```

The previous traceback was a bit cryptic
```

      Traceback (most recent call last):
        File "/usr/lib/python2.7/site-packages/behave/model.py", line 1456, in run
          match.run(runner.context)
        File "/usr/lib/python2.7/site-packages/behave/model.py", line 1903, in run
          self.func(context, *args, **kwargs)
        File "behave/steps/repo_steps.py", line 385, in step_updateinfo_defined_in_repository
          updateinfo_xml = repo_utils.get_updateinfo_xml(repository, updateinfo_table)
        File "/behave/steps/repo_utils.py", line 175, in get_updateinfo_xml
          elem = build_updateinfo_xml_elem_update(updateinfo_table[id], pkg_details)
        File "/behave/steps/repo_utils.py", line 143, in build_updateinfo_xml_elem_update
          rpm = rpms[-1]  # take the last one as that should be the _latest_ version
      IndexError: list index out of range

```