### PR TITLE
match only by pkg name when finding pkg_pre

### DIFF
--- a/dnf-docker-test/features/steps/rpm_steps.py
+++ b/dnf-docker-test/features/steps/rpm_steps.py
@@ -96,10 +96,10 @@ def step_rpmdb_changes_are(ctx):
     # Let's check what user has requested in table
     for expected_state, packages in table.items():
         for pkg in pkgs_split(packages):
-            pkg_pre = rpm_utils.find_pkg(ctx.rpmdb, pkg)
+            pkg_pre = rpm_utils.find_pkg(ctx.rpmdb, pkg, only_by_name=True)
             if pkg_pre:
                 ctx.rpmdb.remove(pkg_pre)
-            pkg_post = rpm_utils.find_pkg(rpmdb, pkg)
+            pkg_post = rpm_utils.find_pkg(rpmdb, pkg, only_by_name=False)
             if pkg_post:
                 rpmdb.remove(pkg_post)
             state = rpm_utils.analyze_state(pkg_pre, pkg_post)

--- a/dnf-docker-test/features/steps/rpm_utils.py
+++ b/dnf-docker-test/features/steps/rpm_utils.py
@@ -48,10 +48,11 @@ def hdr2nevra(hdr):
     """
     return hdr["nevra"].decode() if hdr else None
 
-def find_pkg(pkgs, pkg):
+def find_pkg(pkgs, pkg, only_by_name=True):
     """
     :param list(rpm.hdr) pkgs: List of RPM Headers
     :param str pkg: Package to find
+    :param bool only_by_name: Whether to ignore Epoch, Version, Release
     :return: First found RPM header
     :rtype: rpm.hdr or None
     """
@@ -71,6 +72,8 @@ def find_pkg(pkgs, pkg):
     for p in pkgs:
         if p.name != name:
             continue
+        if only_by_name:
+            return p
         if (epoch is None or p.epoch == epoch) and \
            (version is None or p.version == version) and \
            (release is None or p.release == release):


### PR DESCRIPTION
When a package is identified also using Epoch/Version/Release match only using pkg name when find the package state prior the transaction.