### PR TITLE
Remove xfail from shell and swap tests

### DIFF
--- a/dnf-docker-test/features/shell-1.feature
+++ b/dnf-docker-test/features/shell-1.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Installing updating and removing a package in dnf shell
 
   Scenario: Installing packages

--- a/dnf-docker-test/features/shell-2.feature
+++ b/dnf-docker-test/features/shell-2.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Running dnf shell commands in a batch
 
   @setup

--- a/dnf-docker-test/features/shell-3.feature
+++ b/dnf-docker-test/features/shell-3.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Switching conflicting packages in dnf shell
 
   @setup

--- a/dnf-docker-test/features/shell-4.feature
+++ b/dnf-docker-test/features/shell-4.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Installing a package group in dnf shell
 
 Scenario: Installing package group in dnf shell

--- a/dnf-docker-test/features/shell-5.feature
+++ b/dnf-docker-test/features/shell-5.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Enabling and disabling a repository in dnf shell
 
 Scenario: Enabling and disabling a repository in dnf shell

--- a/dnf-docker-test/features/shell-6.feature
+++ b/dnf-docker-test/features/shell-6.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Testing specific dnf shell text output
 
   @setup

--- a/dnf-docker-test/features/swap-2-shell.feature
+++ b/dnf-docker-test/features/swap-2-shell.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Test for swap command with wildcards package specification (run in dnf shell)
 
   @setup

--- a/dnf-docker-test/features/swap-2.feature
+++ b/dnf-docker-test/features/swap-2.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Test for swap command with wildcards package specification
 
   @setup

--- a/dnf-docker-test/features/swap-3-shell.feature
+++ b/dnf-docker-test/features/swap-3-shell.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Test for swap command with package groups (run in dnf shell)
 
   @setup

--- a/dnf-docker-test/features/swap-3.feature
+++ b/dnf-docker-test/features/swap-3.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Test for swap command with package groups
 
   @setup

--- a/dnf-docker-test/features/swap.feature
+++ b/dnf-docker-test/features/swap.feature
@@ -1,4 +1,3 @@
-@xfail
 Feature: Test for swap command
 
   @setup


### PR DESCRIPTION
We already fixed one issue with memory leak that affect shell and swap command,
therefore we can test if another issue appear. But to make it visible we have to
remove xfail mark.