### PR TITLE
added tests for "dnf --security" and related options

### DIFF
--- a/dnf-docker-test/features/security_3.feature
+++ b/dnf-docker-test/features/security_3.feature
@@ -68,7 +68,6 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        Then rpmdb changes are
          | State      | Packages           |
          | updated    | TestA/4            |
-         | unchanged  | TestB              |
 
   Scenario: Cleanup after security update
        When I save rpmdb
@@ -76,7 +75,6 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        Then rpmdb changes are
          | State      | Packages             |
          | downgraded | TestA/1              |
-         | unchanged  | TestB                |
 
   Scenario: Security upgrade
        When I save rpmdb
@@ -84,7 +82,6 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        Then rpmdb changes are
          | State      | Packages             |
          | updated    | TestA/4              |
-         | unchanged  | TestB                |
 
   Scenario: Cleanup after security upgrade
        When I save rpmdb
@@ -92,7 +89,6 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        Then rpmdb changes are
          | State      | Packages             |
          | downgraded | TestA/1              |
-         | unchanged  | TestB                |
 
   Scenario: Security update-minimal
        When I save rpmdb
@@ -100,7 +96,6 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        Then rpmdb changes are
          | State      | Packages             |
          | updated    | TestA/3              |
-         | unchanged  | TestB                |
 
   Scenario: Cleanup after security update-minimal
        When I save rpmdb
@@ -108,7 +103,6 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        Then rpmdb changes are
          | State      | Packages           |
          | downgraded | TestA/1            |
-         | unchanged  | TestB              |
 
   Scenario: Security upgrade-minimal
        When I save rpmdb
@@ -116,4 +110,3 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        Then rpmdb changes are
          | State      | Packages           |
          | updated    | TestA/3            |
-         | unchanged  | TestB              |

--- a/dnf-docker-test/features/security_3.feature
+++ b/dnf-docker-test/features/security_3.feature
@@ -1,0 +1,127 @@
+Feature: Test for check-update, upgrade, update, upgrade-minimal and update-minimal with security option 
+ repo base: TestA-1 TestB-1
+ repo sec-err-1: errata security Low: TestA-2
+ repo sec-err-2: errata security Moderate: TestA-3
+ repo enh-err: errata enhancement: TestA-4 TestB-2
+
+  @setup
+  Scenario: Setup (install TestA-1 TestB-1)
+      Given repository "base" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 1         |
+         | TestB        | Version  | 1         |
+        And repository "sec-err-1" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 2         |
+        And updateinfo defined in repository "sec-err-1"
+         | Id              | Tag        | Value                  |
+         | RHSA-2999-001   | Title      | TestA security update  |
+         |                 | Type       | security               |
+         |                 | Severity   | Low                    |
+         |                 | Package    | TestA-2                |
+        And repository "sec-err-2" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 3         |
+        And updateinfo defined in repository "sec-err-2"
+         | Id              | Tag        | Value                  |
+         | RHSA-2999-002   | Title      | TestA security update  |
+         |                 | Type       | security               |
+         |                 | Severity   | Moderate               |
+         |                 | Package    | TestA-3                |
+        And repository "enh-err" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 4         |
+         | TestB        | Version  | 2         |
+        And updateinfo defined in repository "enh-err"
+         | Id              | Tag        | Value                  |
+         | RHEA-2999-003   | Title      | TestA TestB enh        |
+         |                 | Type       | enhancement            |
+         |                 | Package    | TestA-4                |
+         |                 | Package    | TestB-2                |
+       When I save rpmdb
+        And I enable repository "base"
+        And I successfully run "dnf -y install TestA TestB"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State     | Packages     |
+         | installed | TestA, TestB |
+
+  Scenario: Security check-update when there are no such updates
+       When I run "dnf --security check-update" 
+       Then the command exit code is 0
+        And the command stdout should not match regexp "TestA"
+        And the command stdout should not match regexp "TestB"
+
+  Scenario: Security check-update when there are such updates
+       When I enable repository "sec-err-1"
+        And I enable repository "sec-err-2"
+        And I enable repository "enh-err"
+        And I run "dnf --security check-update" 
+       Then the command exit code is 100
+        And the command stdout should match regexp "TestA.*2-1.*sec-err-1"
+        And the command stdout should match regexp "TestA.*3-1.*sec-err-2" 
+        And the command stdout should match regexp "TestA.*4-1.*enh-err"
+        And the command stdout should not match regexp "TestB"
+
+  Scenario: Security update
+       When I save rpmdb
+        And I successfully run "dnf -y --security update" 
+       # verze maji byt TestA-4 a TestB-1, az to budeme umet, opravit
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA              |
+         | unchanged  | TestB              |
+
+  Scenario: Cleanup after security update
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last" 
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA              |
+         | unchanged  | TestB              |
+
+  Scenario: Security upgrade
+       When I save rpmdb
+        And I successfully run "dnf -y --security upgrade" 
+       # verze maji byt TestA-4 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA              |
+         | unchanged  | TestB              |
+
+  Scenario: Cleanup after security upgrade
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last" 
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA              |
+         | unchanged  | TestB              |
+
+  Scenario: Security update-minimal
+       When I save rpmdb
+        And I successfully run "dnf -y --security update-minimal" 
+       # verze maji byt TestA-3 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA              |
+         | unchanged  | TestB              |
+
+  Scenario: Cleanup after security update-minimal
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last" 
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA              |
+         | unchanged  | TestB              |
+
+  Scenario: Security upgrade-minimal
+       When I save rpmdb
+        And I successfully run "dnf -y --security upgrade-minimal" 
+       # verze maji byt TestA-3 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA              |
+         | unchanged  | TestB              |

--- a/dnf-docker-test/features/security_3.feature
+++ b/dnf-docker-test/features/security_3.feature
@@ -1,4 +1,4 @@
-Feature: Test for check-update, upgrade, update, upgrade-minimal and update-minimal with security option 
+Feature: Test for check-update, upgrade, update, upgrade-minimal and update-minimal with security option
  repo base: TestA-1 TestB-1
  repo sec-err-1: errata security Low: TestA-2
  repo sec-err-2: errata security Moderate: TestA-3
@@ -41,13 +41,12 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        When I save rpmdb
         And I enable repository "base"
         And I successfully run "dnf -y install TestA TestB"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
-         | State     | Packages     |
-         | installed | TestA, TestB |
+         | State     | Packages         |
+         | installed | TestA/1, TestB/1 |
 
   Scenario: Security check-update when there are no such updates
-       When I run "dnf --security check-update" 
+       When I run "dnf --security check-update"
        Then the command exit code is 0
         And the command stdout should not match regexp "TestA"
         And the command stdout should not match regexp "TestB"
@@ -56,72 +55,65 @@ Feature: Test for check-update, upgrade, update, upgrade-minimal and update-mini
        When I enable repository "sec-err-1"
         And I enable repository "sec-err-2"
         And I enable repository "enh-err"
-        And I run "dnf --security check-update" 
+        And I run "dnf --security check-update"
        Then the command exit code is 100
         And the command stdout should match regexp "TestA.*2-1.*sec-err-1"
-        And the command stdout should match regexp "TestA.*3-1.*sec-err-2" 
+        And the command stdout should match regexp "TestA.*3-1.*sec-err-2"
         And the command stdout should match regexp "TestA.*4-1.*enh-err"
         And the command stdout should not match regexp "TestB"
 
   Scenario: Security update
        When I save rpmdb
-        And I successfully run "dnf -y --security update" 
-       # verze maji byt TestA-4 a TestB-1, az to budeme umet, opravit
+        And I successfully run "dnf -y --security update"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA              |
+         | updated    | TestA/4            |
          | unchanged  | TestB              |
 
   Scenario: Cleanup after security update
        When I save rpmdb
         And I successfully run "dnf -y history undo last" 
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
-         | State      | Packages           |
-         | downgraded | TestA              |
-         | unchanged  | TestB              |
+         | State      | Packages             |
+         | downgraded | TestA/1              |
+         | unchanged  | TestB                |
 
   Scenario: Security upgrade
        When I save rpmdb
-        And I successfully run "dnf -y --security upgrade" 
-       # verze maji byt TestA-4 a TestB-1
+        And I successfully run "dnf -y --security upgrade"
        Then rpmdb changes are
-         | State      | Packages           |
-         | updated    | TestA              |
-         | unchanged  | TestB              |
+         | State      | Packages             |
+         | updated    | TestA/4              |
+         | unchanged  | TestB                |
 
   Scenario: Cleanup after security upgrade
        When I save rpmdb
-        And I successfully run "dnf -y history undo last" 
-       # verze maji byt TestA-1 a TestB-1
+        And I successfully run "dnf -y history undo last"
        Then rpmdb changes are
-         | State      | Packages           |
-         | downgraded | TestA              |
-         | unchanged  | TestB              |
+         | State      | Packages             |
+         | downgraded | TestA/1              |
+         | unchanged  | TestB                |
 
   Scenario: Security update-minimal
        When I save rpmdb
-        And I successfully run "dnf -y --security update-minimal" 
-       # verze maji byt TestA-3 a TestB-1
+        And I successfully run "dnf -y --security update-minimal"
        Then rpmdb changes are
-         | State      | Packages           |
-         | updated    | TestA              |
-         | unchanged  | TestB              |
+         | State      | Packages             |
+         | updated    | TestA/3              |
+         | unchanged  | TestB                |
 
   Scenario: Cleanup after security update-minimal
        When I save rpmdb
-        And I successfully run "dnf -y history undo last" 
-       # verze maji byt TestA-1 a TestB-1
+        And I successfully run "dnf -y history undo last"
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestA              |
+         | downgraded | TestA/1            |
          | unchanged  | TestB              |
 
   Scenario: Security upgrade-minimal
        When I save rpmdb
-        And I successfully run "dnf -y --security upgrade-minimal" 
-       # verze maji byt TestA-3 a TestB-1
+        And I successfully run "dnf -y --security upgrade-minimal"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA              |
+         | updated    | TestA/3            |
          | unchanged  | TestB              |

--- a/dnf-docker-test/features/security_4.feature
+++ b/dnf-docker-test/features/security_4.feature
@@ -1,0 +1,78 @@
+Feature: Test for upgrade and upgrade-minimal with bz and security options
+ repo base: TestA-1 TestB-1
+ repo sec-err-1: errata security Low: TestA-2
+ repo sec-err-2: errata security Moderate: TestB-2
+ repo bug-err: errata bugfix: TestA-3 TestB-3
+
+  @setup
+  Scenario: Setup (install TestA-1 TestB-1)
+      Given repository "base" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 1         |
+         | TestB        | Version  | 1         |
+        And repository "sec-err-1" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 2         |
+        And updateinfo defined in repository "sec-err-1"
+         | Id              | Tag        | Value                  |
+         | RHSA-2999-001   | Title      | TestA security update  |
+         |                 | Type       | security               |
+         |                 | Severity   | Low                    |
+         |                 | Reference  | BZ123                  |
+         |                 | Package    | TestA-2                |
+        And repository "sec-err-2" with packages
+         | Package      | Tag      | Value     |
+         | TestB        | Version  | 2         |
+        And updateinfo defined in repository "sec-err-2"
+         | Id              | Tag        | Value                  |
+         | RHSA-2999-002   | Title      | TestB security update  |
+         |                 | Type       | security               |
+         |                 | Severity   | Moderate               |
+         |                 | Reference  | BZ234                  |
+         |                 | Reference  | BZ345                  |
+         |                 | Package    | TestB-2                |
+        And repository "bug-err" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 3         |
+         | TestB        | Version  | 3         |
+        And updateinfo defined in repository "bug-err"
+         | Id              | Tag        | Value                  |
+         | RHBA-2999-003   | Title      | TestA TestB bugfix     |
+         |                 | Type       | bugfix                 |
+         |                 | Reference  | BZ456                  |
+         |                 | Package    | TestA-3                |
+         |                 | Package    | TestB-3                |
+       When I save rpmdb
+        And I enable repository "base"
+        And I successfully run "dnf -y install TestA TestB"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State     | Packages     |
+         | installed | TestA, TestB |
+
+  Scenario: Security plus three explicitly mentioned bzs upgrade
+       When I enable repository "sec-err-1"
+        And I enable repository "sec-err-2"
+        And I enable repository "bug-err"
+        And I save rpmdb
+        And I run "dnf -y --bz 123 --bz 234 --bz 345 --security upgrade" 
+       # verze maji byt TestA-3 a TestB-3
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA,TestB        |
+
+  Scenario: Cleanup after security plus bzs upgrade
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA,TestB        |
+
+  Scenario: Security plus three explicitly mentioned bzs upgrade-minimal
+       When I save rpmdb
+        And I run "dnf -y --bz 123 --bz 234 --bz 345 --security upgrade-minimal" 
+       # verze maji byt TestA-2 a TestB-2
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA,TestB        |

--- a/dnf-docker-test/features/security_4.feature
+++ b/dnf-docker-test/features/security_4.feature
@@ -45,34 +45,30 @@ Feature: Test for upgrade and upgrade-minimal with bz and security options
        When I save rpmdb
         And I enable repository "base"
         And I successfully run "dnf -y install TestA TestB"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
-         | State     | Packages     |
-         | installed | TestA, TestB |
+         | State     | Packages         |
+         | installed | TestA/1, TestB/1 |
 
   Scenario: Security plus three explicitly mentioned bzs upgrade
        When I enable repository "sec-err-1"
         And I enable repository "sec-err-2"
         And I enable repository "bug-err"
         And I save rpmdb
-        And I run "dnf -y --bz 123 --bz 234 --bz 345 --security upgrade" 
-       # verze maji byt TestA-3 a TestB-3
+        And I run "dnf -y --bz 123 --bz 234 --bz 345 --security upgrade"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA,TestB        |
+         | updated    | TestA/3,TestB/3    |
 
   Scenario: Cleanup after security plus bzs upgrade
        When I save rpmdb
         And I successfully run "dnf -y history undo last"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestA,TestB        |
+         | downgraded | TestA/1,TestB/1    |
 
   Scenario: Security plus three explicitly mentioned bzs upgrade-minimal
        When I save rpmdb
-        And I run "dnf -y --bz 123 --bz 234 --bz 345 --security upgrade-minimal" 
-       # verze maji byt TestA-2 a TestB-2
+        And I run "dnf -y --bz 123 --bz 234 --bz 345 --security upgrade-minimal"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA,TestB        |
+         | updated    | TestA/2,TestB/2    |

--- a/dnf-docker-test/features/security_5.feature
+++ b/dnf-docker-test/features/security_5.feature
@@ -1,0 +1,187 @@
+Feature: Test for upgrade and upgrade-minimal with cve, cves, bugfix, advisory, advisories, sec-severity, secseverity and security options
+ repo base: TestA-1 TestB-1
+ repo ext1: errata bugfix: TestA-2
+            errata security Moderate: TestB-2
+ repo ext2: errata bugfix: TestA-3 TestB-3
+ repo ext3: errata security Critical: TestB-4
+            errata enhancement: TestA-4
+
+  @setup
+  Scenario: Setup (install TestA-1 TestB-1)
+      Given repository "base" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 1         |
+         | TestB        | Version  | 1         |
+        And repository "ext1" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 2         |
+         | TestB        | Version  | 2         |
+        And updateinfo defined in repository "ext1"
+         | Id              | Tag        | Value                  |
+         | RHBA-2999-001   | Title      | TestA bugfix           |
+         |                 | Type       | bugfix                 |
+         |                 | Reference  | BZ111                  |
+         |                 | Package    | TestA-2                |
+         | RHSA-2999-002   | Title      | TestB security update  |
+         |                 | Type       | security               |
+         |                 | Severity   | Moderate               |
+         |                 | Reference  | CVE-2999-0001          |
+         |                 | Reference  | BZ222                  |
+         |                 | Package    | TestB-2                |
+        And repository "ext2" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 3         |
+         | TestB        | Version  | 3         |
+        And updateinfo defined in repository "ext2"
+         | Id              | Tag        | Value                  |
+         | RHBA-2999-003   | Title      | TestA TestB bugfix     |
+         |                 | Type       | bugfix                 |
+         |                 | Reference  | BZ333                  |
+         |                 | Package    | TestA-3                |
+         |                 | Package    | TestB-3                |
+        And repository "ext3" with packages
+         | Package      | Tag      | Value     |
+         | TestA        | Version  | 4         |
+         | TestB        | Version  | 4         |
+        And updateinfo defined in repository "ext3"
+         | Id              | Tag        | Value                  |
+         | RHSA-2999-004   | Title      | TestB security update  |
+         |                 | Type       | security               |
+         |                 | Severity   | Critical               |
+         |                 | Reference  | CVE-2999-0002          | 
+         |                 | Reference  | BZ444                  |
+         |                 | Package    | TestB-4                |
+         | RHEA-2999-005   | Title      | TestA enhancement      |
+         |                 | Type       | enhancement            |
+         |                 | Package    | TestA-4                |
+
+       When I save rpmdb
+        And I enable repository "base"
+        And I successfully run "dnf -y install TestA TestB"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State     | Packages     |
+         | installed | TestA, TestB |
+
+  Scenario: upgrade-minimal cve and advisory
+       When I enable repository "ext1"
+        And I enable repository "ext2"
+        And I enable repository "ext3"
+        And I save rpmdb
+        And I run "dnf -y --cve CVE-2999-0001 --advisory RHBA-2999-001 upgrade-minimal" 
+       # verze maji byt TestA-2 a TestB-2
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA,TestB        |
+
+  Scenario: Cleanup after upgrade-minimal cve and advisory
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA,TestB        |
+
+  Scenario: upgrade advisories
+       When I save rpmdb
+        And I run "dnf -y --advisories=RHSA-2999-004 --advisories=RHBA-2999-001 upgrade" 
+       # verze maji byt TestA-4 a TestB-4
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA,TestB        |
+
+  Scenario: Cleanup after upgrade advisories
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA,TestB        | 
+
+  Scenario: upgrade cves
+       When I save rpmdb
+        And I run "dnf -y --cves=CVE-2999-0001 --cves=CVE-2999-0002 upgrade" 
+       # verze maji byt TestB-4
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestB              |
+
+  Scenario: Cleanup after upgrade cves
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA,TestB        |
+
+  Scenario: upgrade-minimal sec-severity
+       When I save rpmdb
+        And I run "dnf -y --sec-severity Moderate upgrade-minimal" 
+       # verze ma byt TestB-2
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestB              |
+
+  Scenario: Cleanup after upgrade-minimal sec-severity
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestB              |
+
+  Scenario: upgrade secseverity
+       When I save rpmdb
+        And I run "dnf -y --secseverity Critical upgrade" 
+       # verze ma byt TestB-4
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestB              |
+
+  Scenario: Cleanup after upgrade secseverity
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestB              |
+
+  Scenario: upgrade-minimal bugfix
+       When I save rpmdb
+        And I run "dnf -y --bugfix upgrade-minimal" 
+       # verze maji byt TestA-3 a TestB-3
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA,TestB        |
+
+  Scenario: Cleanup after upgrade-minimal bugfix
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA,TestB        |
+
+  Scenario: upgrade bugfix
+       When I save rpmdb
+        And I run "dnf -y --bugfix upgrade" 
+       # verze maji byt TestA-4 a TestB-4
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA,TestB        |
+
+  Scenario: Cleanup after upgrade bugfix
+       When I save rpmdb
+        And I successfully run "dnf -y history undo last"
+       # verze maji byt TestA-1 a TestB-1
+       Then rpmdb changes are
+         | State      | Packages           |
+         | downgraded | TestA,TestB        |
+
+  Scenario: upgrade-minimal security plus bugfix
+       When I save rpmdb
+        And I run "dnf -y --security --bugfix upgrade-minimal" 
+       # verze maji byt TestA-3 a TestB-4
+       Then rpmdb changes are
+         | State      | Packages           |
+         | updated    | TestA,TestB        |

--- a/dnf-docker-test/features/security_5.feature
+++ b/dnf-docker-test/features/security_5.feature
@@ -1,3 +1,4 @@
+@xfail
 Feature: Test for upgrade and upgrade-minimal with cve, cves, bugfix, advisory, advisories, sec-severity, secseverity and security options
  repo base: TestA-1 TestB-1
  repo ext1: errata bugfix: TestA-2
@@ -48,7 +49,7 @@ Feature: Test for upgrade and upgrade-minimal with cve, cves, bugfix, advisory, 
          | RHSA-2999-004   | Title      | TestB security update  |
          |                 | Type       | security               |
          |                 | Severity   | Critical               |
-         |                 | Reference  | CVE-2999-0002          | 
+         |                 | Reference  | CVE-2999-0002          |
          |                 | Reference  | BZ444                  |
          |                 | Package    | TestB-4                |
          | RHEA-2999-005   | Title      | TestA enhancement      |
@@ -58,130 +59,114 @@ Feature: Test for upgrade and upgrade-minimal with cve, cves, bugfix, advisory, 
        When I save rpmdb
         And I enable repository "base"
         And I successfully run "dnf -y install TestA TestB"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
-         | State     | Packages     |
-         | installed | TestA, TestB |
+         | State     | Packages         |
+         | installed | TestA/1, TestB/1 |
 
   Scenario: upgrade-minimal cve and advisory
        When I enable repository "ext1"
         And I enable repository "ext2"
         And I enable repository "ext3"
         And I save rpmdb
-        And I run "dnf -y --cve CVE-2999-0001 --advisory RHBA-2999-001 upgrade-minimal" 
-       # verze maji byt TestA-2 a TestB-2
+        And I run "dnf -y --cve CVE-2999-0001 --advisory RHBA-2999-001 upgrade-minimal"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA,TestB        |
+         | updated    | TestA/2,TestB/2    |
 
   Scenario: Cleanup after upgrade-minimal cve and advisory
        When I save rpmdb
         And I successfully run "dnf -y history undo last"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestA,TestB        |
+         | downgraded | TestA/1,TestB/1    |
 
   Scenario: upgrade advisories
        When I save rpmdb
-        And I run "dnf -y --advisories=RHSA-2999-004 --advisories=RHBA-2999-001 upgrade" 
-       # verze maji byt TestA-4 a TestB-4
+        And I run "dnf -y --advisories=RHSA-2999-004 --advisories=RHBA-2999-001 upgrade"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA,TestB        |
+         | updated    | TestA/4,TestB/4    |
 
   Scenario: Cleanup after upgrade advisories
        When I save rpmdb
         And I successfully run "dnf -y history undo last"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestA,TestB        | 
+         | downgraded | TestA/1,TestB/1    |
 
   Scenario: upgrade cves
        When I save rpmdb
-        And I run "dnf -y --cves=CVE-2999-0001 --cves=CVE-2999-0002 upgrade" 
-       # verze maji byt TestB-4
+        And I run "dnf -y --cves=CVE-2999-0001 --cves=CVE-2999-0002 upgrade"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestB              |
+         | updated    | TestB/4            |
 
   Scenario: Cleanup after upgrade cves
        When I save rpmdb
         And I successfully run "dnf -y history undo last"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestA,TestB        |
+         | downgraded | TestB/1            |
 
   Scenario: upgrade-minimal sec-severity
        When I save rpmdb
-        And I run "dnf -y --sec-severity Moderate upgrade-minimal" 
-       # verze ma byt TestB-2
+        And I run "dnf -y --sec-severity Moderate upgrade-minimal"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestB              |
+         | updated    | TestB/2            |
 
   Scenario: Cleanup after upgrade-minimal sec-severity
        When I save rpmdb
         And I successfully run "dnf -y history undo last"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestB              |
+         | downgraded | TestB/1            |
 
   Scenario: upgrade secseverity
        When I save rpmdb
-        And I run "dnf -y --secseverity Critical upgrade" 
-       # verze ma byt TestB-4
+        And I run "dnf -y --secseverity Critical upgrade"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestB              |
+         | updated    | TestB/4            |
 
   Scenario: Cleanup after upgrade secseverity
        When I save rpmdb
         And I successfully run "dnf -y history undo last"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestB              |
+         | downgraded | TestB/1            |
 
   Scenario: upgrade-minimal bugfix
        When I save rpmdb
-        And I run "dnf -y --bugfix upgrade-minimal" 
-       # verze maji byt TestA-3 a TestB-3
+        And I run "dnf -y --bugfix upgrade-minimal"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA,TestB        |
+         | updated    | TestA/3,TestB/3    |
 
   Scenario: Cleanup after upgrade-minimal bugfix
        When I save rpmdb
         And I successfully run "dnf -y history undo last"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestA,TestB        |
+         | downgraded | TestA/1,TestB/1    |
 
   Scenario: upgrade bugfix
        When I save rpmdb
-        And I run "dnf -y --bugfix upgrade" 
-       # verze maji byt TestA-4 a TestB-4
+        And I run "dnf -y --bugfix upgrade"
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA,TestB        |
+         | updated    | TestA/4,TestB/4    |
 
   Scenario: Cleanup after upgrade bugfix
        When I save rpmdb
         And I successfully run "dnf -y history undo last"
-       # verze maji byt TestA-1 a TestB-1
        Then rpmdb changes are
          | State      | Packages           |
-         | downgraded | TestA,TestB        |
+         | downgraded | TestA/1,TestB/1    |
 
   Scenario: upgrade-minimal security plus bugfix
        When I save rpmdb
         And I run "dnf -y --security --bugfix upgrade-minimal" 
-       # verze maji byt TestA-3 a TestB-4
        Then rpmdb changes are
          | State      | Packages           |
-         | updated    | TestA,TestB        |
+         | updated    | TestA/3,TestB/4    |


### PR DESCRIPTION
security_5 test currently fails due to --sec-severity (afaik it is implemented but probably not present in the latest dnf-nightly build yet)