### PR TITLE
Add build for fedora-rawhide chroots

### DIFF
--- a/jobs/nightly.yaml
+++ b/jobs/nightly.yaml
@@ -29,3 +29,5 @@
       - fedora-25-i386
       - fedora-26-x86_64
       - fedora-26-i386
+      - fedora-rawhide-x86_64
+      - fedora-rawhide-i386


### PR DESCRIPTION
It enables possibility to downloads latest updates for rawhide users

Requested by: https://bugzilla.redhat.com/show_bug.cgi?id=1397174#c12