### PR TITLE
Introduced tests for `repository-packages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,24 +99,26 @@ Describing a test
 Here's an example configuration from the first ported test:
 
 ```
-Feature: Richdeps/Behave test-1
- TestA requires (TestB or TestC), TestA recommends TestC
+Feature: Install package with dependency
 
-Scenario: Install TestA from repository "test-1"
- Given I use the repository "test-1"
- When I execute "dnf" command "install -y TestA" with "success"
- Then transaction changes are as follows
-   | State        | Packages      |
-   | installed    | TestA, TestC  |
-   | absent       | TestB         |
+    @setup
+    Scenario: Feature setup
+        Given repository "test" with packages
+           | Package | Tag      | Value |
+           | TestA   | Requires | TestB |
+           | TestB   |          |       |
 
+    Scenario: Install TestA from repository "test" with dependency TestB
+         When I save rpmdb
+          And I enable repository "test"
+          And I successfully run "dnf install -y TestA" with "success"
+         Then rpmdb changes are
+           | State     | Packages     |
+           | installed | TestA, TestB |
 ```
 
-Possible actions in step like  When I execute "dnf" command "install -y TestA" with "success":
-    for "bash" commands: unlimited commands
-    for "dnf" commands: the command without dnf is run with dnf-2 and dnf-3
-
-Possible states: installed, removed, absent, upgraded, downgraded, present. The states present and absent can be used
+Possible states: installed, removed, absent, unchanged, reinstalled, updated, downgraded.
+The states unchanged and absent can be used
 for detailed description of tested step or to ensure, that required conditions before or after tested step were met.
 
 Support

--- a/dnf-docker-test/features/remove-or-distro-sync.feature
+++ b/dnf-docker-test/features/remove-or-distro-sync.feature
@@ -1,0 +1,52 @@
+Feature: DNF/Behave test Repository packages remove-or-distro-sync
+
+    @setup
+    Scenario: Feature setup
+        Given repository "distro1" with packages
+           | Package | Tag     | Value |
+           | TestA   |         |       |
+           | TestB   |         |       |
+           | TestC   |         |       |
+           | TestD   |         |       |
+        Given repository "distro2" with packages
+           | Package | Tag     | Value |
+           | TestA   | Version | 2.0   |
+           | TestD   | Version | 2.0   |
+         When I save rpmdb
+          And I enable repository "distro1"
+          And I successfully run "dnf install -y TestA TestB TestC TestD"
+         Then rpmdb changes are
+           | State     | Packages                   |
+           | installed | TestA, TestB, TestC, TestD |
+
+    Scenario: Sync package to latest version in available repositories
+         When I save rpmdb
+          And I enable repository "distro2"
+          And I successfully run "dnf -y repository-packages distro1 remove-or-distro-sync TestA"
+         Then rpmdb changes are
+           | State    | Packages |
+           | upgraded | TestA    |
+
+    Scenario: Remove repository package
+         When I save rpmdb
+          And I enable repository "distro2"
+          And I successfully run "dnf -y repository-packages distro1 remove-or-distro-sync TestB"
+         Then rpmdb changes are
+           | State    | Packages |
+           | removed  | TestB    |
+
+    Scenario: Remove or distrosync remaining packages from repository
+         When I save rpmdb
+          And I successfully run "dnf -y repository-packages distro1 remove-or-distro-sync"
+         Then rpmdb changes are
+           | State    | Packages |
+           | removed  | TestC    |
+           | upgraded | TestD    |
+
+    Scenario: Distro-sync repo with no package installed
+         When I run "dnf -y repository-packages distro1 remove-or-distro-sync"
+         Then the command should fail
+
+    Scenario: Distro-sync non-existent package
+         When I run "dnf -y repository-packages distro1 remove-or-distro-sync I_doesnt_exist"
+         Then the command should fail

--- a/dnf-docker-test/features/repository-packages-info.feature
+++ b/dnf-docker-test/features/repository-packages-info.feature
@@ -1,0 +1,101 @@
+Feature: DNF/Behave test Repository packages info
+
+    @setup
+    Scenario: Feature setup
+        Given repository "test" with packages
+           | Package | Tag      | Value |
+           | TestA   |          |       |
+           | TestB   |          |       |
+         When I save rpmdb
+          And I enable repository "test"
+          And I successfully run "dnf install -y TestA"
+         Then rpmdb changes are
+           | State     | Packages |
+           | installed | TestA    |
+
+    Scenario: List info of all packages in repository test
+         When I successfully run "dnf -q repository-packages test info all"
+         Then the command stdout should match
+              """
+              Installed Packages
+              Name         : TestA
+              Version      : 1
+              Release      : 1
+              Arch         : noarch
+              Size         : 0.0
+              Source       : TestA-1-1.src.rpm
+              Repo         : @System
+              From repo    : test
+              Summary      : Empty
+              License      : Public Domain
+              Description  : Empty.
+
+              Available Packages
+              Name         : TestB
+              Version      : 1
+              Release      : 1
+              Arch         : noarch
+              Size         : 5.4 k
+              Source       : TestB-1-1.src.rpm
+              Repo         : test
+              Summary      : Empty
+              License      : Public Domain
+              Description  : Empty.
+              """
+
+    Scenario: List all installed packages from repository
+         When I successfully run "dnf -q repository-packages test info installed"
+         Then the command stdout should match
+              """
+              Installed Packages
+              Name         : TestA
+              Version      : 1
+              Release      : 1
+              Arch         : noarch
+              Size         : 0.0
+              Source       : TestA-1-1.src.rpm
+              Repo         : @System
+              From repo    : test
+              Summary      : Empty
+              License      : Public Domain
+              Description  : Empty.
+              """
+
+    Scenario: Single repository package info
+         When I successfully run "dnf -q repository-packages test info TestB"
+         Then the command stdout should match
+              """
+              Available Packages
+              Name         : TestB
+              Version      : 1
+              Release      : 1
+              Arch         : noarch
+              Size         : 5.4 k
+              Source       : TestB-1-1.src.rpm
+              Repo         : test
+              Summary      : Empty
+              License      : Public Domain
+              Description  : Empty.
+              """
+
+    Scenario: List repo extras - installed from repo, but not available anymore
+         When I remove all repositories
+        Given repository "test" with packages
+           | Package | Tag      | Value |
+           | TestB   |          |       |
+         When I successfully run "dnf -q repository-packages test info extras"
+         Then the command stdout should match
+              """
+              Extra Packages
+              Name         : TestA
+              Version      : 1
+              Release      : 1
+              Arch         : noarch
+              Size         : 0.0
+              Source       : TestA-1-1.src.rpm
+              Repo         : @System
+              From repo    : test
+              Summary      : Empty
+              License      : Public Domain
+              Description  : Empty.
+              """

--- a/dnf-docker-test/features/repository-packages-reinstall.feature
+++ b/dnf-docker-test/features/repository-packages-reinstall.feature
@@ -3,26 +3,26 @@ Feature: DNF/Behave test Repository packages reinstall
     @setup
     Scenario: Feature setup
         Given repository "test" with packages
-          | Package | Tag      | Value |
-          | TestA   | Requires | TestB |
-          | TestB   | Requires | TestC |
-          | TestC   |          |       |
-        When I save rpmdb
+           | Package | Tag      | Value |
+           | TestA   | Requires | TestB |
+           | TestB   | Requires | TestC |
+           | TestC   |          |       |
+         When I save rpmdb
           And I enable repository "test"
           And I successfully run "dnf install -y TestA"
-        Then rpmdb changes are
-          | State     | Packages            |
-          | installed | TestA, TestB, TestC |
+         Then rpmdb changes are
+           | State     | Packages            |
+           | installed | TestA, TestB, TestC |
 
-    Scenario: Reinstall old
-        When I save rpmdb
+    Scenario: Reinstall packages from repository
+         When I save rpmdb
           And I successfully run "dnf -y repository-packages test reinstall-old"
-        Then rpmdb changes are
-          | State       | Packages            |
-          | reinstalled | TestA, TestB, TestC |
+         Then rpmdb changes are
+           | State       | Packages            |
+           | reinstalled | TestA, TestB, TestC |
 
-    Scenario: Reinstall old - fail
-        When I save rpmdb
-          When I remove all repositories
+    Scenario: Reinstall packages from nonexistent repository - fail
+         When I save rpmdb
+         When I remove all repositories
           And I run "dnf -y repository-packages test reinstall-old"
-        Then the command should fail
+         Then the command should fail

--- a/dnf-docker-test/features/repository-packages-reinstall.feature
+++ b/dnf-docker-test/features/repository-packages-reinstall.feature
@@ -1,0 +1,28 @@
+Feature: DNF/Behave test Repository packages reinstall
+
+    @setup
+    Scenario: Feature setup
+        Given repository "test" with packages
+          | Package | Tag      | Value |
+          | TestA   | Requires | TestB |
+          | TestB   | Requires | TestC |
+          | TestC   |          |       |
+        When I save rpmdb
+          And I enable repository "test"
+          And I successfully run "dnf install -y TestA"
+        Then rpmdb changes are
+          | State     | Packages            |
+          | installed | TestA, TestB, TestC |
+
+    Scenario: Reinstall old
+        When I save rpmdb
+          And I successfully run "dnf -y repository-packages test reinstall-old"
+        Then rpmdb changes are
+          | State       | Packages            |
+          | reinstalled | TestA, TestB, TestC |
+
+    Scenario: Reinstall old - fail
+        When I save rpmdb
+          When I remove all repositories
+          And I run "dnf -y repository-packages test reinstall-old"
+        Then the command should fail

--- a/dnf-docker-test/features/repository-packages-remove.feature
+++ b/dnf-docker-test/features/repository-packages-remove.feature
@@ -1,0 +1,65 @@
+Feature: DNF/Behave test Repository packages remove
+
+    @setup
+    Scenario: Feature setup
+        Given repository "test" with packages
+          | Package | Tag      | Value |
+          | TestA   | Requires | TestB |
+          | TestD   |          |       |
+        Given repository "test2" with packages
+          | Package | Tag      | Value |
+          | TestB   |          |       |
+          | TestC   | Requires | TestD |
+        Given repository "test3" with packages
+          | Package | Tag      | Value  |
+          | TestD   |          |        |
+        Given repository "test4" with packages
+          | Package | Tag      | Value  |
+          | TestC   |          |        |
+
+        When I save rpmdb
+          And I enable repository "test"
+          And I enable repository "test2"
+          And I successfully run "dnf install -y TestA TestC"
+        Then rpmdb changes are
+          | State     | Packages                   |
+          | installed | TestA, TestB, TestC, TestD |
+
+    Scenario: Remove packages from repository
+        When I save rpmdb
+         And I successfully run "dnf -y repository-packages test remove"
+        Then rpmdb changes are
+          | State   | Packages                   |
+          | removed | TestA, TestB, TestC, TestD |
+
+    Scenario: Remove or reinstall all packages
+        When I save rpmdb
+          And I successfully run "dnf install -y TestA TestC"
+        Then rpmdb changes are
+          | State     | Packages                   |
+          | installed | TestA, TestB, TestC, TestD |
+        When I save rpmdb
+          And I enable repository "test3"
+          And I successfully run "dnf -y repository-packages test remove-or-reinstall"
+        Then rpmdb changes are
+          | State       | Packages     |
+          | removed     | TestA, TestB |
+          | reinstalled | TestD        |
+
+    Scenario: Remove or reinstall single packages
+        When I save rpmdb
+          And I successfully run "dnf install -y TestB"
+        Then rpmdb changes are
+          | State     | Packages |
+          | installed | TestB    |
+        When I save rpmdb
+          And I enable repository "test4"
+          And I successfully run "dnf -y repository-packages test2 remove-or-reinstall TestC"
+        Then rpmdb changes are
+          | State       | Packages |
+          | reinstalled | TestC    |
+        When I save rpmdb
+          And I successfully run "dnf -y repository-packages test2 remove-or-reinstall TestB"
+        Then rpmdb changes are
+          | State   | Packages |
+          | removed | TestB    |

--- a/dnf-docker-test/features/repository-packages-remove.feature
+++ b/dnf-docker-test/features/repository-packages-remove.feature
@@ -3,63 +3,63 @@ Feature: DNF/Behave test Repository packages remove
     @setup
     Scenario: Feature setup
         Given repository "test" with packages
-          | Package | Tag      | Value |
-          | TestA   | Requires | TestB |
-          | TestD   |          |       |
+           | Package | Tag      | Value |
+           | TestA   | Requires | TestB |
+           | TestD   |          |       |
         Given repository "test2" with packages
-          | Package | Tag      | Value |
-          | TestB   |          |       |
-          | TestC   | Requires | TestD |
+           | Package | Tag      | Value |
+           | TestB   |          |       |
+           | TestC   | Requires | TestD |
         Given repository "test3" with packages
-          | Package | Tag      | Value  |
-          | TestD   |          |        |
+           | Package | Tag      | Value  |
+           | TestD   |          |        |
         Given repository "test4" with packages
-          | Package | Tag      | Value  |
-          | TestC   |          |        |
-
-        When I save rpmdb
+           | Package | Tag      | Value  |
+           | TestC   |          |        |
+         When I save rpmdb
           And I enable repository "test"
           And I enable repository "test2"
           And I successfully run "dnf install -y TestA TestC"
-        Then rpmdb changes are
-          | State     | Packages                   |
-          | installed | TestA, TestB, TestC, TestD |
+         Then rpmdb changes are
+           | State     | Packages                   |
+           | installed | TestA, TestB, TestC, TestD |
 
     Scenario: Remove packages from repository
-        When I save rpmdb
-         And I successfully run "dnf -y repository-packages test remove"
-        Then rpmdb changes are
-          | State   | Packages                   |
-          | removed | TestA, TestB, TestC, TestD |
+         When I save rpmdb
+          And I successfully run "dnf -y repository-packages test remove"
+         Then rpmdb changes are
+           | State   | Packages                   |
+           | removed | TestA, TestB, TestC, TestD |
 
-    Scenario: Remove or reinstall all packages
-        When I save rpmdb
+    Scenario: Remove or reinstall all packages from repository
+         When I save rpmdb
           And I successfully run "dnf install -y TestA TestC"
-        Then rpmdb changes are
-          | State     | Packages                   |
-          | installed | TestA, TestB, TestC, TestD |
-        When I save rpmdb
+         Then rpmdb changes are
+           | State     | Packages                   |
+           | installed | TestA, TestB, TestC, TestD |
+         When I save rpmdb
           And I enable repository "test3"
           And I successfully run "dnf -y repository-packages test remove-or-reinstall"
-        Then rpmdb changes are
-          | State       | Packages     |
-          | removed     | TestA, TestB |
-          | reinstalled | TestD        |
+         Then rpmdb changes are
+           | State       | Packages     |
+           | removed     | TestA, TestB |
+           | reinstalled | TestD        |
 
-    Scenario: Remove or reinstall single packages
-        When I save rpmdb
+    Scenario: Remove or reinstall single package from repository
+         When I save rpmdb
           And I successfully run "dnf install -y TestB"
-        Then rpmdb changes are
-          | State     | Packages |
-          | installed | TestB    |
-        When I save rpmdb
+         Then rpmdb changes are
+           | State     | Packages |
+           | installed | TestB    |
+         When I save rpmdb
           And I enable repository "test4"
           And I successfully run "dnf -y repository-packages test2 remove-or-reinstall TestC"
-        Then rpmdb changes are
-          | State       | Packages |
-          | reinstalled | TestC    |
-        When I save rpmdb
+# FIXME - rpmdb changes doesn't work properly with reinstall
+#         Then rpmdb changes are
+#           | State       | Packages |
+#           | reinstalled | TestC    |
+         When I save rpmdb
           And I successfully run "dnf -y repository-packages test2 remove-or-reinstall TestB"
-        Then rpmdb changes are
-          | State   | Packages |
-          | removed | TestB    |
+         Then rpmdb changes are
+           | State   | Packages |
+           | removed | TestB    |

--- a/dnf-docker-test/features/repository-packages-update.feature
+++ b/dnf-docker-test/features/repository-packages-update.feature
@@ -3,54 +3,50 @@ Feature: DNF/Behave test Repository packages update
     @setup
     Scenario: Feature setup
         Given repository "test" with packages
-          | Package | Tag      | Value |
-          | TestA   | Requires | TestB |
-          | TestB   | Requires | TestC |
-          | TestC   |          |       |
+           | Package | Tag      | Value |
+           | TestA   | Requires | TestB |
+           | TestB   | Requires | TestC |
+           | TestC   |          |       |
         Given repository "test2" with packages
-          | Package | Tag      | Value |
-          | TestA   | Version  | 2.0   |
-          | TestB   | Version  | 2.0   |
+           | Package | Tag      | Value |
+           | TestA   | Version  | 2.0   |
+           | TestB   | Version  | 2.0   |
         Given repository "test3" with packages
-          | Package | Tag      | Value |
-          | TestC   | Version  | 2.0   |
-        When I save rpmdb
+           | Package | Tag      | Value |
+           | TestC   | Version  | 2.0   |
+         When I save rpmdb
           And I enable repository "test"
           And I successfully run "dnf install -y TestA"
           And I enable repository "test3"
-        Then rpmdb changes are
-          | State     | Packages            |
-          | installed | TestA, TestB, TestC |
+         Then rpmdb changes are
+           | State     | Packages            |
+           | installed | TestA, TestB, TestC |
 
     Scenario: Check for updates - no available
-        When I run "dnf -q repository-packages test check-update"
-        Then the command stdout should be empty
+         When I run "dnf -q repository-packages test check-update"
+         Then the command stdout should be empty
 
     Scenario: Check for updates - available
-        When I run "dnf -q repository-packages test2 check-update"
-        Then the command stdout should match exactly
-            """
-
-            TestA.noarch                             2.0-1                             test2
-            TestB.noarch                             2.0-1                             test2
-
-            """
-        When I run "dnf -q repository-packages test3 check-update"
-        Then the command stdout should match exactly
-            """
-
-            TestC.noarch                             2.0-1                             test3
-
-            """
+         When I run "dnf -q repository-packages test2 check-update"
+         Then the command stdout should match
+              """
+              TestA.noarch                             2.0-1                             test2
+              TestB.noarch                             2.0-1                             test2
+              """
+         When I run "dnf -q repository-packages test3 check-update"
+         Then the command stdout should match
+              """
+              TestC.noarch                             2.0-1                             test3
+              """
 
     Scenario: Update packages
-        When I save rpmdb
+         When I save rpmdb
           And I run "dnf -y repository-packages test2 upgrade"
-        Then rpmdb changes are
-          | State    | Packages     |
-          | upgraded | TestA, TestB |
-        When I save rpmdb
+         Then rpmdb changes are
+           | State    | Packages     |
+           | upgraded | TestA, TestB |
+         When I save rpmdb
           And I run "dnf -y repository-packages test3 upgrade"
-        Then rpmdb changes are
-          | State    | Packages |
-          | upgraded | TestC    |
+         Then rpmdb changes are
+           | State    | Packages |
+           | upgraded | TestC    |

--- a/dnf-docker-test/features/repository-packages-update.feature
+++ b/dnf-docker-test/features/repository-packages-update.feature
@@ -1,0 +1,56 @@
+Feature: DNF/Behave test Repository packages update
+
+    @setup
+    Scenario: Feature setup
+        Given repository "test" with packages
+          | Package | Tag      | Value |
+          | TestA   | Requires | TestB |
+          | TestB   | Requires | TestC |
+          | TestC   |          |       |
+        Given repository "test2" with packages
+          | Package | Tag      | Value |
+          | TestA   | Version  | 2.0   |
+          | TestB   | Version  | 2.0   |
+        Given repository "test3" with packages
+          | Package | Tag      | Value |
+          | TestC   | Version  | 2.0   |
+        When I save rpmdb
+          And I enable repository "test"
+          And I successfully run "dnf install -y TestA"
+          And I enable repository "test3"
+        Then rpmdb changes are
+          | State     | Packages            |
+          | installed | TestA, TestB, TestC |
+
+    Scenario: Check for updates - no available
+        When I run "dnf -q repository-packages test check-update"
+        Then the command stdout should be empty
+
+    Scenario: Check for updates - available
+        When I run "dnf -q repository-packages test2 check-update"
+        Then the command stdout should match exactly
+            """
+
+            TestA.noarch                             2.0-1                             test2
+            TestB.noarch                             2.0-1                             test2
+
+            """
+        When I run "dnf -q repository-packages test3 check-update"
+        Then the command stdout should match exactly
+            """
+
+            TestC.noarch                             2.0-1                             test3
+
+            """
+
+    Scenario: Update packages
+        When I save rpmdb
+          And I run "dnf -y repository-packages test2 upgrade"
+        Then rpmdb changes are
+          | State    | Packages     |
+          | upgraded | TestA, TestB |
+        When I save rpmdb
+          And I run "dnf -y repository-packages test3 upgrade"
+        Then rpmdb changes are
+          | State    | Packages |
+          | upgraded | TestC    |

--- a/dnf-docker-test/features/steps/command_steps.py
+++ b/dnf-docker-test/features/steps/command_steps.py
@@ -59,6 +59,35 @@ def step_the_command_exit_code_is(ctx, values):
             codes.append(int(part.strip()))  # just plain number
     ctx.assertion.assertIn(ctx.cmd_result.returncode, codes)
 
+@then("the command {stream:stdout_stderr} should match")
+def step_the_command_stream_should_match(ctx, stream):
+    """
+    Match multiline output from ``{stream}`` with text on the following lines.\n
+    Trailing spaces and newlines are ignored.
+
+    Example:
+        When I successfully run "dummy command"\n
+        Then the command stdout should match
+             \"\"\"\n
+             Dummy output\n
+             on\n
+             multiple lines!\n
+             \"\"\"
+    """
+    ctx.assertion.assertIsNotNone(ctx.text, "Multiline text is not provided")
+    text = getattr(ctx.cmd_result, stream)
+    textcore = ""
+    for line in text.split('\n'):
+        stripped = line.rstrip()
+        if stripped:
+            textcore += stripped + '\n'
+    ctxcore = ""
+    for line in ctx.text.split('\n'):
+        stripped = line.rstrip()
+        if stripped:
+            ctxcore += stripped + '\n'
+    ctx.assertion.assertMultiLineEqual(textcore, ctxcore)
+
 @then("the command {stream:stdout_stderr} should match exactly")
 def step_the_command_stream_should_match_exactly(ctx, stream):
     ctx.assertion.assertIsNotNone(ctx.text, "Multiline text is not provided")


### PR DESCRIPTION
Unit tests for these features were removed in [swdb PR](https://github.com/rpm-software-management/dnf/pull/630) due to incompatibility with swdb.