### PR TITLE
step for signing one GPG key with another

### DIFF
--- a/dnf-docker-test/features/steps/gpg_steps.py
+++ b/dnf-docker-test/features/steps/gpg_steps.py
@@ -26,6 +26,27 @@ GPGKEY_FILEPATH_TMPL = "/root/{!s}.{!s}"
 
 JINJA_ENV = jinja2.Environment(undefined=jinja2.StrictUndefined)
 
+@given('GPG key "{signed_key}" signed by "{signing_key}"')
+def step_gpg_key_signed_by(ctx, signed_key, signing_key):
+    """
+    Signs one GPG with another GPG key producing a detached signature file.
+
+    Examples:
+
+    .. code-block:: gherkin
+
+       Feature: GPG key signing
+
+         Scenario: Sign one GPG with another
+           Given GPG key "James Bond"
+             And GPG key "M"
+             And GPG key "James Bond" signed by "M"
+    """
+    signed_key_path = GPGKEY_FILEPATH_TMPL.format(signed_key, "pubkey")
+    gpgbin = which("gpg2")
+    cmd = "{!s} --detach-sig --armor --default-key '{!s}' '{!s}'".format(gpgbin, signing_key, signed_key_path)
+    step_i_successfully_run_command(ctx, cmd)
+
 @given('GPG key "{name_real}"')
 def step_gpg_key(ctx, name_real):
     """


### PR DESCRIPTION
Necessary for testing gpgcakey functionality, unfortunately not yet implemented in DNF. FYI, into yum it was introduced via RHBZ#662712.

Following feature file would do the required setup

```
     Feature: Repodata signatures

         Scenario: Setup repository with signed metadata
           Given GPG key "JamesBond"
           Given GPG key "M"
           Given GPG key "JamesBond" signed by "M"
             And GPG key "JamesBond" imported in rpm database
             And enabled repository "TestRepo" with packages signed by "JamesBond"
               | Package | Tag | Value |
               | TestA   |     |       |
             And repository "TestRepo" metadata signed by "JamesBond"
             And a repo file of repository "TestRepo" modified with
               | Key           | Value |
               | repo_gpgcheck | True  |
	       | gpgcakey      | file:///root/M.pubkey |

```
When implemented properly, the installation of TestA should trigger the request to import the M key (CA key) and then the other key (JamesBond) should be imported automatically.