### PR TITLE
Change expected output in tree tests

### DIFF
--- a/dnf-docker-test/features/deplist-1.feature
+++ b/dnf-docker-test/features/deplist-1.feature
@@ -5,17 +5,7 @@ Feature: Deplist as commmand and option
 
   Scenario: Deplist as command
        When I successfully run "yum deplist TestA"
-       Then the command stdout should match exactly
-            """
-            package: TestA-1.0.0-1.noarch
-              dependency: TestB
-               provider: TestB-1.0.0-2.noarch
-
-            package: TestA-1.0.0-2.noarch
-              dependency: TestB
-               provider: TestB-1.0.0-2.noarch
-
-            """
+       Then the command stdout should match regexp "package: TestA-1.0.0-1.noarch\s*dependency: TestB\s*provider: TestB-1.0.0-2.noarch\s*package: TestA-1.0.0-2.noarch\s*dependency: TestB\s*provider: TestB-1.0.0-2.noarch"
 
   Scenario: Deplist as repoquery option
        When I successfully run "dnf repoquery --deplist TestA"
@@ -33,27 +23,11 @@ Feature: Deplist as commmand and option
 
   Scenario: Deplist as repoquery option but using dnf bin
        When I successfully run "sh -c 'dnf repoquery --deplist TestA'"
-       Then the command stdout should match exactly
-            """
-            package: TestA-1.0.0-1.noarch
-              dependency: TestB
-               provider: TestB-1.0.0-2.noarch
-
-            package: TestA-1.0.0-2.noarch
-              dependency: TestB
-               provider: TestB-1.0.0-2.noarch
-
-            """
+       Then the command stdout should match regexp "package: TestA-1.0.0-1.noarch\s*dependency: TestB\s*provider: TestB-1.0.0-2.noarch\s*package: TestA-1.0.0-2.noarch\s*dependency: TestB\s*provider: TestB-1.0.0-2.noarch"
 
   Scenario: Deplist with --latest-limit
        When I successfully run "dnf repoquery --deplist --latest-limit 1 TestA"
-       Then the command stdout should match exactly
-            """
-            package: TestA-1.0.0-2.noarch
-              dependency: TestB
-               provider: TestB-1.0.0-2.noarch
-
-            """
+       Then the command stdout should match regexp "package: TestA-1.0.0-2.noarch\s*dependency: TestB\s*provider: TestB-1.0.0-2.noarch"
 
   Scenario: Deplist with --latest-limit and verbose
        When I execute "dnf" command "repoquery --deplist --latest-limit 1 --verbose TestA" with "success"

--- a/dnf-docker-test/features/repolist-2.feature
+++ b/dnf-docker-test/features/repolist-2.feature
@@ -10,23 +10,14 @@ Feature: Handling of --disablerepo and --enablerepo
 
   Scenario: Handling of --disablerepo and --enablerepo with one repo
        When I successfully run "dnf repolist --enablerepo=test* --setopt=strict=true"
-       Then the command stdout should match exactly
-            """
-            repo id                              repo name                            status
-            test-1                               test-1                               0
-
-            """
+       Then the command stdout should match regexp "repo id +repo name +status\s+test-1 +test-1 +0"
 
        When I successfully run "dnf repolist --disablerepo=test* --setopt=strict=true"
        Then the command stdout should be empty
 
        When I successfully run "dnf repolist --enablerepo=test* --setopt=strict=false"
-       Then the command stdout should match exactly
-            """
-            repo id                              repo name                            status
-            test-1                               test-1                               0
 
-            """
+       Then the command stdout should match regexp "repo id +repo name +status\s+test-1 +test-1 +0"
 
        When I successfully run "dnf repolist --disablerepo=test* --setopt=strict=false"
        Then the command stdout should be empty

--- a/dnf-docker-test/features/repolist-enabled-disabled.feature
+++ b/dnf-docker-test/features/repolist-enabled-disabled.feature
@@ -14,40 +14,16 @@ Feature: Repolist with enabled/disabled repositories
 
   Scenario: Repolist without arguments
        When I successfully run "dnf repolist"
-       Then the command stdout should match exactly
-            """
-            repo id                               repo name                           status
-            TestB                                 TestB                               0
-            TestC                                 TestC                               3
-
-            """
+       Then the command stdout should match regexp "repo id +repo name +status\s+TestB +TestB +0\s+TestC +TestC +3"
 
   Scenario: Repolist with "enabled"
        When I successfully run "dnf repolist enabled"
-       Then the command stdout should match exactly
-            """
-            repo id                               repo name                           status
-            TestB                                 TestB                               0
-            TestC                                 TestC                               3
-
-            """
+       Then the command stdout should match regexp "repo id +repo name +status\s+TestB +TestB +0\s+TestC +TestC +3"
 
   Scenario: Repolist with "disabled"
        When I successfully run "dnf repolist disabled"
-       Then the command stdout should match exactly
-            """
-            repo id                                  repo name                              
-            TestA                                    TestA                                  
-
-            """
+       Then the command stdout should match regexp "repo id +repo name\s+TestA +TestA"
 
   Scenario: Repolist with "all"
        When I successfully run "dnf repolist all"
-       Then the command stdout should match exactly
-            """
-            repo id                             repo name                         status
-            TestA                               TestA                             disabled
-            TestB                               TestB                             enabled: 0
-            TestC                               TestC                             enabled: 3
-
-            """
+       Then the command stdout should match regexp "repo id +repo name +status\s+TestA +TestA +disabled\s+TestB +TestB +enabled: 0\s+TestC +TestC +enabled: 3"


### PR DESCRIPTION
It reflects that in output of DNF is also present information about downloaded
metadata.