### PR TITLE
Add "dnf makecache" to Scenario Setup

### DIFF
--- a/dnf-docker-test/features/deplist-1.feature
+++ b/dnf-docker-test/features/deplist-1.feature
@@ -2,6 +2,7 @@ Feature: Deplist as commmand and option
 
   Scenario: Feature Setup
       Given I use the repository "upgrade_1"
+      When I successfully run "dnf makecache"
 
   Scenario: Deplist as command
        When I successfully run "yum deplist TestA"

--- a/dnf-docker-test/features/repolist-2.feature
+++ b/dnf-docker-test/features/repolist-2.feature
@@ -7,6 +7,7 @@ Feature: Handling of --disablerepo and --enablerepo
   @setup
   Scenario: Feature Setup
       Given empty repository "test-1"
+      When I successfully run "dnf --enablerepo=test* makecache"
 
   Scenario: Handling of --disablerepo and --enablerepo with one repo
        When I successfully run "dnf repolist --enablerepo=test* --setopt=strict=true"

--- a/dnf-docker-test/features/repolist-enabled-disabled.feature
+++ b/dnf-docker-test/features/repolist-enabled-disabled.feature
@@ -11,6 +11,7 @@ Feature: Repolist with enabled/disabled repositories
          | TestC   |     |       |
        When I enable repository "TestB"
         And I enable repository "TestC"
+        And I successfully run "dnf makecache"
 
   Scenario: Repolist without arguments
        When I successfully run "dnf repolist"


### PR DESCRIPTION
Cache is created during first test without this -> Problem
with statistics/progress_bar and "stdout should match exactly".

Needed for https://github.com/rpm-software-management/dnf/pull/833.