### PR TITLE
Added option to ignore packages when checking rpmdb changes

### DIFF
--- a/dnf-docker-test/features/steps/rpm_utils.py
+++ b/dnf-docker-test/features/steps/rpm_utils.py
@@ -17,6 +17,7 @@ class State(enum.Enum):
     updated = "updated"
     upgraded = "updated"
     downgraded = "downgraded"
+    ignored = "ignored"
 
 def get_rpmdb():
     """


### PR DESCRIPTION
Adds new state 'ignored' which allows tested to list package
name(s) that should be ignored during the rpmdb changes check.
The package name could contain Unix shell-style wildcard to cover 
multiple packages.