### PR TITLE
support for @backup and @restore scenarios

### DIFF
--- a/dnf-docker-test/features/ssl-1.feature
+++ b/dnf-docker-test/features/ssl-1.feature
@@ -16,6 +16,10 @@ Feature: DNF SSL related features - Package installation
          | State     | Packages |
          | installed | TestA    |
 
+  @backup
+  Scenario: Backup /etc/httpd/conf.d/ssl.conf
+       Given I successfully run "cp -p /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.conf.testbackup"
+
   Scenario: Installing a package from https repository with client verification
        When I successfully run "sed -i 's/.*SSLVerifyClient.*/SSLVerifyClient require/' /etc/httpd/conf.d/ssl.conf"
         And I successfully run "httpd -k restart"
@@ -33,3 +37,8 @@ Feature: DNF SSL related features - Package installation
        When I run "dnf -v -y install TestC"
        Then the command should fail
         And the command stdout should match regexp "Cannot download repomd.xml"
+
+  @restore
+  Scenario: Restore httpd setting
+      Given I successfully run "mv /etc/httpd/conf.d/ssl.conf.testbackup /etc/httpd/conf.d/ssl.conf"
+        And I successfully run "httpd -k restart"

--- a/dnf-docker-test/features/steps/command_steps.py
+++ b/dnf-docker-test/features/steps/command_steps.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from behave import register_type
 from behave import then
-from behave import when
+from behave import step
 import parse
 
 import command_utils
@@ -15,21 +15,21 @@ def parse_stdout_stderr(text):
 
 register_type(stdout_stderr=parse_stdout_stderr)
 
-@when('I run "{command}"')
+@step('I run "{command}"')
 def step_i_run_command(ctx, command):
     """
     Run a ``{command}`` as subprocess, collect its output and returncode.
     """
     ctx.cmd_result = command_utils.run(ctx, command)
 
-@when('I successfully run "{command}" in repository "{repository}"')
+@step('I successfully run "{command}" in repository "{repository}"')
 def step_i_successfully_run_command_in_repository(ctx, command, repository):
     repo = repo_utils.get_repo_dir(repository)
     ctx.assertion.assertIsNotNone(repo, "repository does not exist")
     ctx.cmd_result = command_utils.run(ctx, command, cwd=repo)
     ctx.assertion.assertEqual(ctx.cmd_result.returncode, 0)
 
-@when('I successfully run "{command}"')
+@step('I successfully run "{command}"')
 def step_i_successfully_run_command(ctx, command):
     step_i_run_command(ctx, command)
     step_the_command_should_pass(ctx)

--- a/dnf-docker-test/launch-test
+++ b/dnf-docker-test/launch-test
@@ -20,7 +20,7 @@ if [ "$EXIT_STATUS" = 1 ]; then
 fi
 
 TEST_EXIT=0
-behave-2 -i $new_name -D dnf_cmd=$2 --junit --junit-directory /junit/ /behave/ || TEST_EXIT=$?
+behave-2 --tags ~@backup --tags ~@restore -i $new_name -D dnf_cmd=$2 --junit --junit-directory /junit/ /behave/ || TEST_EXIT=$?
 
 if [ "$RESERVE" == "-r" ] || [ "$RESERVE" == "-R" -a $TEST_EXIT -ne 0 ]; then
     bash || :


### PR DESCRIPTION
Scenarios tagged with @backup and @restore can be used to restore specific changes made by the test to ease the execution of multiple tests outside of the Docker environment. @backup and @restore scenarios won't be executed by default when running in Docker.