### PR TITLE
fix marking of unneeded packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN set -x && \
         # workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1398272
         rpm -q dnf && \
         # some unknown thing
-        dnf -y mark install $(dnf repoquery --unneeded -q); \
+        dnf -q repoquery --unneeded | xargs --no-run-if-empty dnf mark install; \
     else \
         dnf -y install /rpms/*.rpm && \
         dnf -y autoremove; \


### PR DESCRIPTION
Fix marking of unneeded packages in Dockerfile when "dnf repoquery --unneeded" prints empty list.