### PR TITLE
Add @xfail to ssl-2 test

### DIFF
--- a/dnf-docker-test/features/ssl-2.feature
+++ b/dnf-docker-test/features/ssl-2.feature
@@ -1,3 +1,4 @@
+@xfail
 Feature: DNF SSL related features - certificate verification
 
   @setup


### PR DESCRIPTION
The test is broken due to problems with parallel downloads.

Commit in dnf that create the problem: a27e8aaef2cd8cde8e5e29976bbc0cb29be37c12