### PR TITLE
Workaround state when rpmdb timestamp doesn't change during reinstall

### DIFF
--- a/dnf-docker-test/features/repository-packages-remove.feature
+++ b/dnf-docker-test/features/repository-packages-remove.feature
@@ -40,11 +40,10 @@ Feature: DNF/Behave test Repository packages remove
          When I save rpmdb
           And I enable repository "test3"
           And I successfully run "dnf -y repository-packages test remove-or-reinstall"
-# FIXME - rpmdb changes doesn't work properly with reinstall
-#         Then rpmdb changes are
-#           | State       | Packages     |
-#           | removed     | TestA, TestB |
-#           | reinstalled | TestD        |
+         Then rpmdb changes are
+           | State       | Packages     |
+           | removed     | TestA, TestB |
+           | reinstalled | TestD        |
 
     Scenario: Remove or reinstall single package from repository
          When I save rpmdb
@@ -55,10 +54,9 @@ Feature: DNF/Behave test Repository packages remove
          When I save rpmdb
           And I enable repository "test4"
           And I successfully run "dnf -y repository-packages test2 remove-or-reinstall TestC"
-# FIXME - rpmdb changes doesn't work properly with reinstall
-#         Then rpmdb changes are
-#           | State       | Packages |
-#           | reinstalled | TestC    |
+         Then rpmdb changes are
+           | State       | Packages |
+           | reinstalled | TestC    |
          When I save rpmdb
           And I successfully run "dnf -y repository-packages test2 remove-or-reinstall TestB"
          Then rpmdb changes are

--- a/dnf-docker-test/features/steps/rpm_steps.py
+++ b/dnf-docker-test/features/steps/rpm_steps.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from behave import then
 from behave import when
 from behave.model import Table
+from rpm_utils import State
 import six
 from six.moves import zip
 import fnmatch
@@ -114,6 +115,11 @@ def step_rpmdb_changes_are(ctx):
                     rpmdb.remove(pkg_post)
                 state = rpm_utils.analyze_state(pkg_pre, pkg_post)
                 if state != expected_state:
+                    if state == State.unchanged and expected_state == State.reinstalled:
+                        # workaround for unchanged rpmdb timestamp
+                        text = getattr(ctx.cmd_result, 'stdout')
+                        if "Reinstalling     : {}".format(pkg) in text:
+                            continue
                     unexpected_state(pkg, state, expected_state, pkg_pre, pkg_post)
 
     # Now exclude packages matching regexp pattern in the ignore_list

--- a/dnf-docker-test/features/steps/rpm_utils.py
+++ b/dnf-docker-test/features/steps/rpm_utils.py
@@ -110,5 +110,13 @@ def analyze_state(pre, post):
         return State.downgraded
     # In theory, it will never happen as sha1header should be different
     assert ver_cmp == 0
+
+    pre_nevra = hdr2nevra(pre)
+    post_nevra = hdr2nevra(post)
+
+    # probably reinstalled from different repository
+    if pre_nevra == post_nevra:
+        return State.reinstalled
+
     # Most probably we just compare different packages
-    assert False, "{!r} -> {!r}".format(hdr2nevra(pre), hdr2nevra(post))
+    assert False, "{!r} -> {!r}".format(pre_nevra, post_nevra)


### PR DESCRIPTION
Unchanged rpmdb timestamp causes a random behavior in tests which contain `reinstalled` state in expected rpmdb changes.

If a package is tagged as `unchanged` instead of `reinstalled`, then look for `Reinstalled     : pkg` in dnf transaction standard output and possibly consider it `reinstalled`.