### PR TITLE
Added steps to test content of a generic INI file and module config file

### DIFF
--- a/dnf-docker-test/features/steps/file_steps.py
+++ b/dnf-docker-test/features/steps/file_steps.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from behave import given
+from behave import then
 from behave.model import Table
 import six
 from six.moves import configparser
@@ -137,6 +138,45 @@ def step_an_ini_file_filepath_modified_with(ctx, filepath):
                 else:
                     conf.set(section, key, settings[key])
     file_utils.create_file_with_contents(filepath, conf)
+
+
+@then('an INI file "{filepath}" should contain')
+def step_an_ini_file_filepath_should_contain(ctx, filepath):
+    """
+    Tests whether an INI file contain respective Section, Key, Value
+    triples.
+
+    Requires table with following headers:
+
+    ========= ===== =======
+     Section   Key   Value
+    ========= ===== =======
+
+    Examples:
+
+    .. code-block:: gherkin
+
+       Feature: Testing an INI file content
+         Scenario: Check if repozitory Test was enabled
+            Then an INI file "/etc/yum.repos.d/test.repo" should contain
+               | Section | Key        | Value |
+               | Test    | enabled    | True  |
+    """
+    ini_table = table_utils.parse_skv_table(ctx, HEADINGS_INI)
+    sections = ini_table.keys()
+    conf = configparser.ConfigParser()
+    conf.read(filepath)
+    for section in sections:
+        settings = ini_table[section]
+        ctx.assertion.assertTrue(conf.has_section(section), "No such section '%s' in '%s'" % (section, filepath))
+        keys = settings.keys()
+        for key in keys:
+            ctx.assertion.assertTrue(conf.has_option(section, key),
+                                     "No such option '%s' in section '%s' in '%s'" % (key, section, filepath))
+            value = settings[key]
+            ini_value = conf.get(section, key)
+            ctx.assertion.assertEquals(value, ini_value)
+
 
 @given('I run steps from file "{filepath}"')
 def step_i_run_steps_from_file(ctx, filepath):

--- a/dnf-docker-test/features/steps/module_steps.py
+++ b/dnf-docker-test/features/steps/module_steps.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from behave import then
+
+from file_steps import HEADINGS_INI
+from file_steps import step_an_ini_file_filepath_should_contain
+import table_utils
+
+@then('a module "{modulename}" config file should contain')
+def step_a_module_modulename_should_contain(ctx, modulename):
+    """
+    Tests whether a module config file contain respective Key, Value
+    touples.
+
+    ===== =======
+     Key   Value
+    ===== =======
+
+    Examples:
+
+    .. code-block:: gherkin
+
+       Feature: Testing a module config file content
+         Scenario: Check that module ModuleA is locked
+            When I successfully run "dnf module lock ModuleA"
+            Then a module ModuleA config file should contain
+               | Key    | Value |
+               | locked | 1     |
+    """
+    skv_table = table_utils.convert_table_kv_to_skv(ctx.table, HEADINGS_INI, [modulename])
+    ctx.table = skv_table
+    filepath = '/etc/dnf/modules.d/{!s}.module'.format(modulename)
+    step_an_ini_file_filepath_should_contain(ctx, filepath)


### PR DESCRIPTION
Following test file is illustrating the usage
```
Feature: Test

  @setup
  Scenario: Testing repository Setup
      Given I run steps from file "modularity-repo-1.setup"
       When I enable repository "modularityABDE"
        And I successfully run "dnf makecache"
       Then an INI file "/etc/yum.repos.d/modularityABDE.repo" should contain
            | Section        | Key     | Value          |
            | modularityABDE | enabled | True           |
            |                | name    | modularityABDE |

  Scenario: Check that repo modularityABDE is enabled
       When I successfully run "dnf module enable ModuleA:f26"
       Then a module "ModuleA" config file should contain 
            | Key      | Value   |
            | name     | ModuleA |
            | stream   | f26     |
            | enabled  | 1       |
            | version  | -1      |
            | locked   | 0       |
            | profiles |         |
       When I successfully run "dnf module install ModuleA:f26:1/minimal -y"
       Then a module "ModuleA" config file should contain 
            | Key      | Value   |
            | version  | 1       |
            | profiles | minimal |
       When I successfully run "dnf module lock ModuleA"
       Then a module "ModuleA" config file should contain 
            | Key      | Value   |
            | locked   | 1       |
```