### PR TITLE
Temporarily disable all check tests

### DIFF
--- a/dnf-docker-test/features/check-1.feature
+++ b/dnf-docker-test/features/check-1.feature
@@ -1,3 +1,4 @@
+@xfail
 Feature: Test for dnf check --duplicates command
 
   Scenario: Install package in version 1

--- a/dnf-docker-test/features/check-2.feature
+++ b/dnf-docker-test/features/check-2.feature
@@ -1,3 +1,4 @@
+@xfail
 Feature: Test for check --dependencies command
 
   @setup

--- a/dnf-docker-test/features/check-3.feature
+++ b/dnf-docker-test/features/check-3.feature
@@ -1,3 +1,4 @@
+@xfail
 Feature: Test for dnf check --obsoleted command
 
   Scenario: Force install package that obsoletes already installed package


### PR DESCRIPTION
There is problem with rich dependencies in dnf check command,
so this tests now constantly produce confusing errors like:

cmake-rpm-macros-3.10.1-11.fc26.noarch has missing requires of (cmake = 3.10.1-11.fc26 if cmake < 3.10.1-11.fc26)
cmake-rpm-macros-3.10.1-11.fc26.noarch has missing requires of (cmake-data = 3.10.1-11.fc26 if cmake-data < 3.10.1-11.fc26)