### PR TITLE
Not build SQLite DB

### DIFF
--- a/dnf-docker-test/features/steps/repo_steps.py
+++ b/dnf-docker-test/features/steps/repo_steps.py
@@ -691,6 +691,7 @@ def given_package_groups_defined_in_repository(ctx, repository):
 
     createrepo = which("createrepo_c")
     ctx.assertion.assertIsNotNone(createrepo, "createrepo_c is required")
+    createrepo = "{!s} {!s}".format(createrepo, "--no-database")
 
     # prepare the comps.xml
     comps_xml = COMPS_PREFIX


### PR DESCRIPTION
This is a performance improvement. We do not run CI with yum therefore we don't
need this metadata format. The generation of repositories should be now about 5x
faster.