### PR TITLE
Remove migrate plugin from tested set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN set -x && \
         dnf -y install dnf-plugins-core python3-dnf-plugins-core python2-dnf-plugins-core createrepo_c && \
         dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
     fi && \
-    # prevent installation of dnf-plugins-extras (versionlock, local, torproxy)
-    rm -vf /rpms/*dnf-plugin-versionlock*.rpm /rpms/*dnf-plugin-local*.rpm /rpms/*dnf-plugin-torproxy*.rpm && \
+    # prevent installation of dnf-plugins-extras (versionlock, local, torproxy, migrate)
+    rm -vf /rpms/*dnf-plugin-versionlock*.rpm /rpms/*dnf-plugin-local*.rpm /rpms/*dnf-plugin-torproxy*.rpm /rpms/python2-dnf-plugin-migrate*.rpm && \
     # update dnf
     dnf -y --best upgrade dnf && \
     if [ $type = "local" ]; then \


### PR DESCRIPTION
Due to conflict dnf-yum package with yum and requirement of yum by migrate
plugin we cannot have both package in docker image. Therefore removal of migrate
plugin is a logical step.