### PR TITLE
remove python3 incompatible an unnecessary decode() conversions

### DIFF
--- a/dnf-docker-test/features/steps/rpm_utils.py
+++ b/dnf-docker-test/features/steps/rpm_utils.py
@@ -71,13 +71,13 @@ def find_pkg(pkgs, pkg, only_by_name=False):
         name = pkg
 
     for p in pkgs:
-        if p.name != name:
+        if p.name.decode() != name:
             continue
         if only_by_name:
             return p
-        if (epoch is None or p.epoch == epoch) and \
-           (version is None or p.version == version) and \
-           (release is None or p.release == release):
+        if (epoch is None or p.epoch.decode() == epoch) and \
+           (version is None or p.version.decode() == version) and \
+           (release is None or p.release.decode() == release):
             return p
         else:
             logging.warning("Similar package to {!r}: {!r}".format(pkg, hdr2nevra(p)))

--- a/dnf-docker-test/features/steps/test_behave.py
+++ b/dnf-docker-test/features/steps/test_behave.py
@@ -14,7 +14,7 @@ def sack_rpm_comparator():
     """ Gets all installed packages in the system, compare rpm output with DNF sack, and return sack"""
     comparerpmver = shell_call(['rpm', '-qa', '--queryformat',
                                 '%{NAME}-%|epoch?{%{epoch}:}:{0:}|%{VERSION}-%{RELEASE}.%{ARCH}\n'])
-    comparerpmver = [p for p in comparerpmver.splitlines() if not p.decode().startswith('gpg-pubkey')]
+    comparerpmver = [p for p in comparerpmver.splitlines() if not p.startswith('gpg-pubkey')]
     set_comparerpmver = set(comparerpmver)
     assert len(comparerpmver) == len(set_comparerpmver), 'RPM found multiple packages with same nevra'
     sack = dnf.Base().fill_sack(load_available_repos=False)


### PR DESCRIPTION
These changes are necessary to make the test suite work with python3. I have verified that it doesn't cause new test failures when run using python2.