### PR TITLE
added installonly-1 test

### DIFF
--- a/dnf-docker-test/features/installonly-1.feature
+++ b/dnf-docker-test/features/installonly-1.feature
@@ -1,0 +1,99 @@
+Feature: Test for installonly packages upgrade
+# the following provides are supposed to be installonly
+# "kernel", "kernel-PAE", "installonlypkg(kernel)", "installonlypkg(kernel-module)", "installonlypkg(vm)"
+# in this test, only kernel and installonlypkg(vm) are tested
+ repo base: kernel-dummy-5-1
+            kernel-dummy-vm-1-1
+ repo ext1: kernel-dummy-5-2
+            kernel-dummy-vm-1-2
+ repo ext2: kernel-dummy-5-3
+            kernel-dummy-vm-1-3
+ repo ext3: kernel-dummy-5-4
+            kernel-dummy-vm-1-4
+
+  @setup
+  Scenario: Setup (install kernel-dummy-5-1 and kernel-dummy-vm-1-1)
+      Given repository "base" with packages
+         | Package      | Tag      | Value     |
+         | kernel-dummy | Version  | 5         |
+         |              | Release  | 1         |
+	 |              | Provides | kernel = 5-1 |
+         | kernel-dummy-vm | Version  | 1         |
+         |              | Release  | 1         |
+         |              | Provides | installonlypkg(vm) |
+        And repository "ext1" with packages
+         | Package      | Tag      | Value     |
+         | kernel-dummy | Version  | 5         |
+         |              | Release  | 2         |
+         |              | Provides | kernel = 5-2 |
+         | kernel-dummy-vm | Version  | 1         |
+         |              | Release  | 2         |
+         |              | Provides | installonlypkg(vm) |
+        And repository "ext2" with packages
+         | Package      | Tag      | Value     |
+         | kernel-dummy | Version  | 5         |
+         |              | Release  | 3         |
+	 |              | Provides | kernel = 5-3 |
+         | kernel-dummy-vm | Version  | 1         |
+         |              | Release  | 3         |
+         |              | Provides | installonlypkg(vm) |
+        And repository "ext3" with packages
+         | Package      | Tag      | Value     |
+         | kernel-dummy | Version  | 5         |
+         |              | Release  | 4         |
+	 |              | Provides | kernel = 5-4 |
+         | kernel-dummy-vm | Version  | 1         |
+         |              | Release  | 4         |
+         |              | Provides | installonlypkg(vm) |
+
+       When I save rpmdb
+        And I enable repository "base"
+        And I successfully run "dnf -y install kernel-dummy"
+        And I successfully run "dnf -y install kernel-dummy-vm"
+       Then rpmdb changes are
+         | State     | Packages         |
+	 | installed | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
+
+  Scenario: run 'dnf upgrade' when there are no installonly upgrades available (installonly_limit not reached)
+       When I save rpmdb
+        And I successfully run "dnf -y upgrade"
+       Then the command stderr should not match regexp "cannot install both kernel-dummy"
+        And rpmdb does not change
+
+  Scenario: run 'dnf upgrade' when there are 1st installonly upgrades available
+       When I save rpmdb
+        And I enable repository "ext1"
+        And I successfully run "dnf -y upgrade"
+       Then the command stderr should not match regexp "cannot install both kernel-dummy"
+        And rpmdb changes are
+         | State     | Packages         |
+	 | unchanged | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
+	 | installed | kernel-dummy/5-2,kernel-dummy-vm/1-2 |
+
+  Scenario: run 'dnf upgrade' when there are 2nd installonly upgrades available
+       When I save rpmdb
+        And I enable repository "ext2"
+        And I successfully run "dnf -y upgrade"
+       Then the command stderr should not match regexp "cannot install both kernel-dummy"
+        And rpmdb changes are
+         | State     | Packages         |
+	 | unchanged | kernel-dummy/5-1,kernel-dummy/5-2,kernel-dummy-vm/1-1,kernel-dummy-vm/1-2 |
+	 | installed | kernel-dummy/5-3,kernel-dummy-vm/1-3 |
+
+  @xfail
+  Scenario: run 'dnf upgrade' when there is 3rd kernel-dummy upgrade available (installonly_limit exceeded)
+       When I save rpmdb
+        And I enable repository "ext3"
+        And I successfully run "dnf -y upgrade"
+       Then the command stderr should not match regexp "cannot install both kernel-dummy"
+        And rpmdb changes are
+         | State     | Packages         |
+	 | removed   | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
+	 | unchanged | kernel-dummy/5-2,kernel-dummy/5-3,kernel-dummy-vm/1-2,kernel-dummy-vm/1-3 |
+	 | installed | kernel-dummy/5-4,kernel-dummy-vm/1-4 |
+
+  Scenario: run 'dnf upgrade' when there are no installonly upgrades available (installonly_limit reached)
+       When I save rpmdb
+        And I successfully run "dnf -y upgrade"
+       Then the command stderr should not match regexp "cannot install both kernel-dummy"
+        And rpmdb does not change

--- a/dnf-docker-test/features/installonly-1.feature
+++ b/dnf-docker-test/features/installonly-1.feature
@@ -17,7 +17,7 @@ Feature: Test for installonly packages upgrade
          | Package      | Tag      | Value     |
          | kernel-dummy | Version  | 5         |
          |              | Release  | 1         |
-	 |              | Provides | kernel = 5-1 |
+	     |              | Provides | kernel = 5-1 |
          | kernel-dummy-vm | Version  | 1         |
          |              | Release  | 1         |
          |              | Provides | installonlypkg(vm) |
@@ -33,7 +33,7 @@ Feature: Test for installonly packages upgrade
          | Package      | Tag      | Value     |
          | kernel-dummy | Version  | 5         |
          |              | Release  | 3         |
-	 |              | Provides | kernel = 5-3 |
+	     |              | Provides | kernel = 5-3 |
          | kernel-dummy-vm | Version  | 1         |
          |              | Release  | 3         |
          |              | Provides | installonlypkg(vm) |
@@ -41,7 +41,7 @@ Feature: Test for installonly packages upgrade
          | Package      | Tag      | Value     |
          | kernel-dummy | Version  | 5         |
          |              | Release  | 4         |
-	 |              | Provides | kernel = 5-4 |
+	     |              | Provides | kernel = 5-4 |
          | kernel-dummy-vm | Version  | 1         |
          |              | Release  | 4         |
          |              | Provides | installonlypkg(vm) |
@@ -52,7 +52,7 @@ Feature: Test for installonly packages upgrade
         And I successfully run "dnf -y install kernel-dummy-vm"
        Then rpmdb changes are
          | State     | Packages         |
-	 | installed | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
+	     | installed | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
 
   Scenario: run 'dnf upgrade' when there are no installonly upgrades available (installonly_limit not reached)
        When I save rpmdb
@@ -67,8 +67,8 @@ Feature: Test for installonly packages upgrade
        Then the command stderr should not match regexp "cannot install both kernel-dummy"
         And rpmdb changes are
          | State     | Packages         |
-	 | unchanged | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
-	 | installed | kernel-dummy/5-2,kernel-dummy-vm/1-2 |
+	     | unchanged | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
+	     | installed | kernel-dummy/5-2,kernel-dummy-vm/1-2 |
 
   Scenario: run 'dnf upgrade' when there are 2nd installonly upgrades available
        When I save rpmdb
@@ -77,10 +77,9 @@ Feature: Test for installonly packages upgrade
        Then the command stderr should not match regexp "cannot install both kernel-dummy"
         And rpmdb changes are
          | State     | Packages         |
-	 | unchanged | kernel-dummy/5-1,kernel-dummy/5-2,kernel-dummy-vm/1-1,kernel-dummy-vm/1-2 |
-	 | installed | kernel-dummy/5-3,kernel-dummy-vm/1-3 |
+	     | unchanged | kernel-dummy/5-1,kernel-dummy/5-2,kernel-dummy-vm/1-1,kernel-dummy-vm/1-2 |
+	     | installed | kernel-dummy/5-3,kernel-dummy-vm/1-3 |
 
-  @xfail
   Scenario: run 'dnf upgrade' when there is 3rd kernel-dummy upgrade available (installonly_limit exceeded)
        When I save rpmdb
         And I enable repository "ext3"
@@ -88,9 +87,9 @@ Feature: Test for installonly packages upgrade
        Then the command stderr should not match regexp "cannot install both kernel-dummy"
         And rpmdb changes are
          | State     | Packages         |
-	 | removed   | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
-	 | unchanged | kernel-dummy/5-2,kernel-dummy/5-3,kernel-dummy-vm/1-2,kernel-dummy-vm/1-3 |
-	 | installed | kernel-dummy/5-4,kernel-dummy-vm/1-4 |
+    	 | removed   | kernel-dummy/5-1,kernel-dummy-vm/1-1 |
+    	 | unchanged | kernel-dummy/5-2,kernel-dummy/5-3,kernel-dummy-vm/1-2,kernel-dummy-vm/1-3 |
+    	 | installed | kernel-dummy/5-4,kernel-dummy-vm/1-4 |
 
   Scenario: run 'dnf upgrade' when there are no installonly upgrades available (installonly_limit reached)
        When I save rpmdb


### PR DESCRIPTION
* added test for installonly packages
* run on f28, dnf-3.0.1-1.fc28.noarch, currently one phase fails, it's marked as @xfail:
when installonly_limit is exceeded, the oldest version is removed and the newest installed, the "middle" versions are supposed to be "unchanged" in the scenario but in fact they are "updated", which is strange
* please provide info whether the scenario should be updated so that it doesn't fail

behave log:
```
  @xfail
  Scenario: run 'dnf upgrade' when there is 3rd kernel-dummy upgrade available (installonly_limit exceeded)  # behave/installonly-1-dnf-3.feature:84
    When I save rpmdb                                                                                        # behave/steps/rpm_steps.py:17 0.140s
    And I enable repository "ext3"                                                                           # behave/steps/repo_steps.py:525 0.001s
    And I successfully run "dnf -y upgrade"                                                                  # behave/steps/command_steps.py:34 0.467s
    Then the command stderr should not match regexp "cannot install both kernel-dummy"                       # behave/steps/command_steps.py:162 0.000s
    And rpmdb changes are                                                                                    # behave/steps/rpm_steps.py:25 0.168s
      | State     | Packages                                                                  |
      | removed   | kernel-dummy/5-1,kernel-dummy-vm/1-1                                      |
      | unchanged | kernel-dummy/5-2,kernel-dummy/5-3,kernel-dummy-vm/1-2,kernel-dummy-vm/1-3 |
      | installed | kernel-dummy/5-4,kernel-dummy-vm/1-4                                      |
      Assertion Failed: 
      Package u'kernel-dummy/5-2' was supposed to be u'unchanged', but has been u'updated' (u'kernel-dummy-5-1.noarch' -> u'kernel-dummy-5-2.noarch')
      Package u'kernel-dummy/5-3' was supposed to be u'unchanged', but has been u'updated' (u'kernel-dummy-5-2.noarch' -> u'kernel-dummy-5-3.noarch')
      Package u'kernel-dummy-vm/1-2' was supposed to be u'unchanged', but has been u'updated' (u'kernel-dummy-vm-1-1.noarch' -> u'kernel-dummy-vm-1-2.noarch')
      Package u'kernel-dummy-vm/1-3' was supposed to be u'unchanged', but has been u'updated' (u'kernel-dummy-vm-1-2.noarch' -> u'kernel-dummy-vm-1-3.noarch')
      Captured stdout:
      shell.command: ['dnf-3', '-y', 'upgrade']
      shell.command.stdout:
      ext3                                            954 kB/s | 1.0 kB     00:00    
      Last metadata expiration check: 0:00:00 ago on Wed Jun 27 11:52:07 2018.
      Dependencies resolved.
      ================================================================================
       Package                   Arch             Version       Repository       Size
      ================================================================================
      Installing:
       kernel-dummy              noarch           5-4           ext3            6.5 k
       kernel-dummy-vm           noarch           1-4           ext3            6.5 k
      Removing:
       kernel-dummy              noarch           5-1           @base             0  
       kernel-dummy-vm           noarch           1-1           @base             0  
      
      Transaction Summary
      ================================================================================
      Install  2 Packages
      Remove   2 Packages
      
      Total size: 13 k
      Downloading Packages:
      Running transaction check
      Transaction check succeeded.
      Running transaction test
      Transaction test succeeded.
      Running transaction
        Preparing        :                                                        1/1 
        Installing       : kernel-dummy-vm-1-4.noarch                             1/4 
        Installing       : kernel-dummy-5-4.noarch                                2/4 
        Erasing          : kernel-dummy-vm-1-1.noarch                             3/4 
        Erasing          : kernel-dummy-5-1.noarch                                4/4 
        Verifying        : kernel-dummy-5-4.noarch                                1/4 
        Verifying        : kernel-dummy-vm-1-4.noarch                             2/4 
        Verifying        : kernel-dummy-5-1.noarch                                3/4 
        Verifying        : kernel-dummy-vm-1-1.noarch                             4/4 
      
      Installed:
        kernel-dummy-5-4.noarch               kernel-dummy-vm-1-4.noarch              
      
      Removed:
        kernel-dummy-5-1.noarch               kernel-dummy-vm-1-1.noarch              
      
      Complete!
      
      shell.command.stderr:
      
      Captured logging:
      WARNING:root:Similar package to u'kernel-dummy/5-1': u'kernel-dummy-5-4.noarch'
      WARNING:root:Similar package to u'kernel-dummy-vm/1-1': u'kernel-dummy-vm-1-4.noarch'


```