### PR TITLE
make releasever parsing RHEL compatible

### DIFF
--- a/dnf-docker-test/features/vars-releasever.feature
+++ b/dnf-docker-test/features/vars-releasever.feature
@@ -28,7 +28,7 @@ Scenario: Test vars taken from installroot
  Scenario: Test host releasever
   When _deprecated I create a file "/etc/yum.repos.d/var.repo" with content: "[var]\nname=var\nbaseurl=http://127.0.0.1/repo/$releasever\nenabled=1\ngpgcheck=0"
   Then _deprecated the path "/etc/yum.repos.d/var.repo" should be "present"
-  When _deprecated I execute "bash" command "mv /var/www/html/repo/test-1 /var/www/html/repo/$(rpm -q --provides $(rpm -q --whatprovides system-release) | grep -Po '(?<=system-release\()\d+(?=\))')" with "success"
+  When _deprecated I execute "bash" command "mv /var/www/html/repo/test-1 /var/www/html/repo/$(rpm -q --provides $(rpm -q --whatprovides system-release) | grep 'system-release(' | egrep -o '[0-9]\w*')" with "success"
   When _deprecated I execute "bash" command "mv /var/www/html/repo/upgrade_1 /var/www/html/repo/22" with "success"
   When _deprecated I execute "dnf" command "install -y TestE" with "success"
   Then _deprecated transaction changes are as follows
@@ -42,6 +42,6 @@ Scenario: Test vars taken from installroot
 Scenario: Test vars taken from installroot
   When _deprecated I create a file "/dockertesting/etc/yum.repos.d/var.repo" with content: "[var]\nname=var\nbaseurl=http://127.0.0.1/repo/$releasever\nenabled=1\ngpgcheck=0"
   Then _deprecated the path "/dockertesting/etc/yum.repos.d/var.repo" should be "present"
-  When _deprecated I execute "dnf" command "--installroot=/dockertesting -y --releasever=$(rpm -q --provides $(rpm -q --whatprovides system-release) | grep -Po '(?<=system-release\()\d+(?=\))') install TestE" with "success"
+  When _deprecated I execute "dnf" command "--installroot=/dockertesting -y --releasever=$(rpm -q --provides $(rpm -q --whatprovides system-release) | grep 'system-release(' | egrep -o '[0-9]\w*') install TestE" with "success"
   When _deprecated I execute "bash" command "rpm -q --root=/dockertesting TestE" with "success"
   Then _deprecated line from "stdout" should "start" with "TestE-1.0.0-1."


### PR DESCRIPTION
RHEL differs in respective RPM provides from Fedora. The proposed change should work for both.