### PR TITLE
updated module-install-pkg-3

### DIFF
--- a/dnf-docker-test/features/module-install-pkg-3.feature
+++ b/dnf-docker-test/features/module-install-pkg-3.feature
@@ -27,6 +27,9 @@ Feature: Installing package when default stream is defined
           | Key     | Value  |
           | state   |enabled |
           | stream  | f26    |
+       When I run "dnf module list --installed ModuleY"
+       Then the command should fail
+        And the command stderr should match regexp "No matching Modules to list"
 
   @setup
   Scenario: cleanup from previous scenario


### PR DESCRIPTION
updated module-install-pkg-3 due to module defaults ACs
tested both on f29 and rhel8, works as expected