### PR TITLE
updated module-enable-5 tests to match currently preferred behaviour

### DIFF
--- a/dnf-docker-test/features/module-enable-5.feature
+++ b/dnf-docker-test/features/module-enable-5.feature
@@ -22,44 +22,51 @@ Feature: Enable module stream with modular dependencies
         And the command stdout should match regexp "ModuleM +f27"
         And the command stdout should match regexp "ModuleMY +f27"
       
-  @xfail @bz1647804
-  Scenario: When a module stream is disabled, module streams dependent on it are automatically disabled
-       When I successfully run "dnf -y module disable ModuleMY:f27"
-       Then the command stdout should match regexp "Disabling module streams:"
-        And the command stdout should match regexp "ModuleMY +f27"
-        And the command stdout should match regexp "ModuleM +f27"
+#  @xfail @bz1647804
+#  Scenario: When a module stream is disabled, module streams dependent on it are automatically disabled
+#       When I successfully run "dnf -y module disable ModuleMY:f27"
+#       Then the command stdout should match regexp "Disabling module streams:"
+#        And the command stdout should match regexp "ModuleMY +f27"
+#        And the command stdout should match regexp "ModuleM +f27"
+# following scenario is the opposite of the above, matching current bahavior
+  Scenario: Module cannot be disabled if there are other enabled streams requiring it
+       When I run "dnf -y module disable ModuleMY:f27"
+       Then the command should fail
+        And the command stderr should match regexp "Error: Problems in request:"
+        And the command stderr should match regexp "Modular dependency problems:"
+        And the command stderr should match regexp "Problem: module ModuleM:f27:1:-0.noarch requires module\(ModuleMY:f27\)"
+        And a module ModuleMY config file should contain
+           | Key    | Value   |
+           | state  | enabled |
+           | stream | f27     |
 
   Scenario: When a default module stream is enabled, its modular dependencies are automatically enabled
        # reset: just ensure that ModuleM:f27, ModuleMY:f27 are not enabled
-       When I successfully run "dnf -y module reset ModuleM:f27"
+      Given I successfully run "dnf -y module reset ModuleM:f27"
         And I successfully run "dnf -y module reset ModuleMY:f27"
-        And I successfully run "dnf -y module enable ModuleM"
+       When I successfully run "dnf -y module enable ModuleM"
        Then the command stdout should match regexp "Enabling module streams:"
         And the command stdout should match regexp "ModuleM +f26"
         And the command stdout should match regexp "ModuleMX +f26"
 
-  @xfail @bz1648839
-  Scenario: Enablement of a different stream of enabled module switches to the new stream and switches all its dependencies
-       When I successfully run "dnf -y module reset ModuleM:f26"
-        And I successfully run "dnf -y module reset ModuleMX:f26"
-        And I successfully run "dnf -y module enable ModuleMZ:f27"
-       Then the command stdout should match regexp "Enabling module streams:"
-        And the command stdout should match regexp "ModuleMZ +f27"
-        And the command stdout should match regexp "ModuleM +f27"
-        And the command stdout should match regexp "ModuleMY +f27"
-       When I successfully run "dnf -y module enable ModuleMZ:f26"
-       Then the command stdout should match regexp "Switching module streams:"
-        And the command stdout should match regexp "ModuleMZ +f27 -> f26"
-        And the command stdout should match regexp "ModuleM +f27 -> f26"
-        And the command stdout should match regexp "Enabling module streams:"
-        And the command stdout should match regexp "ModuleMX +f26"
-
-  @xfail @bz1648882
-  Scenario: When a disabled module stream is enabled, its modular dependencies are automatically enabled
-       When I successfully run "dnf -y module disable ModuleMZ:f26"
-        And I successfully run "dnf -y module disable ModuleM:f26"
-        And I successfully run "dnf -y module enable ModuleMZ:f26"
-       Then the command stdout should match regexp "Enabling module streams:"
-        And the command stdout should match regexp "ModuleM +f26"
-        And the command stdout should match regexp "ModuleMX +f26"
-        And the command stdout should match regexp "ModuleMZ +f26"
+#  @xfail @bz1648882
+#  Scenario: When a disabled module stream is enabled, its modular dependencies are automatically enabled
+#       When I successfully run "dnf -y module disable ModuleMZ:f26"
+#        And I successfully run "dnf -y module disable ModuleM:f26"
+#        And I successfully run "dnf -y module enable ModuleMZ:f26"
+#       Then the command stdout should match regexp "Enabling module streams:"
+#        And the command stdout should match regexp "ModuleM +f26"
+#        And the command stdout should match regexp "ModuleMX +f26"
+#        And the command stdout should match regexp "ModuleMZ +f26"
+# Following scenario, the opposite of the above, is testing the current and probably desired behavior
+Scenario: Cannot enable a stream depending on a disabled module
+       Given I successfully run "dnf -y module disable ModuleMZ:f26"
+         And I successfully run "dnf -y module disable ModuleM:f26"
+        When I run "dnf -y module enable ModuleMZ:f26"
+        Then the command should fail
+        And the command stderr should match regexp "Error: Problems in request:"
+        And the command stderr should match regexp "Modular dependency problems:"
+        And the command stderr should match regexp "module ModuleM:f26:1:-0.noarch is disabled"
+        And a module ModuleMZ config file should contain
+           | Key    | Value    |
+           | state  | disabled |

--- a/dnf-docker-test/features/module-enable-modular-deps-1.feature
+++ b/dnf-docker-test/features/module-enable-modular-deps-1.feature
@@ -134,6 +134,7 @@ Feature: Default non-enabled streams can be overridden by dependency requests
           | state   | enabled |
           | stream  | stream1 |
 
+  @bz1648839
   Scenario: Enabling a default stream depending on a non-default stream
       Given I successfully run "dnf -y module reset ModuleA ModuleR"
         And a file "/etc/dnf/modules.defaults.d/ModuleA.yaml" with


### PR DESCRIPTION
I have updated test scenarios to match the currently preferred behaviour and commented out the former test cases, along with the removal of the obsoleted test scenario.
Passing on latest F29 and RHEL-8.