### PR TITLE
Best

### DIFF
--- a/dnf-docker-test/features/config-best.feature
+++ b/dnf-docker-test/features/config-best.feature
@@ -1,0 +1,63 @@
+Feature: Test for config option best and commandline options --best and --nobest
+
+  @setup
+  Scenario: Feature Setup
+      Given repository "test" with packages
+         | Package     | Tag      | Value            |
+         | TestA       | Version  | 1                |
+         |             | Requires | TestA-libs = 1-1 |
+         | TestA-libs  | Version  | 1                |
+         | TestB       | Version  | 1                |
+         |             | Requires | TestB-libs = 1-1 |
+         | TestB-libs  | Version  | 1                |
+        And repository "updates" with packages
+         | Package     | Tag      | Value            |
+         | TestA       | Version  | 2                |
+         |             | Requires | TestA-libs = 2-1 |
+         | TestB       | Version  | 2                |
+         |             | Requires | TestB-libs = 2-1 |
+       When I enable repository "test"
+        And I enable repository "updates"
+
+  @bz1670776 @bz1671683
+  Scenario: When installing with best=1 (default), fail on broken packages, and advise to use --nobest
+       When I run "dnf -y install TestA"
+       Then the command should fail
+        And the command stdout should match regexp "try to add .*'--nobest' to use not only best candidate packages"
+
+  @bz1670776 @bz1671683
+  Scenario: When installing with option --best, fail on broken packages, and don't advise to use --nobest
+       When I run "dnf -y install TestA --best"
+       Then the command should fail
+        And the command stdout should not match regexp "--nobest"
+
+  Scenario: When installing with best=0, install a package of lower version
+       When I save rpmdb
+        And I successfully run "dnf -y install TestA --setopt=best=0"
+       Then rpmdb changes are
+           | State       | Packages              |
+           | installed   | TestA/1, TestA-libs/1 |
+
+  @bz1670776 @bz1671683
+  Scenario: When installing with option --nobest, install a package of lower version
+       When I save rpmdb
+        And I successfully run "dnf -y install TestB --nobest"
+       Then rpmdb changes are
+           | State       | Packages              |
+           | installed   | TestB/1, TestB-libs/1 |
+
+  @bz1670776 @bz1671683
+  Scenario: When upgrading with best=1 (default), fail on broken packages
+        And I run "dnf -y upgrade TestA"
+       Then the command should fail
+
+  Scenario: When upgrading with best=0, only report broken packages
+       When I save rpmdb
+        And I successfully run "dnf -y upgrade TestA --setopt=best=0"
+       Then rpmdb does not change
+
+  @bz1670776 @bz1671683
+  Scenario: When upgrading with option --nobest, only report broken packages
+       When I save rpmdb
+        And I successfully run "dnf -y upgrade TestA --nobest"
+       Then rpmdb does not change

--- a/dnf-docker-test/features/install-2.feature
+++ b/dnf-docker-test/features/install-2.feature
@@ -8,8 +8,10 @@ Feature: Install installed pkg with just name or NEVR
          | State        | Packages      |
          | installed    | TestB-1.0.0-1, TestC-1.0.0-2, TestE-1.0.0-1   |
 
+  @bz1670776 @bz1671683
   Scenario: Install of installed package by name (upgrade available)
-      When _deprecated I execute "dnf" command "-y install TestB" with "success"
+      When _deprecated I execute "dnf" command "-y install TestB" with "fail"
+      When _deprecated I execute "dnf" command "-y install TestB --nobest" with "success"
       Then _deprecated transaction changes are as follows
         | State        | Packages              |
         | present      | TestB-1.0.0-1         |

--- a/dnf-docker-test/features/obsoletes-keep-reason.feature
+++ b/dnf-docker-test/features/obsoletes-keep-reason.feature
@@ -15,6 +15,7 @@ Feature: DNF/Behave test Obsolete keep reason
            | State     | Packages |
            | installed | TestB    |
 
+    @xfail @bz1672618
     Scenario: Keep reason of obsolete package
          When I successfully run "dnf mark remove TestB"
          Then history userinstalled should

--- a/dnf-docker-test/features/upgrade-1.feature
+++ b/dnf-docker-test/features/upgrade-1.feature
@@ -16,6 +16,7 @@ Scenario: Upgrade package TestA from repository "upgrade_1"
    | upgraded     | TestA      |
    | present      | TestB      |
 
+@bz1670776 @bz1671683
 Scenario: Upgrade two packages from repository "upgrade_1"
  Given _deprecated I use the repository "upgrade_1"
  When _deprecated I execute "dnf" command "-y upgrade TestD TestF" with "success"
@@ -24,7 +25,8 @@ Scenario: Upgrade two packages from repository "upgrade_1"
    | upgraded     | TestD, TestE, TestF, TestG  |
    | present      | TestH                       |
 
- When _deprecated I execute "dnf" command "-y install TestI TestK" with "success"
+ When _deprecated I execute "dnf" command "-y install TestI TestK" with "fail"
+ When _deprecated I execute "dnf" command "-y install TestI TestK --nobest" with "success"
  Then _deprecated transaction changes are as follows
    | State        | Packages                    |
    | installed    | TestI, TestJ, TestK, TestM  |

--- a/dnf-docker-test/features/upgrade-2.feature
+++ b/dnf-docker-test/features/upgrade-2.feature
@@ -9,9 +9,11 @@ Scenario: Install packages from repository "test-1"
    | absent       | TestC                                                          |
 
 
+@bz1670776 @bz1671683
 Scenario: Upgrade ALL from repository "upgrade_1"
  Given _deprecated I use the repository "upgrade_1"
- When _deprecated I execute "dnf" command "-y upgrade" with "success"
+ When _deprecated I execute "dnf" command "-y upgrade" with "fail"
+ When _deprecated I execute "dnf" command "-y upgrade --nobest" with "success"
  Then _deprecated transaction changes are as follows
    | State        | Packages                                                |
    | upgraded     | TestA, TestB, TestD, TestE, TestF, TestG, TestH, TestM  |

--- a/dnf-docker-test/features/upgrade-3.feature
+++ b/dnf-docker-test/features/upgrade-3.feature
@@ -9,9 +9,11 @@ Scenario: Preparation - Install packages from repository "test-1"
    | absent       | TestC                                                          |
 
 
+@bz1670776 @bz1671683
 Scenario: Upgrade ALL using '*' from repository "upgrade_1"
  Given _deprecated I use the repository "upgrade_1"
- When _deprecated I execute "dnf" command "upgrade -y '*'" with "success"
+ When _deprecated I execute "dnf" command "upgrade -y '*'" with "fail"
+ When _deprecated I execute "dnf" command "upgrade -y '*' --nobest" with "success"
  Then _deprecated transaction changes are as follows
    | State        | Packages                                                |
    | upgraded     | TestA, TestB, TestD, TestE, TestF, TestG, TestH, TestM  |


### PR DESCRIPTION
Hello, I made some tests for the new behavior with the "best" option, as requested by these bugs:
https://bugzilla.redhat.com/show_bug.cgi?id=1670776
https://bugzilla.redhat.com/show_bug.cgi?id=1671683
The tests fail without the following PRs:
https://github.com/rpm-software-management/dnf/pull/1311
https://github.com/rpm-software-management/libdnf/pull/678
I also needed to change few of the current tests to reflect the change.

I am not sure about the tags, though. I referenced both bugs in all the scenarios that require the changed behavior, but if I should do this differently just let me know.

In addition, the test in obsoletes-keep-reason.feature now found following bug: https://bugzilla.redhat.com/show_bug.cgi?id=1672618
