### PR TITLE
Add test for downloading package from multiple repositories, bz1612874

### DIFF
--- a/dnf-docker-test/features/download-2.feature
+++ b/dnf-docker-test/features/download-2.feature
@@ -1,0 +1,35 @@
+Feature: Test for download when there are multiple packages of the same NEVRA
+
+  @setup
+  Scenario: Feature Setup
+      Given http repository "base" with packages
+         | Package  | Tag       | Value  |
+         | TestA    |           |        |
+         | TestB    |           |        |
+         | TestC    |           |        |
+         | TestD    |           |        |
+        And http repository "ext" with packages
+         | Package  | Tag       | Value  |
+         | TestA    |           |        |
+         | TestB    |           |        |
+         | TestC    |           |        |
+         | TestD    |           |        |
+
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1612874
+  @bz1612874
+  Scenario: dnf download when there are multiple packages of the same NEVRA
+       When I enable repository "base"
+        And I enable repository "ext"
+       When I successfully run "dnf download --destdir /tmp/testrpms TestA TestB TestC"
+       Then the command stdout should match regexp "TestA-1.*rpm"
+        And the command stdout should match regexp "TestB-1.*rpm"
+        And the command stdout should match regexp "TestC-1.*rpm"
+        # check that each file was being downloaded only once
+        And the command stdout should not match regexp "TestA.*TestA"
+        And the command stdout should not match regexp "TestB.*TestB"
+        And the command stdout should not match regexp "TestC.*TestC"
+        # check that the files have been downloaded into working directory
+        And I successfully run "stat /tmp/testrpms/TestA-1-1.noarch.rpm"
+        And I successfully run "stat /tmp/testrpms/TestB-1-1.noarch.rpm"
+        And I successfully run "stat /tmp/testrpms/TestC-1-1.noarch.rpm"
+        And I successfully run "bash -c 'rm -rf /tmp/testrpms'"


### PR DESCRIPTION
The test passes with the current version of ``dnf-plugins-core``, and fails with ``dnf-plugins-core-3.0.1-2.fc29.noarch`` . However, it is not 100 % reliable. Since the bug depends on the order of downloads, there might be a run when the test passes even though it shouldn't.

Interestingly, it sometimes fails with "Status code: 416" (just like in the original bug) and sometimes with "checksum doesn't match".
