### PR TITLE
Ignore executable name in several tests as it changes in the outputs.

### DIFF
--- a/dnf-docker-test/features/help-1.feature
+++ b/dnf-docker-test/features/help-1.feature
@@ -19,4 +19,4 @@ Scenario: Command help
   When _deprecated I execute "dnf" command "install --help" with "success"
   Then _deprecated line from "stdout" should "start" with "install a package or packages on your system"
   When _deprecated I execute "dnf" command "update --unknown-opt" with "fail"
-  Then _deprecated line from "stderr" should "start" with "dnf upgrade: error: unrecognized arguments: --unknown-opt"
+  Then _deprecated line from "stderr" should "contain" with "upgrade: error: unrecognized arguments: --unknown-opt"

--- a/dnf-docker-test/features/module-help-1.feature
+++ b/dnf-docker-test/features/module-help-1.feature
@@ -2,8 +2,8 @@ Feature: Module usage help
 
   Scenario: I can print help using dnf module --help
        When I successfully run "dnf module --help"
-       Then the command stdout should match regexp "usage: dnf module \[-c \[config file\]\]"
+       Then the command stdout should match regexp "usage: .+ module \[-c \[config file\]\]"
 
   Scenario: I can print help using dnf module -h
        When I successfully run "dnf module -h"
-       Then the command stdout should match regexp "usage: dnf module \[-c \[config file\]\]"
+       Then the command stdout should match regexp "usage: .+ module \[-c \[config file\]\]"

--- a/dnf-docker-test/features/shell-6.feature
+++ b/dnf-docker-test/features/shell-6.feature
@@ -52,7 +52,7 @@ Feature: Testing specific dnf shell text output
   Scenario: Listing available commands when help command is issued
       Given I have dnf shell session opened with parameters "-y"
        When I run dnf shell command "help"
-       Then the command stdout should match regexp "usage: dnf \[options\] COMMAND"
+       Then the command stdout should match regexp "usage: .+ \[options\] COMMAND"
         And the command stdout should match regexp "List of Main Commands:"
         And the command stdout should match regexp "List of Plugin Commands:"
         And the command stdout should match regexp "Optional arguments:"

--- a/dnf-docker-test/features/steps/test_behave.py
+++ b/dnf-docker-test/features/steps/test_behave.py
@@ -196,6 +196,7 @@ def then_package_state(context, exit_code):
 @then('_deprecated line from "{std_message}" should "{state}" with "{line_start}"')
 def then_package_state(context, std_message, state, line_start):
     counter = 0
+    contains = 0
     if std_message == 'stdout':
         message = context.cmd_output.split('\n')
     elif std_message == 'stderr':
@@ -206,10 +207,18 @@ def then_package_state(context, std_message, state, line_start):
     for line in message:
         if line.startswith(line_start):
             counter += 1
+            contains += 1
+        elif line_start in line:
+            contains += 1
+
     if state == 'start':
         assert counter > 0, 'The line starting with {!r} was not found in {!r}'.format(line_start, std_message)
     elif state == 'not start':
         assert counter == 0, 'The line starting with {!r} was found in {!r}, but should be absent'.format(line_start, std_message)
+    elif state == 'contain':
+        # line from "stderr" should "contain" with "foo" sounds terrible,
+        # but it was a minimal change without duplicating code
+        assert contains > 0, "Line containing '{!r}' wasn't found in {!r}".format(line_start, std_message)
     else:
         raise AssertionError('The state {!r} is not allowed option for Then statement (allowed start, not start)'
                              .format(state))


### PR DESCRIPTION
Related: https://github.com/rpm-software-management/dnf/pull/1288