### PR TITLE
Add tests for download --source (RhBug:1649627)

### DIFF
--- a/dnf-behave-tests/features/plugins-core/download-source.feature
+++ b/dnf-behave-tests/features/plugins-core/download-source.feature
@@ -73,4 +73,27 @@ Examples:
   | wget-1.19.5-5.fc29.x86_64   | wget-1.19.5-5.fc29.src.rpm     |
 
 
+@xfail
+Scenario Outline: Download a source RPM when there are more epochs available
+  Given I use the http repository based on "dnf-ci-fedora-updates-testing"
+   When I execute dnf with args "download --destdir={context.dnf.tempdir} --source <pkgspec>"
+   Then the exit code is 0
+    And stdout contains "<srpm>"
+    And file sha256 checksums are following
+        | Path                          | sha256                                                    |
+        | {context.dnf.tempdir}/<srpm>  | file://{context.dnf.fixturesdir}/repos/<repo>/src/<srpm>  |
+
+Examples:
+  | pkgspec                     | repo                           | srpm                           |
+  | wget-0:1.19.5-5.fc29        | dnf-ci-fedora                  | wget-1.19.5-5.fc29.src.rpm     |
+  | wget-1:1.19.4-1.fc29        | dnf-ci-fedora-updates-testing  | wget-1.19.4-1.fc29.src.rpm     |
+  | wget-1:1.19.5-5.fc29        | dnf-ci-fedora-updates-testing  | wget-1.19.5-5.fc29.src.rpm     |
+  | wget-0:1.19.5-5.fc29.src    | dnf-ci-fedora                  | wget-1.19.5-5.fc29.src.rpm     |
+  | wget-1:1.19.4-1.fc29.src    | dnf-ci-fedora-updates-testing  | wget-1.19.4-1.fc29.src.rpm     |
+  | wget-1:1.19.5-5.fc29.src    | dnf-ci-fedora-updates-testing  | wget-1.19.5-5.fc29.src.rpm     |
+  | wget-0:1.19.5-5.fc29.x86_64 | dnf-ci-fedora                  | wget-1.19.5-5.fc29.src.rpm     |
+  | wget-1:1.19.4-1.fc29.x86_64 | dnf-ci-fedora-updates-testing  | wget-1.19.4-1.fc29.src.rpm     |
+  | wget-1:1.19.5-5.fc29.x86_64 | dnf-ci-fedora-updates-testing  | wget-1.19.5-5.fc29.src.rpm     |
+
+
 # TODO: --source --resolve doesn't work correctly; see see bug 1571251

--- a/dnf-behave-tests/features/plugins-core/download-source.feature
+++ b/dnf-behave-tests/features/plugins-core/download-source.feature
@@ -52,4 +52,25 @@ Scenario: Download a specified source rpm
         | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm  | -                                                                                     |
 
 
+@bz1649627
+Scenario Outline: Download a source RPM when there are more versions available
+  Given I use the http repository based on "dnf-ci-fedora-updates-testing"
+   When I execute dnf with args "download --destdir={context.dnf.tempdir} --source <pkgspec>"
+   Then the exit code is 0
+    And stdout contains "<srpm>"
+    And file sha256 checksums are following
+        | Path                          | sha256                                                    |
+        | {context.dnf.tempdir}/<srpm>  | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates-testing/src/<srpm>  |
+
+Examples:
+  | pkgspec                     | srpm                           |
+  | wget                        | wget-1.19.5-5.fc29.src.rpm     |
+  | wget-1.19.4-1.fc29          | wget-1.19.4-1.fc29.src.rpm     |
+  | wget-1.19.5-5.fc29          | wget-1.19.5-5.fc29.src.rpm     |
+  | wget-1.19.4-1.fc29.src      | wget-1.19.4-1.fc29.src.rpm     |
+  | wget-1.19.5-5.fc29.src      | wget-1.19.5-5.fc29.src.rpm     |
+  | wget-1.19.4-1.fc29.x86_64   | wget-1.19.4-1.fc29.src.rpm     |
+  | wget-1.19.5-5.fc29.x86_64   | wget-1.19.5-5.fc29.src.rpm     |
+
+
 # TODO: --source --resolve doesn't work correctly; see see bug 1571251

--- a/dnf-behave-tests/features/steps/path.py
+++ b/dnf-behave-tests/features/steps/path.py
@@ -46,7 +46,7 @@ def then_file_sha256_checksums_are_following(context):
         if checksum.startswith("file://"):
             checksum_path = checksum[7:]
             checksum_path = checksum_path.format(context=context)
-            checksum = sha256_checksum(open(path, "rb").read())
+            checksum = sha256_checksum(open(checksum_path, "rb").read())
 
         if file_checksum != checksum:
             raise AssertionError("File sha256 checksum doesn't match (expected: %s, actual: %s): %s" % (checksum, file_checksum, path))

--- a/dnf-behave-tests/features/upgrade.feature
+++ b/dnf-behave-tests/features/upgrade.feature
@@ -64,7 +64,7 @@ Scenario: Upgrade all RPMs from multiple repositories
         | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
         | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
         | upgrade       | flac-0:1.4.0-1.fc29.x86_64                |
-        | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
+        | upgrade       | wget-1:1.19.5-5.fc29.x86_64               |
         | upgrade       | SuperRipper-0:1.2-1.x86_64                |
         | upgrade       | abcde-0:2.9.3-1.fc29.noarch               |
         | broken        | SuperRipper-0:1.3-1.x86_64                |

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-updates-testing/wget-1.19.4-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-updates-testing/wget-1.19.4-1.fc29.spec
@@ -1,0 +1,25 @@
+Name: wget
+Epoch: 1
+Version: 1.19.4
+Release: 1%{?dist}
+Summary: A utility for retrieving files using the HTTP or FTP protocols
+
+License: GPLv3+
+Group: Applications/Internet
+Url: http://www.gnu.org/software/wget/
+
+Provides: webclient
+Provides: bundled(gnulib) 
+
+%description
+GNU Wget is a file retrieval utility which can use either the HTTP or
+FTP protocols. Wget features include the ability to work in the
+background while you are logged out, recursive retrieval of
+directories, file name wildcard matching, remote file timestamp
+storage and comparison, use of Rest with FTP servers and Range with
+HTTP servers to retrieve files over slow or unstable connections,
+support for Proxy servers, and configurability.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-updates-testing/wget-1.19.5-5.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-updates-testing/wget-1.19.5-5.fc29.spec
@@ -1,0 +1,25 @@
+Name: wget
+Epoch: 1
+Version: 1.19.5
+Release: 5%{?dist}
+Summary: A utility for retrieving files using the HTTP or FTP protocols
+
+License: GPLv3+
+Group: Applications/Internet
+Url: http://www.gnu.org/software/wget/
+
+Provides: webclient
+Provides: bundled(gnulib) 
+
+%description
+GNU Wget is a file retrieval utility which can use either the HTTP or
+FTP protocols. Wget features include the ability to work in the
+background while you are logged out, recursive retrieval of
+directories, file name wildcard matching, remote file timestamp
+storage and comparison, use of Rest with FTP servers and Range with
+HTTP servers to retrieve files over slow or unstable connections,
+support for Proxy servers, and configurability.
+
+%files
+
+%changelog


### PR DESCRIPTION
This is a WIP for now, since the fix for bug 1649627 is not developed yet (either that or the test is wrong).

All lower-version package specifications in the examples are failing - dnf returns exit code 1 and the package flac-1.3.3-2.fc29.src.rpm never gets downloaded.

The scenario "Check using repoquery that the source RPM exists" shows, however, that the package exists (this scenario can be removed after the fix is developed).