### PR TITLE
 Test module update with profiles depending on other-module rpms (RhBug:1647429)

### DIFF
--- a/dnf-behave-tests/features/module-update.feature
+++ b/dnf-behave-tests/features/module-update.feature
@@ -170,3 +170,111 @@ When I execute dnf with args "module update nodejs"
   And modules state is following
       | Module    | State     | Stream    | Profiles  |
       | nodejs    | enabled   | 11        |           |
+
+
+@bz1647429
+Scenario: Update module packages and dependent packages when no profiles are installed
+  Given I use the repository "dnf-ci-thirdparty-modular"
+   When I execute dnf with args "module enable cookbook:1 ingredience:egg"
+   Then the exit code is 0
+   When I execute dnf with args "install axe egg blender whisk"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | install                  | axe-0:1.0-1.x86_64        |
+        | install                  | blender-0:1.0-1.x86_64    |
+        | install                  | egg-0:1.0-1.x86_64        |
+        | install                  | whisk-0:1.0-1.x86_64      |
+    And modules state is following
+        | Module      | State      | Stream    | Profiles      |
+        | cookbook    | enabled    | 1         |               |
+  Given I use the repository "dnf-ci-thirdparty-modular-updates"
+   When I execute dnf with args "module update cookbook"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | upgrade                  | axe-0:2.0-1.x86_64        |
+        | upgrade                  | blender-0:2.0-1.x86_64    |
+        | upgrade                  | egg-0:2.0-1.x86_64        |
+        | upgrade                  | whisk-0:2.0-1.x86_64      |
+    And modules state is following
+        | Module      | State      | Stream    | Profiles      |
+        | cookbook    | enabled    | 1         |               |
+
+
+@bz1647429
+Scenario: Update module packages and dependent packages when some profiles are installed
+  Given I use the repository "dnf-ci-thirdparty-modular"
+   When I execute dnf with args "module enable cookbook:1 ingredience:egg"
+   Then the exit code is 0
+   When I execute dnf with args "module install cookbook:1/axe-soup"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | install                  | axe-0:1.0-1.x86_64        |
+        | module-profile-install   | cookbook/axe-soup         |
+   When I execute dnf with args "module install cookbook:1/ham-and-eggs"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | install                  | egg-0:1.0-1.x86_64        |
+        | install                  | ham-0:1.0-1.x86_64        |
+        | install                  | spatula-0:1.0-1.x86_64    |
+        | module-profile-install   | cookbook/ham-and-eggs     |
+   When I execute dnf with args "install whisk"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | install                  | whisk-0:1.0-1.x86_64      |
+    And modules state is following
+        | Module      | State      | Stream    | Profiles      |
+        | cookbook    | enabled    | 1         | axe-soup, ham-and-eggs   |
+  Given I use the repository "dnf-ci-thirdparty-modular-updates"
+   When I execute dnf with args "module update cookbook"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | upgrade                  | axe-0:2.0-1.x86_64        |
+        | upgrade                  | egg-0:2.0-1.x86_64        |
+        | upgrade                  | ham-0:2.0-1.x86_64        |
+        | upgrade                  | spatula-0:2.0-1.x86_64    |
+        | upgrade                  | whisk-0:2.0-1.x86_64      |
+    And modules state is following
+        | Module      | State      | Stream    | Profiles      |
+        | cookbook    | enabled    | 1         | axe-soup, ham-and-eggs  |
+
+
+@bz1647429
+Scenario: Update module profiles that contains non-modular packages and packages from different modules
+  Given I use the repository "dnf-ci-thirdparty-modular"
+   When I execute dnf with args "module enable cookbook:1 ingredience:egg"
+   Then the exit code is 0
+   When I execute dnf with args "module install cookbook:1/axe-soup"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | install                  | axe-0:1.0-1.x86_64        |
+        | module-profile-install   | cookbook/axe-soup         |
+   When I execute dnf with args "module install cookbook:1/ham-and-eggs"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | install                  | egg-0:1.0-1.x86_64        |
+        | install                  | ham-0:1.0-1.x86_64        |
+        | install                  | spatula-0:1.0-1.x86_64    |
+        | module-profile-install   | cookbook/ham-and-eggs     |
+    And modules state is following
+        | Module      | State      | Stream    | Profiles      |
+        | cookbook    | enabled    | 1         | axe-soup, ham-and-eggs  |
+  Given I use the repository "dnf-ci-thirdparty-modular-updates"
+   When I execute dnf with args "module update cookbook:1/axe-soup cookbook:1/ham-and-eggs"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package                   |
+        | upgrade                  | axe-0:2.0-1.x86_64        |
+        | upgrade                  | egg-0:2.0-1.x86_64        |
+        | upgrade                  | ham-0:2.0-1.x86_64        |
+        | upgrade                  | spatula-0:2.0-1.x86_64    |
+    And modules state is following
+        | Module      | State      | Stream    | Profiles      |
+        | cookbook    | enabled    | 1         | axe-soup, ham-and-eggs  |

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty-modular-updates.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty-modular-updates.repo
@@ -1,0 +1,5 @@
+[dnf-ci-thirdparty-modular-updates]
+name=dnf-ci-thirdparty-modular-updates
+baseurl=file://$DNF0/repos/dnf-ci-thirdparty-modular-updates
+enabled=1
+gpgcheck=0

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/axe-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/axe-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           axe
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Made-up non-modular package.
+
+%description
+Made-up non-modular package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/blender-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/blender-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           blender
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Made-up package for testing module updates.
+
+%description
+Made-up package for testing module updates.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/egg-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/egg-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           egg
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for rich dependencies testing.
+
+%description
+Modular dependencies testing package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/ham-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/ham-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           ham
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for rich dependencies testing.
+
+%description
+Modular dependencies testing package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/modules.yaml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/modules.yaml
@@ -1,0 +1,120 @@
+---
+document: modulemd
+version: 2
+data:
+  name: ingredience
+  stream: chicken
+  version: 2
+  arch: x86_64
+  summary: Dependency testing module
+  description: Made up module for dependency testing
+  license:
+    module:
+    - MIT
+  profiles:
+    default:
+      rpms: ["chicken"]
+  components:
+    rpms:
+      egg: {rationale: 'rationale for chicken'}
+  artifacts:
+    rpms: ["chicken-0:2.0-1.x86_64"]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: ingredience
+  stream: egg
+  version: 2
+  arch: x86_64
+  summary: Dependency testing module
+  description: Made up module for dependency testing
+  license:
+    module:
+    - MIT
+  profiles:
+    default:
+      rpms: ["egg"]
+  components:
+    rpms:
+      egg: {rationale: 'rationale for egg'}
+  artifacts:
+    rpms: ["egg-0:2.0-1.x86_64"]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: ingredience
+  stream: orange
+  version: 2
+  arch: x86_64
+  summary: Dependency testing module
+  description: Made up module for dependency testing
+  license:
+    module:
+    - MIT
+  profiles:
+    default:
+      rpms: ["orange"]
+  components:
+    rpms:
+      egg: {rationale: 'rationale for orange'}
+  artifacts:
+    rpms: ["orange-0:2.0-1.x86_64"]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: ingredience
+  stream: strawberry
+  version: 2
+  arch: x86_64
+  summary: Dependency testing module
+  description: Made up module for dependency testing
+  license:
+    module:
+    - MIT
+  profiles:
+    default:
+      rpms: ["strawberry"]
+  components:
+    rpms:
+      egg: {rationale: 'rationale for strawberry'}
+  artifacts:
+    rpms: ["strawberry-0:2.0-1.x86_64"]
+...
+---
+document: modulemd
+version: 2
+data:
+  name: cookbook
+  stream: 1
+  version: 2
+  arch: x86_64
+  summary: Module for testing module update independently on installed profiles
+  description: Contains profiles that depend on non-modular packages and packages from different modules
+  license:
+    module:
+    - MIT
+  profiles:
+    ham-and-eggs:
+      rpms: ["ham", "egg", "spatula"]
+    orange-juice:
+      rpms: ["orange", "blender"]
+    axe-soup:
+      rpms: ["axe"]
+  artifacts:
+    rpms: ["spatula-0:2.0-1.x86_64", "blender-0:2.0-1.x86_64", "whisk-0:2.0-1.x86_64"]
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: ingredience
+    stream: orange
+    profiles:
+        default: [default]
+...

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/orange-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/orange-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           orange
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for rich dependencies testing.
+
+%description
+Modular dependencies testing package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/spatula-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/spatula-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           spatula
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Made-up package for testing module updates.
+
+%description
+Made-up package for testing module updates.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/strawberry-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/strawberry-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           strawberry
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for rich dependencies testing.
+
+%description
+Modular dependencies testing package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/whisk-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates/whisk-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           whisk
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Made-up package for testing module updates.
+
+%description
+Made-up package for testing module updates.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/axe-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/axe-1.0-1.spec
@@ -1,0 +1,16 @@
+Name:           axe
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Made-up non-modular package.
+
+%description
+Made-up non-modular package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/blender-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/blender-1.0-1.spec
@@ -1,0 +1,16 @@
+Name:           blender
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Made-up package for testing module updates.
+
+%description
+Made-up package for testing module updates.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/modules.yaml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/modules.yaml
@@ -13,7 +13,7 @@ data:
     - MIT
   profiles:
     default:
-      rpms: ["chicken-1.0-1.x86_64"]
+      rpms: ["chicken"]
   components:
     rpms:
       egg: {rationale: 'rationale for chicken'}
@@ -35,7 +35,7 @@ data:
     - MIT
   profiles:
     default:
-      rpms: ["egg-1.0-1.x86_64"]
+      rpms: ["egg"]
   components:
     rpms:
       egg: {rationale: 'rationale for egg'}
@@ -57,7 +57,7 @@ data:
     - MIT
   profiles:
     default:
-      rpms: ["orange-1.0-1.x86_64"]
+      rpms: ["orange"]
   components:
     rpms:
       egg: {rationale: 'rationale for orange'}
@@ -79,7 +79,7 @@ data:
     - MIT
   profiles:
     default:
-      rpms: ["strawberry-1.0-1.x86_64"]
+      rpms: ["strawberry"]
   components:
     rpms:
       egg: {rationale: 'rationale for strawberry'}

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/modules.yaml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/modules.yaml
@@ -438,6 +438,29 @@ data:
       rpms: []
 ...
 ---
+document: modulemd
+version: 2
+data:
+  name: cookbook
+  stream: 1
+  version: 1
+  arch: x86_64
+  summary: Module for testing module update independently on installed profiles
+  description: Contains profiles that depend on non-modular packages and packages from different modules
+  license:
+    module:
+    - MIT
+  profiles:
+    ham-and-eggs:
+      rpms: ["ham", "egg", "spatula"]
+    orange-juice:
+      rpms: ["orange", "blender"]
+    axe-soup:
+      rpms: ["axe"]
+  artifacts:
+    rpms: ["spatula-0:1.0-1.x86_64", "blender-0:1.0-1.x86_64", "whisk-0:1.0-1.x86_64"]
+...
+---
 document: modulemd-defaults
 version: 1
 data:

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/spatula-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/spatula-1.0-1.spec
@@ -1,0 +1,16 @@
+Name:           spatula
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Made-up package for testing module updates.
+
+%description
+Made-up package for testing module updates.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/whisk-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular/whisk-1.0-1.spec
@@ -1,0 +1,16 @@
+Name:           whisk
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Made-up package for testing module updates.
+
+%description
+Made-up package for testing module updates.
+
+%files
+
+%changelog


### PR DESCRIPTION
There is already a test for the bug 1647429, but this adds tests for updating modules with profiles that contain either non-modular rpms or rpms from another module.