### PR TITLE
remove temporary directories of tests in /tmp

### DIFF
--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -104,6 +104,7 @@ class DNFContext(object):
         self.module_platform_id = userdata.get("module_platform_id", DEFAULT_PLATFORM_ID)
         self.reposdir = userdata.get("reposdir", DEFAULT_REPOSDIR)
         self.repos_location = userdata.get("repos_location", DEFAULT_REPOS_LOCATION)
+        self.preserve_temporary_dirs = True if userdata.get("preserve", "no") in ("yes", "y", "1", "true") else False
         self.fixturesdir = FIXTURES_DIR
         self.disable_plugins = True
         self.disable_repos_option = "--disablerepo='*'"
@@ -114,14 +115,12 @@ class DNFContext(object):
         os.environ['DNF0'] = self.fixturesdir
 
     def __del__(self):
-        if os.path.realpath(self.tempdir) not in ["/", "/tmp"]:
-            print("RMTREE", self.tempdir)
-            #shutil.rmtree(self.tempdir)
+        if not self.preserve_temporary_dirs and os.path.realpath(self.tempdir) not in ["/", "/tmp"]:
+            shutil.rmtree(self.tempdir)
 
-        if self.delete_installroot:
+        if not self.preserve_temporary_dirs and self.delete_installroot:
             if os.path.realpath(self.installroot) not in ["/"]:
-                print("RMTREE", self.installroot)
-                #shutil.rmtree(self.installroot)
+                shutil.rmtree(self.installroot)
 
     def __getitem__(self, name):
         return self._scenario_data[name]

--- a/dnf-behave-tests/run-tests
+++ b/dnf-behave-tests/run-tests
@@ -11,6 +11,17 @@ ENV="$ENV -Ddnf_command=dnf-3"
 
 TAGS=""
 
+for opt in "$@"; do
+  shift
+  case $opt in
+    -p|--preserve)
+      ENV="$ENV -Dpreserve=yes"
+      continue
+      ;;
+  esac
+  set -- "$@" "$opt"
+done
+
 # run only tier1 tests
 #TAGS="$TAGS --tags @tier1"
 


### PR DESCRIPTION
I'm getting thousands of these directories after running the tests for a while. They're eating my RAM as /tmp is mounted as tmpfs.

Fun fact is the default size in Fedora is half the RAM size. If you run two Fedora containers, does it equal your whole RAM size? And if you run more? :slightly_smiling_face: 

Is it ok to delete the directories? If someone needs them for post-mortem examination, should we add a switch somewhere to prevent the deletion?

As an alternative, I'd maybe preferred if they were created in a temporary directory inside the tests directory. There they are easy to find and delete (git clean) at will.