### PR TITLE
Do not run local plugin during container setup

### DIFF
--- a/Dockerfile.f29
+++ b/Dockerfile.f29
@@ -90,7 +90,7 @@ RUN set -x && \
 COPY ./rpms/ /opt/behave/rpms/
 RUN rm /opt/behave/rpms/*-{devel,debuginfo,debugsource}*.rpm; \
     if [ -n "$(find /opt/behave/rpms/ -maxdepth 1 -name '*.rpm' -print -quit)" ]; then \
-        dnf -y install /opt/behave/rpms/*.rpm; \
+        dnf -y install /opt/behave/rpms/*.rpm --disableplugin=local; \
     fi
 
 

--- a/Dockerfile.f30
+++ b/Dockerfile.f30
@@ -87,7 +87,7 @@ RUN set -x && \
 COPY ./rpms/ /opt/behave/rpms/
 RUN rm /opt/behave/rpms/*-{devel,debuginfo,debugsource}*.rpm; \
     if [ -n "$(find /opt/behave/rpms/ -maxdepth 1 -name '*.rpm' -print -quit)" ]; then \
-        dnf -y install /opt/behave/rpms/*.rpm; \
+        dnf -y install /opt/behave/rpms/*.rpm --disableplugin=local; \
     fi
 
 


### PR DESCRIPTION
After change of default in dnf.conf.skip_if_unavailable the container is
unable to setup due to missing local repository.