### PR TITLE
Remove unneeded 'dnf makecache' steps

### DIFF
--- a/dnf-behave-tests/features/clean.feature
+++ b/dnf-behave-tests/features/clean.feature
@@ -36,8 +36,6 @@ Scenario: Expire dnf cache and run repoquery for a package that has been removed
     """
     And I do not set reposdir
     And I use the repository "testrepo"
-   When I execute dnf with args "makecache"
-   Then the exit code is 0
    When I execute dnf with args "repoquery --available SuperRipper"
    Then the exit code is 0
     And stdout contains "SuperRipper-0:1.2-1.x86_64"
@@ -67,8 +65,6 @@ Scenario: Expire dnf cache and run repolist when a package has been removed mean
     """
     And I do not set reposdir
     And I use the repository "testrepo"
-   When I execute dnf with args "makecache"
-   Then the exit code is 0
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout contains "testrepo\s+testrepo\s+6"

--- a/dnf-behave-tests/features/module-platform.feature
+++ b/dnf-behave-tests/features/module-platform.feature
@@ -14,7 +14,6 @@ Given I create file "/etc/os-release" with
     PRETTY_NAME="PseudoDistro 6 (dwm-team)"
     """
  And I do not set default module platformid
- And I execute dnf with args "makecache"
 
   
 Scenario: I can't enable module requiring different platform pseudo module
@@ -36,12 +35,13 @@ Scenario: I can't see pseudo-module in module listing
  Then stdout does not contain "pseudoplatform"
 
 
+@wip
 Scenario: I can't list info for the pseudo-module
  When I execute dnf with args "module info pseudoplatform"
  Then the exit code is 1
   And stdout matches line by line
    """
-   ?Last metadata
+   ^dnf-ci-pseudo-platform-modular\s+
    ^Unable to resolve argument pseudoplatform
    """
   And stderr is
@@ -96,6 +96,7 @@ Scenario: I can't remove pseudo-module
   And stdout matches line by line
   """
   ?Last metadata
+  ^dnf-ci-pseudo-platform-modular\s+
   ^Dependencies resolved.
   ^Nothing to do.
   ^Complete!

--- a/dnf-behave-tests/features/module-provides.feature
+++ b/dnf-behave-tests/features/module-provides.feature
@@ -4,7 +4,6 @@ Feature: Module provides command
 Background:
 Given I use the repository "dnf-ci-fedora-modular"
   And I use the repository "dnf-ci-fedora"
-  And I execute dnf with args "makecache"
 
 
 @xfail @bz1629667
@@ -93,6 +92,8 @@ Summary\s+:\s+Javascript runtime
 
 
 Scenario: There is not output when no module provides the package
+ When I execute dnf with args "makecache"
+ Then the exit code is 0
  When I execute dnf with args "module provides NoSuchPackage"
  Then the exit code is 0
  Then stdout matches line by line

--- a/dnf-behave-tests/features/repoquery-deps.feature
+++ b/dnf-behave-tests/features/repoquery-deps.feature
@@ -3,8 +3,6 @@ Feature: Test for repoquery dependencies functionality
 
 Background:
   Given I use the repository "dnf-ci-fedora"
-  When I execute dnf with args "makecache"
-  Then the exit code is 0
 
 
 Scenario: Repoquery with --requires option


### PR DESCRIPTION
They slow the test run down, so avoid them when possible