### PR TITLE
Test for bz1722493

### DIFF
--- a/dnf-behave-tests/features/config.feature
+++ b/dnf-behave-tests/features/config.feature
@@ -178,3 +178,26 @@ Scenario: Test usage of not existing config file
    When I execute dnf with args "list"
    Then the exit code is 1
     And stderr contains "Config file.*does not exist"
+
+
+@not.with_os=rhel__eq__8
+@bz1722493
+Scenario: Lines that contain only whitespaces do not spoil previous config options
+  Given I enable plugin "config_manager"
+    And I do not set config file
+    And I create file "/etc/dnf/dnf.conf" with
+    # the "empty" line between gpgcheck and baseurl intentionally contains spaces
+    """
+    [main]
+    gpgcheck=0
+
+    [testingrepo]
+    gpgcheck=1
+         
+    baseurl=http://some.url/
+    """
+   When I execute dnf with args "config-manager testingrepo --dump"
+   Then stdout contains lines
+   """
+   gpgcheck = 1
+   """

--- a/dnf-behave-tests/features/config.feature
+++ b/dnf-behave-tests/features/config.feature
@@ -170,7 +170,7 @@ Scenario: Reposdir option set by --setopt
 	| install       | setup-0:2.12.1-1.fc29.noarch      |
 
 
-@xfail @bz1512457
+@bz1512457
 Scenario: Test usage of not existing config file
   Given I use the repository "dnf-ci-fedora"
     And I set config file to "/etc/dnf/not_existing_dnf.conf"


### PR DESCRIPTION
Tests correct parsing of a value followed in config file by line
containing only whitespaces.
E.g.

gpgcheck=1
  <some spaces are here>

results in gpgcheck=1 not in gpgcheck='1\n'