### PR TITLE
Adjust tests for module install without a default profile

### DIFF
--- a/dnf-behave-tests/features/module-enable-errors.feature
+++ b/dnf-behave-tests/features/module-enable-errors.feature
@@ -31,7 +31,7 @@ Scenario: Fail to install a different stream of an already enabled module
     And modules state is following
         | Module    | State     | Stream    | Profiles  |
         | nodejs    | enabled   | 8         |           |
-   When I execute dnf with args "module install nodejs:10"
+   When I execute dnf with args "module install nodejs:10/minimal --skip-broken"
    Then the exit code is 1
     And modules state is following
         | Module    | State     | Stream    | Profiles  |
@@ -49,7 +49,7 @@ Scenario: Fail to install a different stream of an already enabled module using 
     And modules state is following
         | Module    | State     | Stream    | Profiles  |
         | nodejs    | enabled   | 8         |           |
-   When I execute dnf with args "install @nodejs:10"
+   When I execute dnf with args "install @nodejs:10/minimal --skip-broken"
    Then the exit code is 1
     And modules state is following
         | Module    | State     | Stream    | Profiles  |

--- a/dnf-behave-tests/features/module-install-default.feature
+++ b/dnf-behave-tests/features/module-install-default.feature
@@ -4,14 +4,19 @@ Feature: Installing modules without profile specification using defaults from re
 Background:
   Given I use the repository "dnf-ci-thirdparty"
 
-
+@bz1724564
 Scenario: Install module, no default profile defined, expecting no profile selection
    When I execute dnf with args "module install DnfCiModuleNoDefaults:stable"
-   Then the exit code is 0
+   Then the exit code is 1
     And modules state is following
         | Module                | State     | Stream    | Profiles  |
-        | DnfCiModuleNoDefaults | enabled   | stable    |           |
-
+        | DnfCiModuleNoDefaults |           |           |           |
+    And stderr is
+        """
+        No default profiles for module DnfCiModuleNoDefaults:stable. Available profiles: default
+        Error: Problems in request:
+        missing groups or modules: DnfCiModuleNoDefaults:stable
+        """
 
 Scenario: Install module, empty default profile exists, expecting default profile selection
    When I execute dnf with args "module install DnfCiModuleEmptyDefault:stable"

--- a/dnf-behave-tests/features/module-install.feature
+++ b/dnf-behave-tests/features/module-install.feature
@@ -134,25 +134,6 @@ Scenario: I can install a module profile for a stream that was enabled as depend
         | module-profile-install    | postgresql/client                                       |
 
 
-Scenario: Installing a stream without a defined default profile enables the stream
-  Given I use the repository "dnf-ci-thirdparty"
-   When I execute dnf with args "module install DnfCiModulePackageDep:packagedep"
-   Then the exit code is 0
-    And Transaction is following
-        | Action                   | Package                            |
-        | module-stream-enable     | DnfCiModulePackageDep:packagedep   |
-
-
-Scenario: Installing a stream without a defined default profile enables the stream and its requires
-  Given I use the repository "dnf-ci-thirdparty"
-   When I execute dnf with args "module install DnfCiModulePackageDep:moduledep"
-   Then the exit code is 0
-    And Transaction is following
-        | Action                   | Package                            |
-        | module-stream-enable     | DnfCiModulePackageDep:moduledep    |
-        | module-stream-enable     | nodejs:8                           |
-
-
 # rely on merging bz1649261 fix
 Scenario: Install a module profile of a disabled module
    When I execute dnf with args "module disable nodejs"


### PR DESCRIPTION
The new behavior of dnf that install commands requires to install a
profile must be also reflected in tests. In case that there is no
default provide, dnf provides a hint about available profiles and raises
an error.

The patch also deletes two scenario because they are nor completely
irrelevant and adjusting them to new behavior makes them redundant.