### PR TITLE
Repoquery command tests

### DIFF
--- a/dnf-behave-tests/features/repoquery/rich-deps.feature
+++ b/dnf-behave-tests/features/repoquery/rich-deps.feature
@@ -32,6 +32,27 @@ Scenario: repoquery --whatrequires for "(a1-prov1 if b1)"
       """
 
 
+@bz1534123
+@bz1698034
+Scenario: repoquery --whatrequires NAME for "(b1-prov2 >= 1.0 with b1-prov2 < 2.0)"
+ When I execute dnf with args "repoquery --whatrequires b1"
+ Then the exit code is 0
+  And stdout is
+      """
+      c1-0:1.0-1.x86_64
+      """
+
+@bz1534123
+@bz1698034
+Scenario: repoquery --whatrequires PROVIDE_NAME = VERSION for "(b1-prov2 >= 1.0 with b1-prov2 < 2.0)"
+ When I execute dnf with args "repoquery --whatrequires 'b1-prov2 = 1.0'"
+ Then the exit code is 0
+  And stdout is
+      """
+      c1-0:1.0-1.x86_64
+      """
+
+
 # a1-1.0: Conflicts: ((b1 and x1) or c1)
 Scenario: repoquery --whatconflicts for "((b1 and x1) or c1)"
  When I execute dnf with args "repoquery --whatconflicts b1"
@@ -70,6 +91,26 @@ Given I successfully execute dnf with args "install x1"
   And stdout is
       """
       a1-0:1.0-1.x86_64
+      """
+
+@bz1534123
+@bz1698034
+Scenario: repoquery --whatconflicts for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)"
+ When I execute dnf with args "repoquery --whatconflicts d1-1.0"
+ Then the exit code is 0
+  And stdout is
+      """
+      c1-0:1.0-1.x86_64
+      """
+
+@bz1534123
+@bz1698034
+Scenario: repoquery --whatconflicts PROVIDE_NAME = VERSION for "(d1-prov1 >= 1.0 with d1-prov0 < 2.0)"
+ When I execute dnf with args "repoquery --whatconflicts 'd1-prov1 = 1.0'"
+ Then the exit code is 0
+  And stdout is
+      """
+      c1-0:1.0-1.x86_64
       """
 
 
@@ -114,6 +155,26 @@ Scenario: repoquery --whatsuggests for "((b1 with b1-prov2 > 1.7) or (c1 <= 1.0 
   And stdout is
       """
       a1-0:1.0-1.x86_64
+      """
+
+@bz1534123
+@bz1698034
+Scenario: repoquery --whatsuggests for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" - only d1-1.0 should match
+ When I execute dnf with args "repoquery --whatsuggests d1"
+ Then the exit code is 0
+  And stdout is
+      """
+      b1-0:1.0-1.x86_64
+      """
+
+@bz1534123
+@bz1698034
+Scenario: repoquery --whatsuggests with provide for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" - only b1-1.0 should match
+        When I execute dnf with args "repoquery --whatsuggests 'd1-prov1 = 1.0'"
+ Then the exit code is 0
+  And stdout is
+      """
+      b1-0:1.0-1.x86_64
       """
 
 

--- a/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/b1-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/b1-1.0-1.spec
@@ -9,6 +9,7 @@ Provides:       b1-prov1
 Provides:       b1-prov2 = 1.0
 
 Enhances:       (a1 unless x1 else c1)
+Suggests:       (d1-prov1 >= 1.0 with d1-prov1 < 2.0)
 
 Summary:        Rich deps package.
 

--- a/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/c1-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/c1-1.0-1.spec
@@ -5,7 +5,12 @@ Release:        1
 License:        Public Domain
 URL:            None
 
+Provides:       c1-prov1 = 1.0
+
 Requires:       (a1-prov1 if b1)
+Requires:       (b1-prov2 >= 1.0 with b1-prov2 < 2.0)
+
+Conflicts:      (d1-prov1 >= 1.0 with d1-prov1 < 2.0)
 
 Recommends:     (b1 and a1)
 

--- a/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/c1-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/c1-2.0-1.spec
@@ -8,6 +8,9 @@ URL:            None
 Provides:       c1-prov1 = 2.0
 
 Requires:       (a1-prov1 if b1)
+Requires:       (b1-prov2 >= 2.0 with b1-prov2 < 3.0)
+
+Conflicts:      (d1-prov1 >= 2.0 with d1-prov1 < 3.0)
 
 Recommends:     (b1 and a1)
 

--- a/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/d1-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/d1-1.0-1.spec
@@ -1,0 +1,17 @@
+Name:           d1
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Provides:       d1-prov1 = 1.0
+
+Summary:        Rich deps package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/d1-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-rich-deps/d1-2.0-1.spec
@@ -1,14 +1,11 @@
-Name:           b1
+Name:           d1
 Version:        2.0
 Release:        1
 
 License:        Public Domain
 URL:            None
 
-Provides:       b1-prov1
-Provides:       b1-prov2 <= 1.0
-
-Suggests:       (d1-prov1 >= 4.0 with d1-prov1 < 5.0)
+Provides:       d1-prov1 = 2.0
 
 Summary:        Rich deps package.
 


### PR DESCRIPTION
This big PR adds (reasonably) comprehensive tests for the repoquery command. It's meant to cover all the functionality (a few niche bits may be missing).

The reason for this is I had to make some big changes to the behavior of the command and wanted to make sure I'm not breaking anything. The last commit adds tests for that.

Note this shares some commits with my previous PR here: https://github.com/rpm-software-management/ci-dnf-stack/pull/566

That should go in first.

Not all the tests are passing. They're marked with @xfail and there is a TODO for each with a comment on what I think. I'd like to discuss how those should be resolved (i.e. desired behavior or bug...).

The tests completely replace the previous repoquery tests (apart from repoquery-cache.feature which perhaps still remains to move) and each feature file has its own separate repository, which makes it independent of the other tests.