### PR TITLE
Add repoquery querytag "reason"

### DIFF
--- a/dnf-behave-tests/features/repoquery.feature
+++ b/dnf-behave-tests/features/repoquery.feature
@@ -169,5 +169,5 @@ Scenario: dnf repoquery --querytags is working
  debug_name, source_name, source_debug_name,
  installtime, buildtime, size, downloadsize, installsize,
  provides, requires, obsoletes, conflicts, sourcerpm,
- description, summary, license, url
+ description, summary, license, url, reason
  """


### PR DESCRIPTION
New repoquery tag "reason" was added by PR https://github.com/rpm-software-management/dnf/pull/1462 .