### PR TITLE
Update of modular errors generated by libsolv

### DIFF
--- a/dnf-behave-tests/features/module-enable-errors.feature
+++ b/dnf-behave-tests/features/module-enable-errors.feature
@@ -147,7 +147,7 @@ Scenario: Enabling a stream depending on other than enabled stream should fail
         | module-stream-enable     | fluid:oil              |
    When I execute dnf with args "module enable beverage:soda"
    Then the exit code is 1
-    And stderr contains "Problem: conflicting requests"
+    And stderr contains "module fluid:water:1:-0\.x86_64 conflicts with module\(fluid:oil\) provided by fluid:oil:1:-0\.x86_64"
 
 Scenario: Enabling a stream depending on a disabled stream should fail
   Given I use the repository "dnf-ci-thirdparty-modular"
@@ -179,7 +179,8 @@ Scenario: Enabling a stream depending on a disabled stream should fail
         | module-disable           | fluid                  |
    When I execute dnf with args "module enable beverage:soda"
    Then the exit code is 1
-    And stderr contains "Problem: conflicting requests"
+    And stderr contains "Modular dependency problems:"
+    And stderr contains "module beverage:soda:1:-0\.x86_64 requires module\(fluid:water\), but none of the providers can be installed"
     And stderr contains "module fluid:water:.* is disabled"
 
 
@@ -200,5 +201,5 @@ Scenario: Enabling module stream and another module requiring another stream
    When I execute dnf with args "module enable fluid:oil beverage:beer"
    Then the exit code is 1
     And stderr contains "Modular dependency problems:"
-    And stderr contains "Problem: conflicting requests"
+    And stderr contains "module fluid:water:1:-0\.x86_64 conflicts with module\(fluid:oil\) provided by fluid:oil:1:-0\.x86_64"
 


### PR DESCRIPTION
In some cases libsolv could return same errors in different order
therefore testing message with `Problem: ` for the first message could
result in false negative results.