### PR TITLE
 Update expected output of stderr for module-enable-errors

### DIFF
--- a/dnf-behave-tests/features/module-enable-errors.feature
+++ b/dnf-behave-tests/features/module-enable-errors.feature
@@ -19,8 +19,13 @@ Scenario: Fail to enable a different stream of an already enabled module
     And modules state is following
         | Module    | State     | Stream    | Profiles  |
         | nodejs    | enabled   | 8         |           |
-    And stderr contains "The operation would result in switching of module 'nodejs' stream '8' to stream '10'"
-    And stderr contains "Error: It is not possible to switch enabled streams of a module."
+    And stderr is
+        """
+        The operation would result in switching of module 'nodejs' stream '8' to stream '10'
+        Error: It is not possible to switch enabled streams of a module.
+        It is recommended to remove all installed content from the module, and reset the module using 'dnf module reset <module_name>' command. After you reset the module, you can install the other stream.
+        """
+
 
 Scenario: Fail to install a different stream of an already enabled module
    When I execute dnf with args "module enable nodejs:8"
@@ -36,8 +41,13 @@ Scenario: Fail to install a different stream of an already enabled module
     And modules state is following
         | Module    | State     | Stream    | Profiles  |
         | nodejs    | enabled   | 8         |           |
-    And stderr contains "The operation would result in switching of module 'nodejs' stream '8' to stream '10'"
-    And stderr contains "Error: It is not possible to switch enabled streams of a module."
+    And stderr is
+        """
+        The operation would result in switching of module 'nodejs' stream '8' to stream '10'
+        Error: It is not possible to switch enabled streams of a module.
+        It is recommended to remove all installed content from the module, and reset the module using 'dnf module reset <module_name>' command. After you reset the module, you can install the other stream.
+        """
+
 
 @bz1706215
 Scenario: Fail to install a different stream of an already enabled module using @module:stream syntax
@@ -54,8 +64,13 @@ Scenario: Fail to install a different stream of an already enabled module using 
     And modules state is following
         | Module    | State     | Stream    | Profiles  |
         | nodejs    | enabled   | 8         |           |
-    And stderr contains "The operation would result in switching of module 'nodejs' stream '8' to stream '10'"
-    And stderr contains "Error: It is not possible to switch enabled streams of a module."
+    And stderr is
+        """
+        The operation would result in switching of module 'nodejs' stream '8' to stream '10'
+        Error: It is not possible to switch enabled streams of a module.
+        It is recommended to remove all installed content from the module, and reset the module using 'dnf module reset <module_name>' command. After you reset the module, you can install the other stream.
+        """
+
 
 Scenario: Fail to enable a module stream when specifying only module
    When I execute dnf with args "module enable nodejs"
@@ -100,7 +115,6 @@ Scenario: Fail to enable a module stream when not specifying anything
     And stderr is
         """
         Error: dnf module enable: too few arguments
-
         """
 
 

--- a/dnf-behave-tests/features/module-enable-errors.feature
+++ b/dnf-behave-tests/features/module-enable-errors.feature
@@ -147,7 +147,9 @@ Scenario: Enabling a stream depending on other than enabled stream should fail
         | module-stream-enable     | fluid:oil              |
    When I execute dnf with args "module enable beverage:soda"
    Then the exit code is 1
-    And stderr contains "Problem: conflicting requests"
+    And stderr contains "Modular dependency problems:"
+    And stderr contains "module beverage:soda:1:-0.x86_64 requires module\(fluid:water\), but none of the providers can be installed"
+
 
 Scenario: Enabling a stream depending on a disabled stream should fail
   Given I use the repository "dnf-ci-thirdparty-modular"
@@ -179,8 +181,9 @@ Scenario: Enabling a stream depending on a disabled stream should fail
         | module-disable           | fluid                  |
    When I execute dnf with args "module enable beverage:soda"
    Then the exit code is 1
-    And stderr contains "Problem: conflicting requests"
-    And stderr contains "module fluid:water:.* is disabled"
+    And stderr contains "Modular dependency problems:"
+    And stderr contains "module beverage:soda:1:-0.x86_64 requires module\(fluid:water\), but none of the providers can be installed"
+    And stderr contains "module fluid:water:1:-0.x86_64 is disabled"
 
 
 # side-dish:chip requires fluid:oil
@@ -190,7 +193,8 @@ Scenario: Enabling two modules both requiring different streams of another modul
    When I execute dnf with args "module enable side-dish:chips beverage:beer"
    Then the exit code is 1
     And stderr contains "Modular dependency problems:"
-    And stderr contains "- conflicting requests"
+    And stderr contains "module side-dish:chips:1:-0.x86_64 requires module\(fluid:oil\), but none of the providers can be installed"
+    And stderr contains "module beverage:beer:1:-0.x86_64 requires module\(fluid:water\), but none of the providers can be installed"
 
 
 # beverage:beer requires fluid:water
@@ -200,5 +204,4 @@ Scenario: Enabling module stream and another module requiring another stream
    When I execute dnf with args "module enable fluid:oil beverage:beer"
    Then the exit code is 1
     And stderr contains "Modular dependency problems:"
-    And stderr contains "Problem: conflicting requests"
-
+    And stderr contains "module beverage:beer:1:-0.x86_64 requires module\(fluid:water\), but none of the providers can be installed"


### PR DESCRIPTION
Update modular errors generated by libsolv
- In some cases, libsolv returns some errors in different order. Therefore, the strings can be prefixed with "Problem:" or with "- " randomly and this prefix shouldn't be tested.
- Also, the message "conflicting requests" doesn't always have to be present, so the modular problems of the form "module X requires module Y, but none of the providers can be installed" are checked instead.

Check the exact match of stderr for stream-switching tests
- The output is not dynamic in this case and doesn't change the order, so we can check the exact match here.