### PR TITLE
Extend tests for repoquery --extras

### DIFF
--- a/dnf-behave-tests/features/repoquery/main.feature
+++ b/dnf-behave-tests/features/repoquery/main.feature
@@ -354,6 +354,39 @@ Scenario: repoquery --extras NAME (package is not installed)
  Then the exit code is 0
   And stdout is empty
 
+   # --extras: installed pkgs, different NEVRA in available repository
+Scenario: dnf repoquery --extras (when there are such pkgs with different NEVRA in repository)
+Given I drop repository "repoquery-main"
+ When I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/repoquery-main-multilib/x86_64/mid-a1-1.0-1.x86_64.rpm"
+ Then the exit code is 0
+ When I execute dnf with args "repoquery --installed"
+ Then stdout is
+ """
+ mid-a1-1:1.0-1.x86_64
+ """
+Given I use repository "repoquery-main"
+ When I execute dnf with args "repoquery --extras"
+ Then stdout is empty
+
+  # --extras: installed pkgs, no NA in available repository
+Scenario: dnf repoquery --extras (no NA in available repository)
+ When I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/repoquery-main-multilib/i686/mid-a1-1.0-1.i686.rpm"
+ Then the exit code is 0
+ When I execute dnf with args "repoquery --installed"
+ Then stdout is
+ """
+ mid-a1-1:1.0-1.i686
+ """
+ When I execute dnf with args "repoquery --extras"
+ Then the exit code is 0
+  And stdout is
+ """
+ mid-a1-1:1.0-1.i686
+ """
+Given I use repository "repoquery-main-multilib"
+ When I execute dnf with args "repoquery --extras"
+ Then the exit code is 0
+  And stdout is empty
 
 # --installed: list only installed packages
 Scenario: repoquery --installed

--- a/dnf-behave-tests/fixtures/specs/repoquery-main-multilib/mid-a1.multilib.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-main-multilib/mid-a1.multilib.spec
@@ -1,0 +1,16 @@
+Name:           mid-a1
+Epoch:          1
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Mid level package.
+
+%description
+Dummy.
+
+%files
+
+%changelog


### PR DESCRIPTION
It also tests when package with installed architecture disappears from
repository or installed package NEVRA not in repository but NA is
present.

The test requires to add i686 package therefore one additional test was
necessary to modify.