### PR TITLE
History list tests and a couple of history info tests

### DIFF
--- a/dnf-behave-tests/features/history-list.feature
+++ b/dnf-behave-tests/features/history-list.feature
@@ -1,0 +1,194 @@
+Feature: history list
+
+Background:
+Given I use the repository "dnf-ci-fedora"
+  # create some history to start with
+  And I successfully execute dnf with args "install abcde basesystem"
+  And I successfully execute dnf with args "remove abcde"
+  And I successfully execute dnf with args "install nodejs"
+
+
+Scenario: history list
+ When I execute dnf with args "history list"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+
+Scenario: history
+ When I execute dnf with args "history"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+
+
+# single item tests
+Scenario: history list 2
+ When I execute dnf with args "history list 2"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+
+Scenario: history list last
+ When I execute dnf with args "history list last"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+
+Scenario: history last
+ When I execute dnf with args "history last"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+
+Scenario: history list last-1
+ When I execute dnf with args "history list last-1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+
+Scenario: history last-1
+ When I execute dnf with args "history last-1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+
+
+# range tests
+Scenario: history 1..last-1
+ When I execute dnf with args "history 1..last-1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+
+Scenario: history 1..last-2
+ When I execute dnf with args "history 1..last-2"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 1  |         | Install | 6       |
+
+Scenario: history 1..last-2
+ When I execute dnf with args "history 1..last-2"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 1  |         | Install | 6       |
+
+Scenario: history list 1..-1
+ When I execute dnf with args "history 1..-1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+
+Scenario: history list 1..-2
+ When I execute dnf with args "history 1..-2"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 1  |         | Install | 6       |
+
+Scenario: history 2..3
+ When I execute dnf with args "history 2..3"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+      | 2  |         | Removed | 3       |
+
+Scenario: history 10..11
+ When I execute dnf with args "history 10..11"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+
+Scenario: history last..11
+ When I execute dnf with args "history last..11"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+
+
+# "invalid" range tests
+Scenario: history 3..2
+ When I execute dnf with args "history 3..2"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+      | 2  |         | Removed | 3       |
+
+Scenario: history last-1..1
+ When I execute dnf with args "history last-1..1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+
+Scenario: history 11..last-1
+ When I execute dnf with args "history 11..last-1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+      | 2  |         | Removed | 3       |
+
+Scenario: history last-1..aaa
+ When I execute dnf with args "history last-1..aaa"
+ Then the exit code is 1
+  And stderr is
+      """
+      Can't convert 'aaa' to transaction ID.
+      Use '<number>', 'last', 'last-<number>'.
+      """
+
+Scenario: history 12a..bc
+ When I execute dnf with args "history 12a..bc"
+ Then the exit code is 1
+  And stderr is
+      """
+      Can't convert '12a' to transaction ID.
+      Use '<number>', 'last', 'last-<number>'.
+      """
+
+
+# package name tests
+Scenario: history abcde
+ When I execute dnf with args "history abcde"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+
+Scenario: history filesystem
+ When I execute dnf with args "history filesystem"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 1  |         | Install | 6       |
+
+@not.with_os=rhel__eq__8
+Scenario: history lame (no transaction with such package)
+ When I execute dnf with args "history lame"
+ Then the exit code is 0
+  And stdout is
+      """
+      No transaction which manipulates package 'lame' was found.
+      """

--- a/dnf-behave-tests/features/history-view.feature
+++ b/dnf-behave-tests/features/history-view.feature
@@ -90,3 +90,24 @@ Scenario: History info of package
         | Return-Code   | Success                   |
         | Install       | abcde-2.9.2-1.fc29.noarch |
         | Removed       | abcde-2.9.2-1.fc29.noarch |
+
+
+@not.with_os=rhel__eq__8
+Scenario: history info aaa (nonexistent package)
+   When I execute dnf with args "history info aaa"
+   Then the exit code is 0
+    And stdout is
+        """
+        No transaction which manipulates package 'aaa' was found.
+        """
+
+
+@not.with_os=rhel__eq__8
+Scenario: history info aaa (nonexistent package)
+  Given I successfully execute dnf with args "install abcde"
+   When I execute dnf with args "history info aaa"
+   Then the exit code is 0
+    And stdout is
+        """
+        No transaction which manipulates package 'aaa' was found.
+        """

--- a/dnf-behave-tests/features/history-view.feature
+++ b/dnf-behave-tests/features/history-view.feature
@@ -1,4 +1,3 @@
-@global_dnf_context
 Feature: Transaction history userinstalled, list and info
 
 Background:
@@ -24,44 +23,10 @@ Scenario: List userinstalled packages
         | not match     | setup-2.12.1-1.fc29.noarch                |
         | not match     | filesystem-3.9-2.fc29.x86_64              |
 
-Scenario: History list range
-   When I execute dnf with args "install glibc"
-   Then the exit code is 0
-    And Transaction is following
-        | Action        | Package                                   |
-        | install       | glibc-0:2.28-9.fc29.x86_64                |
-        | install       | glibc-common-0:2.28-9.fc29.x86_64         |
-        | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-   When I execute dnf with args "remove setup"
-   Then the exit code is 0
-    And Transaction is following
-        | Action        | Package                                   |
-        | remove        | glibc-0:2.28-9.fc29.x86_64                |
-        | remove        | glibc-common-0:2.28-9.fc29.x86_64         |
-        | remove        | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-        | remove        | basesystem-0:11-6.fc29.noarch             |
-        | remove        | filesystem-0:3.9-2.fc29.x86_64            |
-        | remove        | setup-0:2.12.1-1.fc29.noarch              |
-    And History "list last-1..last" is following
-        | Id     | Command       | Action        | Altered   |
-        | 3      |               | Removed       | 6         |  
-        | 2      |               | Install       | 3         |  
-    And History "last" is following
-        | Id     | Command       | Action        | Altered   |
-        | 3      |               | Removed       | 6         |  
-
-
-Scenario: History list package
-   When I execute dnf with args "install setup"
-   Then the exit code is 0
-    And History "setup" is following
-        | Id     | Command       | Action        | Altered   |
-        | 4      |               | Install       |           |  
-        | 3      |               | Removed       |           |  
-        | 1      |               | Install       |           |  
-
 
 Scenario: History info
+  Given I successfully execute dnf with args "install abcde"
+   When I execute dnf with args "install setup"
    Then History info should match
         | Key           | Value                         |
         | Command Line  | install setup                 |
@@ -79,8 +44,9 @@ Scenario: History info
 
 
 Scenario: History info in range - transaction merging
-   When I execute dnf with args "install abcde"
-   Then the exit code is 0
+  Given I successfully execute dnf with args "install abcde"
+  Given I successfully execute dnf with args "remove abcde"
+  Given I successfully execute dnf with args "install abcde"
    When I use the repository "dnf-ci-fedora-updates"
     And I execute dnf with args "update"
    Then the exit code is 0
@@ -117,10 +83,10 @@ Scenario: History info in range - transaction merging
 
 
 Scenario: History info of package
+  Given I successfully execute dnf with args "install abcde"
+  Given I successfully execute dnf with args "remove abcde"
    Then History info "abcde" should match
         | Key           | Value                     |
         | Return-Code   | Success                   |
         | Install       | abcde-2.9.2-1.fc29.noarch |
         | Removed       | abcde-2.9.2-1.fc29.noarch |
-        | Upgraded      | abcde-2.9.2-1.fc29.noarch |
-        | Upgrade       | abcde-2.9.3-1.fc29.noarch |


### PR DESCRIPTION
Adds a new step to test the history list output, a comprehensive test suite for the `history list` command and a couple more tests for `history info` (for which it isn't so easy to test the output, the tests should be sufficient though).

The tests were written for https://github.com/rpm-software-management/dnf/pull/1481 and a few of them are fixed by it.