### PR TITLE
Improvements to handling reposync in `stdout is` step

### DIFF
--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -8,15 +8,10 @@ import re
 import sys
 from datetime import datetime
 
-PY3 = sys.version_info.major >= 3
-if PY3:
-    from itertools import zip_longest
-else:
-    from itertools import izip_longest as zip_longest
-
 import behave
 
 from common import *
+from common.string import print_lines_diff
 
 
 def print_cmd(context, cmd, stdout, stderr):
@@ -26,23 +21,6 @@ def print_cmd(context, cmd, stdout, stderr):
         print(context.cmd_stdout)
     if stderr:
         print(context.cmd_stderr, file=sys.stderr)
-
-
-def print_diff(expected, found, reposync_lines=0):
-    left_width = len("expected")
-
-    # calculate the width of the left column
-    for line in expected:
-        left_width = max(len(line), left_width)
-
-    print("{:{left_width}}  |  {}".format("expected", "found", left_width=left_width))
-
-    green, red, reset = "\033[1;32m", "\033[1;31m", "\033[0;0m"
-
-    for line in zip_longest(expected, found, fillvalue=""):
-        col = green if reposync_lines > 0 or line[0] == line[1] else red
-        print("{}{:{left_width}}  |  {}{}".format(col, line[0], line[1], reset, left_width=left_width))
-        reposync_lines -= 1
 
 
 @behave.step("I execute step \"{step}\"")
@@ -241,7 +219,7 @@ def then_stdout_is(context):
         expected = [""] * (i - 1) + expected
 
     print_cmd(context, True, True, False)
-    print_diff(expected, found, reposync_lines=i)
+    print_lines_diff(expected, found, num_lines_equal=i)
 
     raise AssertionError("Stdout is not: %s" % context.text)
 
@@ -303,7 +281,7 @@ def then_stderr_is(context):
         return
 
     print_cmd(context, True, False, True)
-    print_diff(expected, found)
+    print_lines_diff(expected, found)
 
     raise AssertionError("Stderr is not: %s" % context.text)
 

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -212,6 +212,9 @@ def then_stdout_is(context):
     expected = context.text.strip().split('\n')
     found = context.cmd_stdout.strip().split('\n')
 
+    if found == [""]:
+        found = []
+
     clean_expected, clean_found = handle_reposync(expected, found)
 
     if clean_expected == clean_found:

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -209,6 +209,12 @@ def then_stdout_is_empty(context):
 
 @behave.then("stdout is")
 def then_stdout_is(context):
+    """
+    Checks for the exact match of the test's stdout. Supports the <REPOSYNC>
+    placeholder on the first line, which will match against the repository
+    synchronization lines (i.e. the "Last metadata expiration check:" line as
+    well as the individual repo download lines) in the test's output.
+    """
     expected = context.text.strip().split('\n')
     found = context.cmd_stdout.strip().split('\n')
 

--- a/dnf-behave-tests/features/steps/common/string.py
+++ b/dnf-behave-tests/features/steps/common/string.py
@@ -5,6 +5,40 @@ from __future__ import print_function
 
 import re
 
+import sys
+PY3 = sys.version_info.major >= 3
+if PY3:
+    from itertools import zip_longest
+else:
+    from itertools import izip_longest as zip_longest
+
+
+def print_lines_diff(expected, found, num_lines_equal=0):
+    """ Prints a colored diff of two lists of strings.
+
+    Parameters:
+        expected: list of strings expected to find
+        found: list of strings found
+        num_lines_equal: a number that says how many strings at the beginning
+            treat as equal even if they differ; a hack for correctly diffing
+            outputs with repository syncing
+    """
+    left_width = len("expected")
+
+    # calculate the width of the left column
+    for line in expected:
+        left_width = max(len(line), left_width)
+
+    print("{:{left_width}}  |  {}".format("expected", "found", left_width=left_width))
+
+    green, red, reset = "\033[1;32m", "\033[1;31m", "\033[0;0m"
+
+    for line in zip_longest(expected, found, fillvalue=""):
+        col = green if num_lines_equal > 0 or line[0] == line[1] else red
+        print("{}{:{left_width}}  |  {}{}".format(col, line[0], line[1], reset, left_width=left_width))
+        num_lines_equal -= 1
+
+
 def extract_section_content_from_text(section_header, text):
     SECTION_HEADERS = [
             'Installing:', 'Upgrading:', 'Removing:', 'Downgrading:', 'Installing dependencies:',


### PR DESCRIPTION
Restructuring the code a bit for future reuse, fixing an issue with the diff for when the reposync didn't actually happen and adding some documentation.