### PR TITLE
Update tests for module provides searching in disabled modules

### DIFF
--- a/dnf-behave-tests/features/module-provides.feature
+++ b/dnf-behave-tests/features/module-provides.feature
@@ -10,7 +10,7 @@ Given I use the repository "dnf-ci-fedora-modular"
 Scenario: I can get list of all modules providing specific package
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
- Then stdout is
+  And stdout is
       """
       <REPOSYNC>
       nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
@@ -41,14 +41,10 @@ Scenario: I can get list of all modules providing specific package
 
 @bz1623866
 Scenario: I can get list of enabled modules providing specific package
- When I execute dnf with args "module enable nodejs:8"
- Then the exit code is 0
-  And modules state is following
-      | Module    | State     | Stream    | Profiles  |
-      | nodejs    | enabled   | 8         |           |
+Given I successfully execute dnf with args "module enable nodejs:8"
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
- Then stdout is
+  And stdout is
       """
       <REPOSYNC>
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
@@ -61,14 +57,10 @@ Scenario: I can get list of enabled modules providing specific package
 
 @bz1633151
 Scenario: I see packages only once when they are availiable and installed
- When I execute dnf with args "module enable nodejs:8"
+Given I successfully execute dnf with args "module enable nodejs:8"
+ When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
-  And modules state is following
-      | Module    | State     | Stream    | Profiles  |
-      | nodejs    | enabled   | 8         |           |
- Then I execute dnf with args "module provides nodejs-devel"
-  And the exit code is 0
- Then stdout is
+  And stdout is
       """
       <REPOSYNC>
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
@@ -77,14 +69,14 @@ Scenario: I see packages only once when they are availiable and installed
       Repo     : dnf-ci-fedora-modular
       Summary  : Javascript runtime
       """
- Then I execute dnf with args "module install nodejs:8/development"
-  And the exit code is 0
+ When I execute dnf with args "module install nodejs:8/development"
+ Then the exit code is 0
   And Transaction contains
       | Action                    | Package                                             |
       | install                   | nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64 |
       | module-profile-install    | nodejs/development                                  |
- Then I execute dnf with args "module provides nodejs-devel"
-  And the exit code is 0
+ When I execute dnf with args "module provides nodejs-devel"
+ Then the exit code is 0
   And stdout is
       """
       <REPOSYNC>
@@ -97,11 +89,10 @@ Scenario: I see packages only once when they are availiable and installed
 
 
 Scenario: There is not output when no module provides the package
- When I execute dnf with args "makecache"
- Then the exit code is 0
+Given I successfully execute dnf with args "makecache"
  When I execute dnf with args "module provides NoSuchPackage"
  Then the exit code is 0
- Then stdout is
+  And stdout is
       """
       <REPOSYNC>
       """

--- a/dnf-behave-tests/features/module-provides.feature
+++ b/dnf-behave-tests/features/module-provides.feature
@@ -10,28 +10,33 @@ Given I use the repository "dnf-ci-fedora-modular"
 Scenario: I can get list of all modules providing specific package
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
- Then stdout matches line by line
-   """
-   ?Last metadata expiration check
-   nodejs-devel-1:8.11.4-1.module_2030\+42747d40.x86_64
-   Module\s+:\s+nodejs:8
-   Profiles\s+:\s+development
-   Repo\s+:\s+dnf-ci-fedora-modular
-   Summary\s+:\s+Javascript runtime
+ Then stdout is
+      """
+      <REPOSYNC>
+      nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
+      Module   : nodejs:10:20180920144631:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
 
-   nodejs-devel-1:10.11.0-1.module_2200\+adbac02b.x86_64
-   Module\s+:\s+nodejs:10
-   Profiles\s+:\s+development
-   Repo\s+:\s+dnf-ci-fedora-modular
-   Summary\s+:\s+Javascript runtime
+      nodejs-devel-1:11.0.0-1.module_2311+8d497411.x86_64
+      Module   : nodejs:11:20180920144611:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
 
-   nodejs-devel-1:11.0.0-1.module_2311\+8d497411.x86_64
-   Module\s+:\s+nodejs:11
-   Profiles\s+:\s+development
-   Repo\s+:\s+dnf-ci-fedora-modular
-   Summary\s+:\s+Javascript runtime
+      nodejs-devel-1:5.3.1-1.module_2011+41787af0.x86_64
+      Module   : nodejs:5:20150811143428:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
 
-   """
+      nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
+      Module   : nodejs:8:20180801080000:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+      """
 
 
 @bz1623866
@@ -43,15 +48,15 @@ Scenario: I can get list of enabled modules providing specific package
       | nodejs    | enabled   | 8         |           |
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
- Then stdout matches line by line
-"""
-?Last metadata expiration check
-nodejs-devel-1:8.11.4-1.module_2030\+42747d40.x86_64
-Module\s+:\s+nodejs:8
-Profiles\s+:\s+development
-Repo\s+:\s+dnf-ci-fedora-modular
-Summary\s+:\s+Javascript runtime
-"""
+ Then stdout is
+      """
+      <REPOSYNC>
+      nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
+      Module   : nodejs:8:20180801080000:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+      """
 
 
 @bz1633151
@@ -63,15 +68,15 @@ Scenario: I see packages only once when they are availiable and installed
       | nodejs    | enabled   | 8         |           |
  Then I execute dnf with args "module provides nodejs-devel"
   And the exit code is 0
-  And stdout matches line by line
-"""
-?Last metadata expiration check
-nodejs-devel-1:8.11.4-1.module_2030\+42747d40.x86_64
-Module\s+:\s+nodejs:8
-Profiles\s+:\s+development
-Repo\s+:\s+dnf-ci-fedora-modular
-Summary\s+:\s+Javascript runtime
-"""
+ Then stdout is
+      """
+      <REPOSYNC>
+      nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
+      Module   : nodejs:8:20180801080000:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+      """
  Then I execute dnf with args "module install nodejs:8/development"
   And the exit code is 0
   And Transaction contains
@@ -80,15 +85,15 @@ Summary\s+:\s+Javascript runtime
       | module-profile-install    | nodejs/development                                  |
  Then I execute dnf with args "module provides nodejs-devel"
   And the exit code is 0
-  And stdout matches line by line
-"""
-?Last metadata expiration check
-nodejs-devel-1:8.11.4-1.module_2030\+42747d40.x86_64
-Module\s+:\s+nodejs:8
-Profiles\s+:\s+development
-Repo\s+:\s+dnf-ci-fedora-modular
-Summary\s+:\s+Javascript runtime
-"""
+  And stdout is
+      """
+      <REPOSYNC>
+      nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
+      Module   : nodejs:8:20180801080000:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+      """
 
 
 Scenario: There is not output when no module provides the package
@@ -96,18 +101,16 @@ Scenario: There is not output when no module provides the package
  Then the exit code is 0
  When I execute dnf with args "module provides NoSuchPackage"
  Then the exit code is 0
- Then stdout matches line by line
- """
- ?Last metadata expiration check
-
- """
+ Then stdout is
+      """
+      <REPOSYNC>
+      """
 
 
 Scenario: An error is printed when no arguments are provided
  When I execute dnf with args "module provides"
  Then the exit code is 1
   And stderr is
- """
- Error: dnf module provides: too few arguments
-
- """
+      """
+      Error: dnf module provides: too few arguments
+      """

--- a/dnf-behave-tests/features/module-provides.feature
+++ b/dnf-behave-tests/features/module-provides.feature
@@ -6,7 +6,8 @@ Given I use the repository "dnf-ci-fedora-modular"
   And I use the repository "dnf-ci-fedora"
 
 
-@xfail @bz1629667
+@bz1629667
+@not.with_os=rhel__eq__8
 Scenario: I can get list of all modules providing specific package
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
@@ -40,6 +41,7 @@ Scenario: I can get list of all modules providing specific package
 
 
 @bz1623866
+@not.with_os=rhel__eq__8
 Scenario: I can get list of enabled modules providing specific package
 Given I successfully execute dnf with args "module enable nodejs:8"
  When I execute dnf with args "module provides nodejs-devel"
@@ -47,6 +49,24 @@ Given I successfully execute dnf with args "module enable nodejs:8"
   And stdout is
       """
       <REPOSYNC>
+      nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
+      Module   : nodejs:10:20180920144631:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
+      nodejs-devel-1:11.0.0-1.module_2311+8d497411.x86_64
+      Module   : nodejs:11:20180920144611:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
+      nodejs-devel-1:5.3.1-1.module_2011+41787af0.x86_64
+      Module   : nodejs:5:20150811143428:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
       Module   : nodejs:8:20180801080000:6c81f848:x86_64
       Profiles : development
@@ -56,6 +76,7 @@ Given I successfully execute dnf with args "module enable nodejs:8"
 
 
 @bz1633151
+@not.with_os=rhel__eq__8
 Scenario: I see packages only once when they are availiable and installed
 Given I successfully execute dnf with args "module enable nodejs:8"
  When I execute dnf with args "module provides nodejs-devel"
@@ -63,6 +84,24 @@ Given I successfully execute dnf with args "module enable nodejs:8"
   And stdout is
       """
       <REPOSYNC>
+      nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
+      Module   : nodejs:10:20180920144631:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
+      nodejs-devel-1:11.0.0-1.module_2311+8d497411.x86_64
+      Module   : nodejs:11:20180920144611:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
+      nodejs-devel-1:5.3.1-1.module_2011+41787af0.x86_64
+      Module   : nodejs:5:20150811143428:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
       Module   : nodejs:8:20180801080000:6c81f848:x86_64
       Profiles : development
@@ -80,6 +119,24 @@ Given I successfully execute dnf with args "module enable nodejs:8"
   And stdout is
       """
       <REPOSYNC>
+      nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
+      Module   : nodejs:10:20180920144631:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
+      nodejs-devel-1:11.0.0-1.module_2311+8d497411.x86_64
+      Module   : nodejs:11:20180920144611:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
+      nodejs-devel-1:5.3.1-1.module_2011+41787af0.x86_64
+      Module   : nodejs:5:20150811143428:6c81f848:x86_64
+      Profiles : development
+      Repo     : dnf-ci-fedora-modular
+      Summary  : Javascript runtime
+
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
       Module   : nodejs:8:20180801080000:6c81f848:x86_64
       Profiles : development


### PR DESCRIPTION
Tests are for: https://github.com/rpm-software-management/dnf/pull/1483
Related: https://github.com/rpm-software-management/libdnf/pull/795

@j-mracek by making the searching in disabled modules default, all the different tests that enable the module etc. end up having the same output, so I'm not sure they are useful anymore.