### PR TITLE
Drop global context

### DIFF
--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -247,25 +247,20 @@ def before_scenario(context, scenario):
             context.config.userdata.get('destructive', 'no') == 'yes'):
         scenario.skip(reason="DESTRUCTIVE")
 
-    if not context.feature_global_dnf_context:
-        context.dnf = DNFContext(context.config.userdata,
-                                 force_installroot='force_installroot' in scenario.tags)
+    context.dnf = DNFContext(context.config.userdata,
+                             force_installroot='force_installroot' in scenario.tags)
 
 
 def after_scenario(context, scenario):
-    if not context.feature_global_dnf_context:
-        del context.dnf
+    del context.dnf
 
 
 def before_feature(context, feature):
-    context.feature_global_dnf_context = 'global_dnf_context' in feature.tags
-    if context.feature_global_dnf_context:
-        context.dnf = DNFContext(context.config.userdata)
+    pass
 
 
 def after_feature(context, feature):
-    if context.feature_global_dnf_context:
-        del context.dnf
+    pass
 
 
 def before_tag(context, tag):

--- a/dnf-behave-tests/features/history-undo.feature
+++ b/dnf-behave-tests/features/history-undo.feature
@@ -7,7 +7,7 @@ Scenario: Undoing transactions
   Given I successfully execute dnf with args "install filesystem"
    Then History is following
         | Id     | Command               | Action        | Altered   |
-        | 1      | install filesystem    | Install       | 2         |  
+        | 1      | install filesystem    | Install       | 2         |
    When I execute dnf with args "history undo last"
    Then the exit code is 0
     And Transaction is following
@@ -15,9 +15,9 @@ Scenario: Undoing transactions
         | remove        | setup-0:2.12.1-1.fc29.noarch               |
         | remove        | filesystem-0:3.9-2.fc29.x86_64             |
     And History is following
-        | Id     | Command       | Action        | Altered   |
-        | 2      |               | Removed       | 2         |  
-        | 1      |               | Install       | 2         |  
+        | Id     | Command               | Action        | Altered   |
+        | 2      |                       | Removed       | 2         |
+        | 1      |                       | Install       | 2         |
    When I execute dnf with args "history undo last"
    Then the exit code is 0
     And Transaction is following
@@ -25,10 +25,10 @@ Scenario: Undoing transactions
         | install       | setup-0:2.12.1-1.fc29.noarch               |
         | install       | filesystem-0:3.9-2.fc29.x86_64             |
     And History is following
-        | Id     | Command       | Action        | Altered   |
-        | 3      |               | Install       | 2         |  
-        | 2      |               | Removed       | 2         |  
-        | 1      |               | Install       | 2         |  
+        | Id     | Command               | Action        | Altered   |
+        | 3      |                       | Install       | 2         |
+        | 2      |                       | Removed       | 2         |
+        | 1      |                       | Install       | 2         |
    When I execute dnf with args "history undo last-2"
    Then the exit code is 0
     And Transaction is following
@@ -36,15 +36,15 @@ Scenario: Undoing transactions
         | remove        | setup-0:2.12.1-1.fc29.noarch               |
         | remove        | filesystem-0:3.9-2.fc29.x86_64             |
     And History is following
-        | Id     | Command       | Action        | Altered   |
-        | 4      |               | Removed       | 2         |  
-        | 3      |               | Install       | 2         |  
-        | 2      |               | Removed       | 2         |  
-        | 1      |               | Install       | 2         |  
+        | Id     | Command               | Action        | Altered   |
+        | 4      |                       | Removed       | 2         |
+        | 3      |                       | Install       | 2         |
+        | 2      |                       | Removed       | 2         |
+        | 1      |                       | Install       | 2         |
 
 @1627111
 Scenario: Handle missing packages required for undoing the transaction
-    When I execute dnf with args "install wget flac" 
+    When I execute dnf with args "install wget flac"
     Then the exit code is 0
      And Transaction is following
          | Action        | Package                      |
@@ -64,4 +64,3 @@ Scenario: Handle missing packages required for undoing the transaction
      And stderr contains "No package flac-1.3.2-8.fc29.x86_64 available."
      And stderr contains "No package wget-1.19.5-5.fc29.x86_64 available."
      And stderr contains "Error: no package matched"
-

--- a/dnf-behave-tests/features/history-undo.feature
+++ b/dnf-behave-tests/features/history-undo.feature
@@ -1,21 +1,13 @@
-@global_dnf_context
 Feature: Transaction history undo
 
 Background:
   Given I use the repository "dnf-ci-fedora"
 
-Scenario: History list of simple transaction
-   When I execute dnf with args "install filesystem"
-   Then the exit code is 0
-    And Transaction is following
-        | Action        | Package                                    |
-        | install       | setup-0:2.12.1-1.fc29.noarch               |
-        | install       | filesystem-0:3.9-2.fc29.x86_64             |
-    And History is following
+Scenario: Undoing transactions
+  Given I successfully execute dnf with args "install filesystem"
+   Then History is following
         | Id     | Command               | Action        | Altered   |
         | 1      | install filesystem    | Install       | 2         |  
-
-Scenario: Undo last transaction
    When I execute dnf with args "history undo last"
    Then the exit code is 0
     And Transaction is following
@@ -26,8 +18,6 @@ Scenario: Undo last transaction
         | Id     | Command       | Action        | Altered   |
         | 2      |               | Removed       | 2         |  
         | 1      |               | Install       | 2         |  
-
-Scenario: Undo last transaction again
    When I execute dnf with args "history undo last"
    Then the exit code is 0
     And Transaction is following
@@ -39,8 +29,6 @@ Scenario: Undo last transaction again
         | 3      |               | Install       | 2         |  
         | 2      |               | Removed       | 2         |  
         | 1      |               | Install       | 2         |  
-
-Scenario: Undo transaction last-2
    When I execute dnf with args "history undo last-2"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/history-update.feature
+++ b/dnf-behave-tests/features/history-update.feature
@@ -1,8 +1,9 @@
-@global_dnf_context
 Feature: History of update
 
-Scenario: History of update packages
+Background:
   Given I use the repository "dnf-ci-fedora"
+
+Scenario: History of update packages
    # `install setup` step added so that `install abcde` was not the first
    # transaction in history. Dnf due to some error is not able to
    # rollback the very first transaction.
@@ -29,14 +30,17 @@ Scenario: History of update packages
         | upgrade       | abcde-0:2.9.3-1.fc29.noarch               |
     And History is following
         | Id     | Command               | Action        | Altered   |
-        | 3      | update                | Upgrade       | 3         |  
-        | 2      |                       | Install       | 3         |  
-        | 1      |                       | Install       | 1         |  
+        | 3      | update                | Upgrade       | 3         |
+        | 2      |                       | Install       | 3         |
+        | 1      |                       | Install       | 1         |
 
 
 @bz1612885
 Scenario: Rollback update
-  Given I use the repository "dnf-ci-fedora"
+  Given I successfully execute dnf with args "install setup"
+    And I execute dnf with args "install abcde"
+    And I use the repository "dnf-ci-fedora-updates"
+    And I successfully execute dnf with args "update"
    When I execute dnf with args "history rollback last-1"
    Then the exit code is 0
    Then stderr does not contain "Traceback"

--- a/dnf-behave-tests/features/installonly.feature
+++ b/dnf-behave-tests/features/installonly.feature
@@ -1,21 +1,18 @@
-@global_dnf_context
 Feature: Test upgrading installonly packages
 
 
 Background:
   Given I use the repository "dnf-ci-fedora"
-    And I set config option "installonly_limit" to "2"
 
 
-Scenario: Setup (install the first installonly package)
+@bz1668256 @bz1616191 @bz1639429
+Scenario: Install multiple versions of an installonly package with a limit of 2
+  Given I set config option "installonly_limit" to "2"
    When I execute dnf with args "install kernel-core"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                               |
         | install       | kernel-core-0:4.18.16-300.fc29.x86_64 |
-
-
-Scenario: run `dnf upgrade` when installonly_limit not reached
   Given I use the repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade"
    Then the exit code is 0
@@ -23,20 +20,11 @@ Scenario: run `dnf upgrade` when installonly_limit not reached
         | Action        | Package                               |
         | install       | kernel-core-0:4.19.15-300.fc29.x86_64 |
         | unchanged     | kernel-core-0:4.18.16-300.fc29.x86_64 |
-
-
-@bz1668256 @bz1616191 @bz1639429
-Scenario: run 'dnf upgrade kernel-core' when there are no installonly upgrades available (installonly_limit reached)
-  Given I use the repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade kernel-core"
    Then the exit code is 0
    Then stderr does not contain "cannot install both"
     And Transaction is empty
-
-
-Scenario: run `dnf upgrade` when installonly_limit reached
-  Given I use the repository "dnf-ci-fedora-updates"
-    And I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use the repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "upgrade"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/module-install-package-ursine.feature
+++ b/dnf-behave-tests/features/module-install-package-ursine.feature
@@ -1,4 +1,3 @@
-@global_dnf_context
 Feature: Installing package from ursine repo
 
 Background: Enable repositories
@@ -16,6 +15,7 @@ Scenario: I can install a package from ursine repo when the same pkg is availabl
 
 
 Scenario: I can see installed non-modular content listed in dnf list installed
+  Given I successfully execute dnf with args "install wget"
    When I execute dnf with args "list --installed"
    Then the exit code is 0
     And stdout contains "wget\.x86_64\s+1\.19\.5-5\.fc29\s+@dnf-ci-fedora"
@@ -27,12 +27,16 @@ Scenario: I can see installed non-modular content listed in dnf list installed
 
 
 Scenario: I can't reinstall installed non-modular content which is masked by active modular content
+  Given I successfully execute dnf with args "install wget"
+    And I successfully execute dnf with args "module enable DnfCiModuleNoDefaults:stable"
    When I execute dnf with args "reinstall wget"
    Then the exit code is 1
     And stdout contains "Installed package wget-1.19.5-5.fc29.x86_64 \(from dnf-ci-fedora\) not available."
 
- 
+
 Scenario: I can remove installed non-modular content
+  Given I successfully execute dnf with args "install wget"
+    And I successfully execute dnf with args "module enable DnfCiModuleNoDefaults:stable"
    When I execute dnf with args "remove wget"
    Then the exit code is 0
     And Transaction contains
@@ -40,7 +44,8 @@ Scenario: I can remove installed non-modular content
         | remove                | wget-0:1.19.5-5.fc29.x86_64                       |
 
 
-Scenario: I can't install a package from ursine repo when the same pkg is available in enabled non-default module stream 
+Scenario: I can't install a package from ursine repo when the same pkg is available in enabled non-default module stream
+  Given I successfully execute dnf with args "module enable DnfCiModuleNoDefaults:stable"
    When I execute dnf with args "install wget"
    Then the exit code is 0
     And Transaction contains
@@ -49,10 +54,7 @@ Scenario: I can't install a package from ursine repo when the same pkg is availa
 
 
 Scenario: I can install a package from ursine repo when the same pkg is available in disabled non-default module stream
-   # cleanup from previous scenario
-   When I execute dnf with args "remove wget"
-   Then the exit code is 0
-   When I execute dnf with args "module disable DnfCiModuleNoDefaults:stable"
+  Given I successfully execute dnf with args "module disable DnfCiModuleNoDefaults:stable"
    When I execute dnf with args "install wget"
    Then the exit code is 0
     And Transaction contains
@@ -61,8 +63,8 @@ Scenario: I can install a package from ursine repo when the same pkg is availabl
 
 
 Scenario: I can upgrade installed non-modular pkg by active modular content
-   When I execute dnf with args "module enable DnfCiModuleNoDefaults:development"
-   Then the exit code is 0
+  Given I successfully execute dnf with args "install wget"
+    And I successfully execute dnf with args "module enable DnfCiModuleNoDefaults:development"
    When I execute dnf with args "upgrade wget"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/module-list.feature
+++ b/dnf-behave-tests/features/module-list.feature
@@ -1,20 +1,15 @@
-@global_dnf_context
 Feature: Modules listing
 
 Background:
   Given I use the repository "dnf-ci-fedora-modular"
     And I use the repository "dnf-ci-fedora-modular-updates"
     And I use the repository "dnf-ci-fedora"
+    And I successfully execute dnf with args "module enable nodejs:8"
+    And I successfully execute dnf with args "module install nodejs:8/minimal"
+    And I successfully execute dnf with args "module enable postgresql:11"
+    And I successfully execute dnf with args "module install postgresql:11/client"
 
 Scenario: I can list all available modules
-   When I execute dnf with args "module enable nodejs:8"
-   Then the exit code is 0
-   When I execute dnf with args "module install nodejs:8/minimal"
-   Then the exit code is 0
-   When I execute dnf with args "module enable postgresql:11"
-   Then the exit code is 0
-   When I execute dnf with args "module install postgresql:11/client"
-   Then the exit code is 0
    When I execute dnf with args "module list"
    Then the exit code is 0
     And stdout contains "Javascript runtime"
@@ -98,8 +93,7 @@ Scenario: Get error message when list of non-existent module is requested
     And stderr contains "Error: No matching Modules to list"
 
 Scenario: I can list disabled modules
-   When I execute dnf with args "module disable postgresql"
-   Then the exit code is 0
+  Given I successfully execute dnf with args "module disable postgresql"
    When I execute dnf with args "module list --disabled"
    Then the exit code is 0
     And module list is
@@ -145,6 +139,7 @@ Scenario: I can limit the scope of installed modules through providing specific 
 
 
 Scenario: I can limit the scope of disabled modules through providing specific module names
+  Given I successfully execute dnf with args "module disable postgresql"
    When I execute dnf with args "module list --disabled postgresql nodejs"
    Then the exit code is 0
     And module list is


### PR DESCRIPTION
Removes global context from the feature files and then also from `environment.py`.

The global context makes scenarios not be independent and in effect be just a single scenario. The only benefit then is that there is explicit description (name) of each "subscenario". OTOH it makes the scenarios harder to edit, because you are modifying everything that follows.

Maintaining independent test cases is one of basic principles for writing tests.

depends on https://github.com/rpm-software-management/ci-dnf-stack/pull/627, which drops `global_dnf_context` from `history-view.feature`.