### PR TITLE
Download tests are run in temp directory

### DIFF
--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -115,6 +115,7 @@ class DNFContext(object):
         self.disable_plugins = True
         self.disable_repos_option = "--disablerepo='*'"
         self.assumeyes_option = "-y"
+        self.working_dir = None
 
         # temporarily use DNF0 for substituting fixturesdir in repo files
         # the future could be in named environment variable like DNF_VAR_FIXTURES_DIR

--- a/dnf-behave-tests/features/install-path.feature
+++ b/dnf-behave-tests/features/install-path.feature
@@ -2,7 +2,8 @@ Feature: Tests for installing RPM from paths
 
 
 Scenario Outline: I can install an RPM from path, where path is <path type>
-   When I execute dnf with args "install <path>" from repo "dnf-ci-fedora"
+  Given I set working directory to "{context.dnf.fixturesdir}/repos/dnf-ci-fedora"
+   When I execute dnf with args "install <path>"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
@@ -17,7 +18,7 @@ Examples:
 
 
 Scenario: I can install an RPM from path, when specifying the RPM multiple times
-   When I execute dnf with args "install noarch/setup-2.12.1-1.fc29.noarch.rpm noarch/setup-2.12.1-1.fc29.noarch.rpm" from repo "dnf-ci-fedora"
+   When I execute dnf with args "install {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
@@ -26,7 +27,8 @@ Scenario: I can install an RPM from path, when specifying the RPM multiple times
 
 @xfail
 Scenario: I can install an RPM from path, when specifying the RPM multiple times using different paths
-   When I execute dnf with args "install noarch/setup-2.12.1-1.fc29.noarch.rpm {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm" from repo "dnf-ci-fedora"
+  Given I set working directory to "{context.dnf.fixturesdir}/repos/dnf-ci-fedora"
+   When I execute dnf with args "install noarch/setup-2.12.1-1.fc29.noarch.rpm {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |

--- a/dnf-behave-tests/features/plugins-core/download-binary.feature
+++ b/dnf-behave-tests/features/plugins-core/download-binary.feature
@@ -5,6 +5,7 @@ Feature: dnf download command
 Background:
   Given I enable plugin "download"
     And I use the http repository based on "dnf-ci-fedora"
+    And I set working directory to "{context.dnf.tempdir}"
 
 
 Scenario: Download an RPM that doesn't exist
@@ -18,8 +19,8 @@ Scenario: Download an existing RPM
    Then the exit code is 0
     And stdout contains "setup-2.12.1-1.fc29.noarch.rpm"
     And file sha256 checksums are following
-        | Path                                  | sha256                                                                                        |
-        | setup-2.12.1-1.fc29.noarch.rpm        | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
+        | Path                                                  | sha256                                                                                        |
+        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm  | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
 
 
 Scenario: Download an existing RPM with --verbose option
@@ -27,8 +28,8 @@ Scenario: Download an existing RPM with --verbose option
    Then the exit code is 0
     And stdout contains "setup-2.12.1-1.fc29.noarch.rpm"
     And file sha256 checksums are following
-        | Path                                  | sha256                                                                                        |
-        | setup-2.12.1-1.fc29.noarch.rpm        | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
+        | Path                                                  | sha256                                                                                        |
+        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm  | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
 
 
 Scenario: Download an existing RPM with dependencies
@@ -37,20 +38,20 @@ Scenario: Download an existing RPM with dependencies
     And stdout contains "filesystem-3.9-2.fc29.x86_64.rpm"
     And stdout contains "setup-2.12.1-1.fc29.noarch.rpm"
     And file sha256 checksums are following
-        | Path                                  | sha256                                                                                        |
-        | filesystem-3.9-2.fc29.x86_64.rpm      | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm  |
-        | setup-2.12.1-1.fc29.noarch.rpm        | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
+        | Path                                                      | sha256                                                                                        |
+        | {context.dnf.tempdir}/filesystem-3.9-2.fc29.x86_64.rpm    | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm  |
+        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm      | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
 
 
 Scenario: Download an existing RPM with dependencies into a --destdir
-   When I execute dnf with args "download filesystem --resolve --destdir={context.dnf.tempdir}"
+   When I execute dnf with args "download filesystem --resolve --destdir={context.dnf.tempdir}/downloaddir"
    Then the exit code is 0
     And stdout contains "filesystem-3.9-2.fc29.x86_64.rpm"
     And stdout contains "setup-2.12.1-1.fc29.noarch.rpm"
     And file sha256 checksums are following
-        | Path                                                          | sha256                                                                                        |
-        | {context.dnf.tempdir}/filesystem-3.9-2.fc29.x86_64.rpm        | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm  |
-        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm          | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
+        | Path                                                                  | sha256                                                                                        |
+        | {context.dnf.tempdir}/downloaddir/filesystem-3.9-2.fc29.x86_64.rpm    | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm  |
+        | {context.dnf.tempdir}/downloaddir/setup-2.12.1-1.fc29.noarch.rpm      | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
 
 
 Scenario: Download an existing RPM with dependencies into a --destdir where a dependency is installed
@@ -59,16 +60,16 @@ Scenario: Download an existing RPM with dependencies into a --destdir where a de
     And Transaction is following
         | Action        | Package                               |
         | install       | setup-0:2.12.1-1.fc29.noarch          |
-   When I execute dnf with args "download basesystem --resolve --destdir={context.dnf.tempdir}"
+   When I execute dnf with args "download basesystem --resolve --destdir={context.dnf.tempdir}/downloaddir"
    Then the exit code is 0
     And stdout contains "basesystem-11-6.fc29.noarch.rpm"
     And stdout contains "filesystem-3.9-2.fc29.x86_64.rpm"
     And stdout does not contain "setup-2.12.1-1.fc29.noarch.rpm"
     And file sha256 checksums are following
-        | Path                                                          | sha256                                                                                        |
-        | {context.dnf.tempdir}/basesystem-11-6.fc29.noarch.rpm         | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/basesystem-11-6.fc29.noarch.rpm   |
-        | {context.dnf.tempdir}/filesystem-3.9-2.fc29.x86_64.rpm        | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm  |
-        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm          | -                                                                                             |
+        | Path                                                                  | sha256                                                                                        |
+        | {context.dnf.tempdir}/downloaddir/basesystem-11-6.fc29.noarch.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/basesystem-11-6.fc29.noarch.rpm   |
+        | {context.dnf.tempdir}/downloaddir/filesystem-3.9-2.fc29.x86_64.rpm    | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm  |
+        | {context.dnf.tempdir}/downloaddir/setup-2.12.1-1.fc29.noarch.rpm      | -                                                                                             |
 
 
 Scenario: Download an existing RPM with dependencies into a --destdir where all packages are already installed
@@ -79,16 +80,16 @@ Scenario: Download an existing RPM with dependencies into a --destdir where all 
         | install       | basesystem-0:11-6.fc29.noarch         |
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install       | setup-0:2.12.1-1.fc29.noarch          |
-   When I execute dnf with args "download basesystem --resolve --destdir={context.dnf.tempdir}"
+   When I execute dnf with args "download basesystem --resolve --destdir={context.dnf.tempdir}/downloaddir"
    Then the exit code is 0
     And stdout contains "basesystem-11-6.fc29.noarch.rpm"
     And stdout does not contain "filesystem-3.9-2.fc29.x86_64.rpm"
     And stdout does not contain "setup-2.12.1-1.fc29.noarch.rpm"
     And file sha256 checksums are following
-        | Path                                                          | sha256                                                                                        |
-        | {context.dnf.tempdir}/basesystem-11-6.fc29.noarch.rpm         | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/basesystem-11-6.fc29.noarch.rpm   |
-        | {context.dnf.tempdir}/filesystem-3.9-2.fc29.x86_64.rpm        | -                                                                                             |
-        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm          | -                                                                                             |
+        | Path                                                                  | sha256                                                                                        |
+        | {context.dnf.tempdir}/downloaddir/basesystem-11-6.fc29.noarch.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/basesystem-11-6.fc29.noarch.rpm   |
+        | {context.dnf.tempdir}/downloaddir/filesystem-3.9-2.fc29.x86_64.rpm    | -                                                                                             |
+        | {context.dnf.tempdir}/downloaddir/setup-2.12.1-1.fc29.noarch.rpm      | -                                                                                             |
 
 Scenario: Download an existing RPM when there are multiple packages of the same NEVRA
   Given I use the http repository based on "dnf-ci-gpg"

--- a/dnf-behave-tests/features/plugins-core/download-debuginfo.feature
+++ b/dnf-behave-tests/features/plugins-core/download-debuginfo.feature
@@ -4,6 +4,7 @@ Feature: dnf download --debuginfo command
 
 Background:
   Given I enable plugin "download"
+    And I set working directory to "{context.dnf.tempdir}"
 
 
 Scenario: Download a debuginfo for an RPM that doesn't exist
@@ -19,8 +20,8 @@ Scenario: Download a debuginfo for an existing RPM
    Then the exit code is 0
     And stdout contains "libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm"
     And file sha256 checksums are following
-        | Path                                          | sha256                                                                                                        |
-        | libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm |
+        | Path                                                              | sha256                                                                                                        |
+        | {context.dnf.tempdir}/libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm   | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm |
 
 
 Scenario: Download a debuginfo for an existing RPM with a different name
@@ -30,9 +31,9 @@ Scenario: Download a debuginfo for an existing RPM with a different name
     And stdout contains "glibc-debuginfo-2.28-9.fc29.x86_64.rpm"
     And stdout does not contain "glibc-debuginfo-common-2.28-9.fc29.x86_64.rpm"
     And file sha256 checksums are following
-        | Path                                          | sha256                                                                                                |
-        | glibc-debuginfo-2.28-9.fc29.x86_64.rpm        | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/glibc-debuginfo-2.28-9.fc29.x86_64.rpm    |
-        | glibc-debuginfo-common-2.28-9.fc29.x86_64.rpm | -                                                                                                     |
+        | Path                                                                  | sha256                                                                                                |
+        | {context.dnf.tempdir}/glibc-debuginfo-2.28-9.fc29.x86_64.rpm          | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/glibc-debuginfo-2.28-9.fc29.x86_64.rpm    |
+        | {context.dnf.tempdir}/glibc-debuginfo-common-2.28-9.fc29.x86_64.rpm   | -                                                                                                     |
 
 # TODO: glibc-debuginfo-common should be ideally downloaded as well
 
@@ -43,5 +44,5 @@ Scenario: Download an existing --debuginfo RPM with --verbose option
    Then the exit code is 0
     And stdout contains "libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm"
     And file sha256 checksums are following
-        | Path                                          | sha256                                                                                                        |
-        | libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm |
+        | Path                                                              | sha256                                                                                                        |
+        | {context.dnf.tempdir}/libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm   | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm |

--- a/dnf-behave-tests/features/plugins-core/download-source.feature
+++ b/dnf-behave-tests/features/plugins-core/download-source.feature
@@ -5,6 +5,7 @@ Feature: dnf download --source command
 Background:
   Given I enable plugin "download"
     And I use the http repository based on "dnf-ci-fedora"
+    And I set working directory to "{context.dnf.tempdir}"
 
 
 Scenario: Download a source for an RPM that doesn't exist
@@ -18,8 +19,8 @@ Scenario: Download a source for an existing RPM
    Then the exit code is 0
     And stdout contains "setup-2.12.1-1.fc29.src.rpm"
     And file sha256 checksums are following
-        | Path                                  | sha256                                                                                |
-        | setup-2.12.1-1.fc29.src.rpm           | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
+        | Path                                              | sha256                                                                                |
+        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.src.rpm | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
 
 
 Scenario: Download a source for an existing RPM with a different name
@@ -27,8 +28,8 @@ Scenario: Download a source for an existing RPM with a different name
    Then the exit code is 0
     And stdout contains "glibc-2.28-9.fc29.src.rpm"
     And file sha256 checksums are following
-        | Path                                  | sha256                                                                                |
-        | glibc-2.28-9.fc29.src.rpm             | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/glibc-2.28-9.fc29.src.rpm    |
+        | Path                                              | sha256                                                                                |
+        | {context.dnf.tempdir}/glibc-2.28-9.fc29.src.rpm   | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/glibc-2.28-9.fc29.src.rpm    |
 
 
 Scenario: Download an existing --source RPM with --verbose option
@@ -36,26 +37,26 @@ Scenario: Download an existing --source RPM with --verbose option
    Then the exit code is 0
     And stdout contains "setup-2.12.1-1.fc29.src.rpm"
     And file sha256 checksums are following
-        | Path                                  | sha256                                                                |
-        | setup-2.12.1-1.fc29.src.rpm           | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
+        | Path                                              | sha256                                                                |
+        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.src.rpm | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
 
 
 @bz1649627
 Scenario: Download a specified source rpm
-   When I execute dnf with args "download --destdir={context.dnf.tempdir} --source setup-2.12.1-1.fc29.src"
+   When I execute dnf with args "download --destdir={context.dnf.tempdir}/downloaddir --source setup-2.12.1-1.fc29.src"
    Then the exit code is 0
     And stdout contains "setup-2.12.1-1.fc29.src.rpm"
     And stdout does not contain "setup-2.12.1-1.fc29.noarch.rpm"
     And file sha256 checksums are following
-        | Path                                                  | sha256                                                                                |
-        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.src.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
-        | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm  | -                                                                                     |
+        | Path                                                              | sha256                                                                                |
+        | {context.dnf.tempdir}/downloaddir/setup-2.12.1-1.fc29.src.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
+        | {context.dnf.tempdir}/downloaddir/setup-2.12.1-1.fc29.noarch.rpm  | -                                                                                     |
 
 
 @bz1649627
 Scenario Outline: Download a source RPM when there are more versions available
   Given I use the http repository based on "dnf-ci-fedora-updates-testing"
-   When I execute dnf with args "download --destdir={context.dnf.tempdir} --source <pkgspec>"
+   When I execute dnf with args "download --source <pkgspec>"
    Then the exit code is 0
     And stdout contains "<srpm>"
     And file sha256 checksums are following
@@ -76,7 +77,7 @@ Examples:
 @xfail
 Scenario Outline: Download a source RPM when there are more epochs available
   Given I use the http repository based on "dnf-ci-fedora-updates-testing"
-   When I execute dnf with args "download --destdir={context.dnf.tempdir} --source <pkgspec>"
+   When I execute dnf with args "download --source <pkgspec>"
    Then the exit code is 0
     And stdout contains "<srpm>"
     And file sha256 checksums are following

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -77,18 +77,6 @@ def faketime_today(context, when):
     context.execute_steps('when I move the clock backward to "{}"'.format(when))
 
 
-@behave.step("I execute dnf with args \"{args}\" from repo \"{repo}\"")
-def when_I_execute_dnf_with_args_from_repo(context, repo, args):
-    repodir = os.path.join(context.dnf.repos_location, repo)
-
-    cmd = " ".join(context.dnf.get_cmd(context))
-    cmd += " " + args.format(context=context)
-    context.dnf["rpmdb_pre"] = get_rpmdb_rpms(context.dnf.installroot)
-    context.cmd = cmd
-    context.cmd_exitcode, context.cmd_stdout, context.cmd_stderr = run(
-        cmd, shell=True, cwd=repodir)
-
-
 @behave.step("I execute dnf with args \"{args}\"")
 def when_I_execute_dnf_with_args(context, args):
     cmd = " ".join(context.dnf.get_cmd(context))

--- a/dnf-behave-tests/features/upgrade-from-path.feature
+++ b/dnf-behave-tests/features/upgrade-from-path.feature
@@ -28,7 +28,8 @@ Scenario: Upgrade an RPM from absolute path on disk
 
 
 Scenario: Upgrade an RPM from relative path on disk
-   When I execute dnf with args "upgrade x86_64/glibc-2.28-26.fc29.x86_64.rpm x86_64/glibc-common-2.28-26.fc29.x86_64.rpm x86_64/glibc-all-langpacks-2.28-26.fc29.x86_64.rpm" from repo "dnf-ci-fedora-updates"
+  Given I set working directory to "{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates"
+   When I execute dnf with args "upgrade x86_64/glibc-2.28-26.fc29.x86_64.rpm x86_64/glibc-common-2.28-26.fc29.x86_64.rpm x86_64/glibc-all-langpacks-2.28-26.fc29.x86_64.rpm"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
@@ -39,7 +40,7 @@ Scenario: Upgrade an RPM from relative path on disk
 
 Scenario: Upgrade an RPM from path on disk containing wildcards
   Given I use the repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "upgrade x86_64/glibc*" from repo "dnf-ci-fedora-updates"
+   When I execute dnf with args "upgrade {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/glibc*"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
@@ -49,7 +50,7 @@ Scenario: Upgrade an RPM from path on disk containing wildcards
 
 
 Scenario: Upgrade an RPM from path on disk, when specifying the RPM multiple times
-   When I execute dnf with args "upgrade x86_64/wget-1.19.6-5.fc29.x86_64.rpm x86_64/wget-1.19.6-5.fc29.x86_64.rpm" from repo "dnf-ci-fedora-updates"
+   When I execute dnf with args "upgrade {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |


### PR DESCRIPTION
Download tests used to download files into directory from where the behave was run.
This PR adds step to change working directory and use it in download tests. Also step for running dnf in repository directory was replaced by setting working directory.