### PR TITLE
Debug output enhancement and some cleanups

### DIFF
--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -276,7 +276,24 @@ def before_scenario(context, scenario):
 
 
 def after_scenario(context, scenario):
-    context.dnf.scenario_failed = scenario.status == model.Status.failed
+    if scenario.status == model.Status.failed:
+        context.dnf.scenario_failed = True
+
+        if getattr(context, "cmd", ""):
+            print(
+                "%sLast Command: %sDNF0=%s %s" %
+                (escapes["failed"], escapes["failed_arg"], context.dnf.fixturesdir, context.cmd)
+            )
+            print(escapes["reset"])
+        if getattr(context, "cmd_stdout", ""):
+            print("%sLast Command stdout:%s" % (escapes['outline_arg'], escapes['executing']))
+            print(context.cmd_stdout.strip())
+            print(escapes["reset"])
+        if getattr(context, "cmd_stderr", ""):
+            print("%sLast Command stderr:%s" % (escapes['outline_arg'], escapes['executing']))
+            print(context.cmd_stderr.strip())
+            print(escapes["reset"])
+
     del context.dnf
 
 

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -161,7 +161,7 @@ class DNFContext(object):
     def __contains__(self, name):
         return name in self._scenario_data
 
-    def _get(self, context, name):
+    def _get(self, name):
         if name in self:
             return self[name]
         return getattr(self, name, None)
@@ -177,35 +177,35 @@ class DNFContext(object):
         if self.installroot:
             result.append("--installroot={0}".format(self.installroot))
 
-        config = self._get(context, "config")
+        config = self._get("config")
         if config:
             result.append("--config={0}".format(config))
 
-        reposdir = self._get(context, "reposdir")
+        reposdir = self._get("reposdir")
         if reposdir:
             result.append("--setopt=reposdir={0}".format(reposdir))
 
-        releasever = self._get(context, "releasever")
+        releasever = self._get("releasever")
         if releasever:
             result.append("--releasever={0}".format(releasever))
 
-        module_platform_id = self._get(context, "module_platform_id")
+        module_platform_id = self._get("module_platform_id")
         if module_platform_id:
             result.append("--setopt=module_platform_id={0}".format(module_platform_id))
 
         result.append(self.disable_repos_option)
-        repos = self._get(context, "repos") or []
+        repos = self._get("repos") or []
         for repo in repos:
             result.append("--enablerepo='{0}'".format(repo))
 
-        disable_plugins = self._get(context, "disable_plugins")
+        disable_plugins = self._get("disable_plugins")
         if disable_plugins:
             result.append("--disableplugin='*'")
-        plugins = self._get(context, "plugins") or []
+        plugins = self._get("plugins") or []
         for plugin in plugins:
             result.append("--enableplugin='{0}'".format(plugin))
 
-        setopts = self._get(context, "setopts") or {}
+        setopts = self._get("setopts") or {}
         for key,value in setopts.items():
             result.append("--setopt={0}={1}".format(key, value))
 

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -31,15 +31,6 @@ def handle_reposync(expected, found):
     return expected, found
 
 
-def run_in_context(context, cmd, **run_args):
-    if getattr(context, "faketime", None) is not None:
-        cmd = context.faketime + cmd
-    context.cmd = cmd
-    if context.dnf.working_dir and 'cwd' not in run_args:
-        run_args['cwd'] = context.dnf.working_dir
-    context.cmd_exitcode, context.cmd_stdout, context.cmd_stderr = run(cmd, **run_args)
-
-
 @behave.step("I execute step \"{step}\"")
 def execute_step(context, step):
     context.execute_steps(step)
@@ -73,7 +64,7 @@ def when_I_execute_dnf_with_args(context, args):
     cmd = " ".join(context.dnf.get_cmd(context))
     cmd += " " + args.format(context=context)
     context.dnf["rpmdb_pre"] = get_rpmdb_rpms(context.dnf.installroot)
-    run_in_context(context, cmd, shell=True)
+    run_in_context(context, cmd, can_fail=True)
 
 
 @behave.step("I execute dnf with args \"{args}\" {times} times")
@@ -86,30 +77,24 @@ def when_I_execute_dnf_with_args_times(context, args, times):
 def when_I_execute_rpm_with_args(context, args):
     cmd = "rpm --root=" + context.dnf.installroot
     cmd += " " + args.format(context=context)
-    run_in_context(context, cmd, shell=True)
+    run_in_context(context, cmd, can_fail=True)
 
 
 @behave.step("I execute rpm on host with args \"{args}\"")
 def when_I_execute_rpm_on_host_with_args(context, args):
     cmd = "rpm"
     cmd += " " + args.format(context=context)
-    run_in_context(context, cmd, shell=True)
+    run_in_context(context, cmd, can_fail=True)
 
 
 @behave.step("I execute \"{command}\" in \"{directory}\"")
 def when_I_execute_command_in_directory(context, command, directory):
-    run_in_context(
-        context,
-        command.format(context=context),
-        cwd=directory.format(context=context),
-        shell=True,
-        can_fail=False
-    )
+    run_in_context(context, command.format(context=context), cwd=directory.format(context=context))
 
 
 @behave.step("I execute \"{command}\"")
 def when_I_execute_command(context, command):
-    run_in_context(context, command.format(context=context), shell=True, can_fail=False)
+    run_in_context(context, command.format(context=context))
 
 
 @behave.given("I do not disable all repos")

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -14,15 +14,6 @@ from common import *
 from common.string import print_lines_diff
 
 
-def print_cmd(context, cmd, stdout, stderr):
-    if cmd:
-        print('Command: DNF0={} {}\n'.format(context.dnf.fixturesdir, context.cmd))
-    if stdout:
-        print(context.cmd_stdout)
-    if stderr:
-        print(context.cmd_stderr, file=sys.stderr)
-
-
 def handle_reposync(expected, found):
     if expected[0] == "<REPOSYNC>":
         sync_line = re.compile(r".*[0-9.]+ +[kMG]?B/s \| +[0-9.]+ +[kMG]?B +[0-9]{2}:[0-9]{2}")
@@ -188,7 +179,6 @@ def step_impl(context, option, value):
 def then_the_exit_code_is(context, exitcode):
     if context.cmd_exitcode == int(exitcode):
         return
-    print_cmd(context, True, True, True)
     raise AssertionError("Command has returned exit code {0}: {1}".format(context.cmd_exitcode, context.cmd))
 
 
@@ -196,14 +186,12 @@ def then_the_exit_code_is(context, exitcode):
 def then_stdout_contains(context, text):
     if re.search(text, context.cmd_stdout):
         return
-    print_cmd(context, True, True, False)
     raise AssertionError("Stdout doesn't contain: %s" % text)
 
 @behave.then("stdout does not contain \"{text}\"")
 def then_stdout_does_not_contain(context, text):
     if not re.search(text, context.cmd_stdout):
         return
-    print_cmd(context, True, True, False)
     raise AssertionError("Stdout contains: %s" % text)
 
 
@@ -211,7 +199,6 @@ def then_stdout_does_not_contain(context, text):
 def then_stdout_is_empty(context):
     if not context.cmd_stdout:
         return
-    print_cmd(context, True, True, False)
     raise AssertionError("Stdout is not empty, it contains: %s" % context.cmd_stdout)
 
 
@@ -247,7 +234,6 @@ def then_stdout_is(context):
             # lines in found
             expected = [""] * (rs_offset - 1) + expected
 
-    print_cmd(context, True, True, False)
     print_lines_diff(expected, found, num_lines_equal=rs_offset)
 
     raise AssertionError("Stdout is not: %s" % context.text)
@@ -262,7 +248,6 @@ def then_stdout_contains_lines(context):
             if line == outline:
                 break
         else:
-            print_cmd(context, True, True, False)
             raise AssertionError("Stdout doesn't contain line: %s" % line)
 
 
@@ -273,7 +258,6 @@ def then_stdout_contains_lines(context):
     for line in test_lines:
         for outline in out_lines:
             if line == outline:
-                print_cmd(context, True, True, False)
                 raise AssertionError("Stdout contains line: %s" % line)
 
 
@@ -283,7 +267,6 @@ def then_stdout_section_contains(context, section, regexp):
     section_content = extract_section_content_from_text(section, context.cmd_stdout)
     if re.search(regexp, section_content):
         return
-    print_cmd(context, True, True, False)
     raise AssertionError("Stdout section %s doesn't contain: %s" % (section, regexp))
 
 
@@ -295,7 +278,6 @@ def then_stderr_is(context):
     if expected == found:
         return
 
-    print_cmd(context, True, False, True)
     print_lines_diff(expected, found)
 
     raise AssertionError("Stderr is not: %s" % context.text)
@@ -305,7 +287,6 @@ def then_stderr_is(context):
 def then_stderr_contains(context, text):
     if re.search(text, context.cmd_stderr):
         return
-    print_cmd(context, True, False, True)
     raise AssertionError("Stderr doesn't contain: %s" % text)
 
 
@@ -313,7 +294,6 @@ def then_stderr_contains(context, text):
 def then_stderr_contains(context, text):
     if not re.search(text, context.cmd_stderr):
         return
-    print_cmd(context, True, False, True)
     raise AssertionError("Stderr contains: %s" % text)
 
 
@@ -321,7 +301,6 @@ def then_stderr_contains(context, text):
 def then_stderr_is_empty(context):
     if not context.cmd_stderr:
         return
-    print_cmd(context, True, False, True)
     raise AssertionError("Stderr is not empty, it contains: %s" % context.cmd_stderr)
 
 
@@ -334,7 +313,6 @@ def then_stdout_contains_lines(context):
             if line.strip() == outline.strip():
                 break
         else:
-            print_cmd(context, True, False, True)
             raise AssertionError("Stderr doesn't contain line: %s" % line)
 
 

--- a/dnf-behave-tests/features/steps/common/__init__.py
+++ b/dnf-behave-tests/features/steps/common/__init__.py
@@ -1,6 +1,7 @@
 from .behave_ext import check_context_table
 from .behave_ext import parse_context_table
 from .cmd import run
+from .cmd import run_in_context
 from .cmd import get_boot_time
 from .checksum import sha256_checksum
 from .dnf import parse_history_info

--- a/dnf-behave-tests/features/steps/common/cmd.py
+++ b/dnf-behave-tests/features/steps/common/cmd.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 import subprocess
 
 
-def run(cmd, shell=False, can_fail=True, cwd=None):
+def run(cmd, shell=True, cwd=None):
     """
     Run a command.
     Return exitcode, stdout, stderr
@@ -22,11 +22,22 @@ def run(cmd, shell=False, can_fail=True, cwd=None):
     )
 
     stdout, stderr = proc.communicate()
-
-    if not can_fail and proc.returncode != 0:
-        raise RuntimeError("Running command failed: %s" % cmd)
-
     return proc.returncode, stdout, stderr
+
+
+def run_in_context(context, cmd, can_fail=False, **run_args):
+    if getattr(context, "faketime", None) is not None:
+        cmd = context.faketime + cmd
+
+    context.cmd = cmd
+
+    if context.dnf.working_dir and 'cwd' not in run_args:
+        run_args['cwd'] = context.dnf.working_dir
+
+    context.cmd_exitcode, context.cmd_stdout, context.cmd_stderr = run(cmd, **run_args)
+
+    if not can_fail and context.cmd_exitcode != 0:
+        raise AssertionError('Running command "%s" failed: %s' % (cmd, context.cmd_exitcode))
 
 
 def get_boot_time():

--- a/dnf-behave-tests/features/steps/history.py
+++ b/dnf-behave-tests/features/steps/history.py
@@ -9,8 +9,8 @@ from common import *
 
 def parsed_history_info(context, spec):
     cmd = " ".join(context.dnf.get_cmd(context) + ["history", "info", spec])
-    _, cmd_stdout, _ = run(cmd, shell=True, can_fail=False)
-    return parse_history_info(cmd_stdout.splitlines())
+    run_in_context(context, cmd)
+    return parse_history_info(context.cmd_stdout.splitlines())
 
 
 def assert_history_list(context, cmd_stdout):
@@ -70,9 +70,9 @@ def step_impl(context, history_range=None):
         history_range = "list"
 
     cmd = " ".join(context.dnf.get_cmd(context) + ["history", history_range])
-    _, cmd_stdout, _ = run(cmd, shell=True, can_fail=False)
+    run_in_context(context, cmd)
 
-    assert_history_list(context, cmd_stdout)
+    assert_history_list(context, context.cmd_stdout)
 
 
 @behave.then('History info should match')
@@ -118,15 +118,15 @@ def step_impl(context, spec=""):
 def step_impl(context):
     check_context_table(context, ["Action", "Package"])
     cmd = " ".join(context.dnf.get_cmd(context) + ["history", "userinstalled"])
-    _, cmd_stdout, _ = run(cmd, shell=True, can_fail=True)
+    run_in_context(context, cmd)
 
     for action, package in context.table:
         if action == 'match':
-            if not package in cmd_stdout:
+            if package not in context.cmd_stdout:
                 raise AssertionError(
                     '[history] package "{0}" not matched as userinstalled.'.format(package))
         elif action == 'not match':
-            if package in cmd_stdout:
+            if package in context.cmd_stdout:
                 raise AssertionError(
                     '[history] package "{0}" matched as userinstalled.'.format(package))
         else:

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -56,7 +56,7 @@ def step_impl(context, rtype, repo):
                             'certificates/testcerts/server/cert.pem')
         key = os.path.join(context.dnf.fixturesdir,
                            'certificates/testcerts/server/key.pem')
-        client_ssl = context.dnf._get(context, "client_ssl")
+        client_ssl = context.dnf._get("client_ssl")
         if client_ssl:
             client_cert = client_ssl["certificate"]
             client_key = client_ssl["key"]
@@ -94,7 +94,7 @@ def step_impl(context, rtype, repo):
         repocfg.format(**locals()))
 
     # add /http.repos.d to reposdir
-    current_reposdir = context.dnf._get(context, "reposdir")
+    current_reposdir = context.dnf._get("reposdir")
     if not repos_path in current_reposdir:
         context.dnf._set("reposdir", "{},{}".format(current_reposdir, repos_path))
 


### PR DESCRIPTION
Some debugging enhancements that print the last called command and its outputs in a consistent way and with colors, temp directories handling enhancements and some cleanups.

The last commit also shortens the name of the `dnf-ci-fedora-modular-updates` repository across all tests. The name is too long and triggers a bug with dnf output, which had to be workarounded in one scenario. This change is in order to be able to work with the repositories in a uniform way, without a workaround.