### PR TITLE
New steps for working with repositories

### DIFF
--- a/dnf-behave-tests/features/alias-command.feature
+++ b/dnf-behave-tests/features/alias-command.feature
@@ -17,7 +17,7 @@ Scenario: List aliases
 
 
 Scenario: Use alias
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "inthrone setup"
    Then the exit code is 0
     And Transaction is following
@@ -32,7 +32,7 @@ Scenario: Delete alias
    When I execute dnf with args "alias list"
    Then the exit code is 0
    And stdout does not contain "Alias inthrone"
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "inthrone setup"
    Then the exit code is 1
     And stderr contains "No such command: inthrone"

--- a/dnf-behave-tests/features/autoremove.feature
+++ b/dnf-behave-tests/features/autoremove.feature
@@ -1,8 +1,8 @@
 Feature: Autoremoval of unneeded packages
 
 Scenario: Autoremoval of package which became non-required by others
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install SuperRipper"
    Then the exit code is 0
     And Transaction is following
@@ -12,7 +12,7 @@ Scenario: Autoremoval of package which became non-required by others
         | install       | flac-0:1.3.2-8.fc29.x86_64        |
         | install       | wget-0:1.19.5-5.fc29.x86_64       |
         | install       | FlacBetterEncoder-0:1.0-1.x86_64  |
-   When I use the repository "dnf-ci-thirdparty-updates"
+   When I use repository "dnf-ci-thirdparty-updates"
     And I execute dnf with args "update --nobest"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/builddep.feature
+++ b/dnf-behave-tests/features/builddep.feature
@@ -1,7 +1,7 @@
 Feature: Builddep
 
 Scenario: Builddep with simple dependency (spec)
-    Given I use the repository "dnf-ci-fedora"
+    Given I use repository "dnf-ci-fedora"
       And I enable plugin "builddep"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec"
      Then the exit code is 0
@@ -10,7 +10,7 @@ Scenario: Builddep with simple dependency (spec)
         | install       | lame-libs-0:3.100-4.fc29.x86_64   |
 
 Scenario: Builddep with simple dependency (spec) + define
-    Given I use the repository "dnf-ci-fedora"
+    Given I use repository "dnf-ci-fedora"
       And I enable plugin "builddep"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec --define 'buildrequires flac'"
      Then the exit code is 0
@@ -19,7 +19,7 @@ Scenario: Builddep with simple dependency (spec) + define
         | install       | flac-0:1.3.2-8.fc29.x86_64        |
 
 Scenario: Builddep with simple dependency (srpm)
-    Given I use the repository "dnf-ci-fedora"
+    Given I use repository "dnf-ci-fedora"
       And I enable plugin "builddep"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/repos/dnf-ci-thirdparty/src/SuperRipper-1.0-1.src.rpm"
      Then the exit code is 0
@@ -29,7 +29,7 @@ Scenario: Builddep with simple dependency (srpm)
 
 @not.with_os=rhel__eq__7
 Scenario: Builddep with rich dependency
-    Given I use the repository "dnf-ci-fedora"
+    Given I use repository "dnf-ci-fedora"
       And I enable plugin "builddep"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec --define 'buildrequires (flac and lame-libs)'"
      Then the exit code is 0
@@ -39,7 +39,7 @@ Scenario: Builddep with rich dependency
         | install       | lame-libs-0:3.100-4.fc29.x86_64   |
 
 Scenario: Builddep with simple dependency (files-like provide)
-    Given I use the repository "dnf-ci-fedora"
+    Given I use repository "dnf-ci-fedora"
       And I enable plugin "builddep"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec --define 'buildrequires /etc/ld.so.conf'"
      Then the exit code is 0
@@ -48,7 +48,7 @@ Scenario: Builddep with simple dependency (files-like provide)
         | install       | glibc-0:2.28-9.fc29.x86_64        |
 
 Scenario: Builddep with simple dependency (non-existent)
-    Given I use the repository "dnf-ci-fedora"
+    Given I use repository "dnf-ci-fedora"
       And I enable plugin "builddep"
       When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec --define 'buildrequires flac = 15'"
      Then the exit code is 1

--- a/dnf-behave-tests/features/check-all.feature
+++ b/dnf-behave-tests/features/check-all.feature
@@ -2,7 +2,7 @@ Feature: Check when there are multiple problems
 
 
 Background: Force installation of an RPM that will cause problems with dependencies, duplicates and obsoletes
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/check-duplicates.feature
+++ b/dnf-behave-tests/features/check-duplicates.feature
@@ -2,7 +2,7 @@ Feature: Check when there are duplicate packages
 
 
 Background: Force installation of two different versions of an RPM
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install flac-1.3.3-1.fc29"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/check-obsoleted.feature
+++ b/dnf-behave-tests/features/check-obsoleted.feature
@@ -2,7 +2,7 @@ Feature: Check when there is a package that obsoletes another installed package
 
 
 Background: Force installation of an obsoleted RPM
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/clean-requirements-on-remove.feature
+++ b/dnf-behave-tests/features/clean-requirements-on-remove.feature
@@ -1,8 +1,8 @@
 Feature: Autoremoval of unneeded packages
 
 Scenario: Remove with --setopt=clean_requirements_on_remove=True
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
     When I execute dnf with args "install abcde"
    Then the exit code is 0
     And Transaction is following
@@ -21,8 +21,8 @@ Scenario: Remove with --setopt=clean_requirements_on_remove=True
         | remove        | FlacBetterEncoder-0:1.0-1.x86_64  |
 
 Scenario: Remove with --setopt=clean_requirements_on_remove=False
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
     When I execute dnf with args "install abcde"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/config-best.feature
+++ b/dnf-behave-tests/features/config-best.feature
@@ -2,8 +2,8 @@ Feature: Config option: best
 
 
 Scenario: Verify that repo priorities work
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc --setopt=dnf-ci-fedora.priority=90 --setopt=best=0"
    Then the exit code is 0
     And Transaction is following
@@ -17,8 +17,8 @@ Scenario: Verify that repo priorities work
 
 
 Scenario: When priority repo is broken and best=0, install a package from repo with lower priority
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc --setopt=dnf-ci-fedora.priority=90 --setopt=best=0 -x glibc-common-0:2.28-9.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -33,8 +33,8 @@ Scenario: When priority repo is broken and best=0, install a package from repo w
 
 
 Scenario: When installing with option --nobest, install a package from repo with lower priority
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc --setopt=dnf-ci-fedora.priority=90 --nobest -x glibc-common-0:2.28-9.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -50,8 +50,8 @@ Scenario: When installing with option --nobest, install a package from repo with
 
 @bz1670776 @bz1671683
 Scenario: When installing with best=1 set in dnf.conf, fail on broken packages, and advise to use --nobest
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
     And I do not set config file
     And I create file "/etc/dnf/dnf.conf" with
     """
@@ -68,16 +68,16 @@ Scenario: When installing with best=1 set in dnf.conf, fail on broken packages, 
 
 @bz1670776 @bz1671683
 Scenario: When installing with option --best, fail on broken packages, and don't advise to use --nobest
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc --best -x glibc-common-0:2.28-26.fc29.x86_64"
    Then the exit code is 1
     And stdout does not contain "--nobest"
 
 
 Scenario: When installing with best=0, install a package of lower version
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc --setopt=best=0 -x glibc-common-0:2.28-26.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -93,8 +93,8 @@ Scenario: When installing with best=0, install a package of lower version
 
 @bz1670776 @bz1671683
 Scenario: When installing with option --nobest, install a package of lower version
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc --nobest -x glibc-common-0:2.28-26.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -109,7 +109,7 @@ Scenario: When installing with option --nobest, install a package of lower versi
 
 
 Scenario: When upgrading with best=0, only report broken packages
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -120,7 +120,7 @@ Scenario: When upgrading with best=0, only report broken packages
         | install       | basesystem-0:11-6.fc29.noarch         |
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install       | setup-0:2.12.1-1.fc29.noarch          |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade --setopt=best=0 -x glibc-common-0:2.28-26.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -131,7 +131,7 @@ Scenario: When upgrading with best=0, only report broken packages
 
 @bz1670776 @bz1671683
 Scenario: When upgrading with option --nobest, only report broken packages
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -142,7 +142,7 @@ Scenario: When upgrading with option --nobest, only report broken packages
         | install       | basesystem-0:11-6.fc29.noarch         |
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install       | setup-0:2.12.1-1.fc29.noarch          |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade --nobest -x glibc-common-0:2.28-26.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -152,7 +152,7 @@ Scenario: When upgrading with option --nobest, only report broken packages
 
 @bz1670776 @bz1671683
 Scenario: When upgrading with best=1 (default), fail on broken packages
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -163,6 +163,6 @@ Scenario: When upgrading with best=1 (default), fail on broken packages
         | install       | basesystem-0:11-6.fc29.noarch         |
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install       | setup-0:2.12.1-1.fc29.noarch          |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade -x glibc-common-0:2.28-26.fc29.x86_64 --best"
    Then the exit code is 1

--- a/dnf-behave-tests/features/config.feature
+++ b/dnf-behave-tests/features/config.feature
@@ -66,21 +66,19 @@ Scenario: Test with dnf.conf in installroot and --config (dnf.conf is taken from
 
 
 Scenario: Reposdir option in dnf.conf file in installroot
-  Given I use the repository "testrepo"
-    And I create file "/etc/dnf/dnf.conf" with
+  Given I create file "/etc/dnf/dnf.conf" with
     """
     [main]
     reposdir=/testrepos
     """
-    And I create file "/testrepos/test.repo" with
+    And I create and substitute file "/testrepos/test.repo" with
     """
     [testrepo]
     name=testrepo
-    baseurl=$DNF0/repos/dnf-ci-fedora
+    baseurl={context.dnf.repos_location}/dnf-ci-fedora
     enabled=1
     gpgcheck=0
     """
-    And I do not set reposdir
     And I do not set config file
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
@@ -91,21 +89,19 @@ Scenario: Reposdir option in dnf.conf file in installroot
 
 
 Scenario: Reposdir option in dnf.conf file with --config option in installroot
-  Given I use the repository "testrepo"
-    And I create file "/testdnf.conf" with
+  Given I create file "/testdnf.conf" with
     """
     [main]
     reposdir=/testrepos
     """
-    And I create file "/testrepos/test.repo" with
+    And I create and substitute file "/testrepos/test.repo" with
     """
     [testrepo]
     name=testrepo
-    baseurl=$DNF0/repos/dnf-ci-fedora
+    baseurl={context.dnf.repos_location}/dnf-ci-fedora
     enabled=1
     gpgcheck=0
     """
-    And I do not set reposdir
     And I set config file to "/testdnf.conf"
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
@@ -116,26 +112,24 @@ Scenario: Reposdir option in dnf.conf file with --config option in installroot
 
 
 Scenario: Reposdir option in dnf.conf file with --config option in installroot is taken first from installroot then from host
-  Given I use the repository "testrepo"
-    And I create and substitute file "/testdnf.conf" with
+  Given I create and substitute file "/testdnf.conf" with
     """
     [main]
     reposdir={context.dnf.installroot}/testrepos,/othertestrepos
     """
-    And I create file "/testrepos/test.repo" with
+    And I create and substitute file "/testrepos/test.repo" with
     """
     [testrepo]
     name=testrepo
-    baseurl=$DNF0/repos/dnf-ci-fedora
+    baseurl={context.dnf.repos_location}/dnf-ci-fedora
     enabled=1
     gpgcheck=0
     """
-    And I do not set reposdir
     And I set config file to "/testdnf.conf"
     And I create directory "/othertestrepos"
    When I execute dnf with args "install filesystem"
    Then the exit code is 1
-    And stderr contains "Error: Unknown repo: 'testrepo'"
+    And stderr contains "Error: There are no enabled repositories in "
   Given I delete directory "/othertestrepos"
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
@@ -146,16 +140,14 @@ Scenario: Reposdir option in dnf.conf file with --config option in installroot i
 
 
 Scenario: Reposdir option set by --setopt
-  Given I use the repository "testrepo"
-    And I create file "/testrepos/test.repo" with
+  Given I create and substitute file "/testrepos/test.repo" with
     """
     [testrepo]
     name=testrepo
-    baseurl=$DNF0/repos/dnf-ci-fedora
+    baseurl={context.dnf.repos_location}/dnf-ci-fedora
     enabled=1
     gpgcheck=0
     """
-    And I do not set reposdir
    # fail due to unavailable repository
    When I execute dnf with args "install filesystem"
    Then the exit code is 1

--- a/dnf-behave-tests/features/config.feature
+++ b/dnf-behave-tests/features/config.feature
@@ -7,7 +7,7 @@ Feature: DNF config files testing
 # Scenario: Reposdir option in dnf conf.file in host
 
 Scenario: Test removal of dependency when clean_requirements_on_remove=false
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I do not set config file
     And I create file "/etc/dnf/dnf.conf" with
     """
@@ -29,7 +29,7 @@ Scenario: Test removal of dependency when clean_requirements_on_remove=false
 
 
 Scenario: Test with dnf.conf in installroot (dnf.conf is taken from installroot)
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I do not set config file
     And I create file "/etc/dnf/dnf.conf" with
     """
@@ -43,7 +43,7 @@ Scenario: Test with dnf.conf in installroot (dnf.conf is taken from installroot)
 
 
 Scenario: Test with dnf.conf in installroot and --config (dnf.conf is taken from --config)
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I create file "/etc/dnf/dnf.conf" with
     """
     [main]
@@ -172,7 +172,7 @@ Scenario: Reposdir option set by --setopt
 
 @bz1512457
 Scenario: Test usage of not existing config file
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I set config file to "/etc/dnf/not_existing_dnf.conf"
     And I delete file "/etc/dnf/not_existing_dnf.conf"
    When I execute dnf with args "list"

--- a/dnf-behave-tests/features/countme.feature
+++ b/dnf-behave-tests/features/countme.feature
@@ -5,7 +5,7 @@ Feature: Better user counting
     Scenario: User-Agent header is sent
         Given I am running a system identified as the "Fedora 30 server"
           And I am using libdnf of the version X.Y.Z
-          And I have enabled a remote repository
+          And I use repository "dnf-ci-fedora" as http
          When I execute dnf with args "makecache"
          Then every HTTP GET request should match:
             | header     | value                                          |
@@ -16,7 +16,7 @@ Feature: Better user counting
     Scenario: User-Agent header is sent (missing variant)
         Given I am running a system identified as the "Fedora 31"
           And I am using libdnf of the version X.Y.Z
-          And I have enabled a remote repository
+          And I use repository "dnf-ci-fedora" as http
          When I execute dnf with args "makecache"
          Then every HTTP GET request should match:
             | header     | value                                           |
@@ -27,7 +27,7 @@ Feature: Better user counting
     Scenario: User-Agent header is sent (unknown variant)
         Given I am running a system identified as the "Fedora 31 myspin"
           And I am using libdnf of the version X.Y.Z
-          And I have enabled a remote repository
+          And I use repository "dnf-ci-fedora" as http
          When I execute dnf with args "makecache"
          Then every HTTP GET request should match:
             | header     | value                                           |
@@ -38,7 +38,7 @@ Feature: Better user counting
     Scenario: Shortened User-Agent value on a non-Fedora system
         Given I am running a system identified as the "OpenSUSE 15.1 desktop"
           And I am using libdnf of the version X.Y.Z
-          And I have enabled a remote repository
+          And I use repository "dnf-ci-fedora" as http
          When I execute dnf with args "makecache"
          Then every HTTP GET request should match:
             | header     | value        |
@@ -46,7 +46,7 @@ Feature: Better user counting
 
     @fixture.httpd.log
     Scenario: Custom User-Agent value
-        Given I have enabled a remote repository
+        Given I use repository "dnf-ci-fedora" as http
           And I set config option "user_agent" to "'Agent 007'"
          When I execute dnf with args "makecache"
          Then every HTTP GET request should match:
@@ -57,7 +57,9 @@ Feature: Better user counting
     Scenario: Countme flag is sent once per week
         Given I set config option "countme" to "1"
           And today is Wednesday, August 07, 2019
-          And I have enabled a remote metalink repository
+          And I copy repository "dnf-ci-fedora" for modification
+          And I use repository "dnf-ci-fedora" as http
+          And I set up metalink for repository "dnf-ci-fedora"
           # The countme feature only activates when refreshing the metalink so
           # we need one first.
           And I execute dnf with args "makecache"
@@ -77,7 +79,9 @@ Feature: Better user counting
     @fixture.httpd.log
     Scenario: Countme feature is disabled
         Given I set config option "countme" to "0"
-          And I have enabled a remote metalink repository
+          And I copy repository "dnf-ci-fedora" for modification
+          And I use repository "dnf-ci-fedora" as http
+          And I set up metalink for repository "dnf-ci-fedora"
           And I execute dnf with args "makecache"
          When I execute dnf with args "check-update --refresh" 4 times
          Then no metalink request should include the countme flag

--- a/dnf-behave-tests/features/debuglevel.feature
+++ b/dnf-behave-tests/features/debuglevel.feature
@@ -2,7 +2,7 @@ Feature: Tests for --debuglevel / -d cmdline option
 
 
 Background: Enable repo
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
 
 
 Scenario: Test for debuglevel 0

--- a/dnf-behave-tests/features/downgrade.feature
+++ b/dnf-behave-tests/features/downgrade.feature
@@ -1,7 +1,7 @@
 Feature: Downgrade command
 
 Scenario: Downgrade one RPM
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install flac"
    Then the exit code is 0
     And Transaction is following
@@ -22,8 +22,8 @@ Scenario: Downgrade one RPM
     And stderr contains "Package flac of lowest version already installed, cannot downgrade it."
 
 Scenario: Downgrade RPM that requires downgrade of dependency
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -21,7 +21,6 @@ FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fi
 
 DEFAULT_DNF_COMMAND = "dnf"
 DEFAULT_CONFIG = os.path.join(FIXTURES_DIR, "dnf.conf")
-DEFAULT_REPOSDIR = os.path.join(FIXTURES_DIR, "repos.d")
 DEFAULT_REPOS_LOCATION = os.path.join(FIXTURES_DIR, "repos")
 DEFAULT_RELEASEVER="29"
 DEFAULT_PLATFORM_ID="platform:f29"
@@ -116,7 +115,6 @@ class DNFContext(object):
         self.config = userdata.get("config", DEFAULT_CONFIG)
         self.releasever = userdata.get("releasever", DEFAULT_RELEASEVER)
         self.module_platform_id = userdata.get("module_platform_id", DEFAULT_PLATFORM_ID)
-        self.reposdir = userdata.get("reposdir", DEFAULT_REPOSDIR)
         self.repos_location = userdata.get("repos_location", DEFAULT_REPOS_LOCATION)
         self.fixturesdir = FIXTURES_DIR
         self.disable_plugins = True
@@ -132,10 +130,6 @@ class DNFContext(object):
             self.preserve_temporary_dirs = "failed"
 
         self.scenario_failed = False
-
-        # temporarily use DNF0 for substituting fixturesdir in repo files
-        # the future could be in named environment variable like DNF_VAR_FIXTURES_DIR
-        os.environ['DNF0'] = self.fixturesdir
 
     def __del__(self):
         preserved_dirs = []
@@ -195,16 +189,6 @@ class DNFContext(object):
         module_platform_id = self._get("module_platform_id")
         if module_platform_id:
             result.append("--setopt=module_platform_id={0}".format(module_platform_id))
-
-        if self._get("use_repo_args"):
-            reposdir = self._get("reposdir")
-            if reposdir:
-                result.append("--setopt=reposdir={0}".format(reposdir))
-
-            result.append(self.disable_repos_option)
-            repos = self._get("repos") or []
-            for repo in repos:
-                result.append("--enablerepo='{0}'".format(repo))
 
         disable_plugins = self._get("disable_plugins")
         if disable_plugins:
@@ -289,8 +273,8 @@ def after_scenario(context, scenario):
 
         if getattr(context, "cmd", ""):
             print(
-                "%sLast Command: %sDNF0=%s %s" %
-                (escapes["failed"], escapes["failed_arg"], context.dnf.fixturesdir, context.cmd)
+                "%sLast Command: %s%s" %
+                (escapes["failed"], escapes["failed_arg"], context.cmd)
             )
             print(escapes["reset"])
         if getattr(context, "cmd_stdout", ""):

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -14,6 +14,7 @@ from behave.formatter.ansi_escapes import escapes
 
 from steps.fixtures.httpd import HttpServerContext
 from steps.fixtures.ftpd import FtpServerContext
+from steps.common.file import ensure_directory_exists
 
 
 FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fixtures"))
@@ -106,6 +107,9 @@ class DNFContext(object):
             self.delete_installroot = False
         else:
             self.installroot = tempfile.mkdtemp(prefix="dnf_ci_installroot_")
+            # if we're creating installroot, ensure /etc/yum.repos.d exists,
+            # otherwise dnf picks repo configs from the host
+            ensure_directory_exists(os.path.join(self.installroot, "etc/yum.repos.d"))
             self.delete_installroot = True
 
         self.dnf_command = userdata.get("dnf_command", DEFAULT_DNF_COMMAND)

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -95,6 +95,7 @@ class DNFContext(object):
         self._scenario_data = {}
 
         self.repos = {}
+        self.ports = {}
 
         self.tempdir = tempfile.mkdtemp(prefix="dnf_ci_tempdir_")
         # some tests need to be run inside the installroot, it can be forced

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -188,10 +188,6 @@ class DNFContext(object):
         if config:
             result.append("--config={0}".format(config))
 
-        reposdir = self._get("reposdir")
-        if reposdir:
-            result.append("--setopt=reposdir={0}".format(reposdir))
-
         releasever = self._get("releasever")
         if releasever:
             result.append("--releasever={0}".format(releasever))
@@ -200,10 +196,15 @@ class DNFContext(object):
         if module_platform_id:
             result.append("--setopt=module_platform_id={0}".format(module_platform_id))
 
-        result.append(self.disable_repos_option)
-        repos = self._get("repos") or []
-        for repo in repos:
-            result.append("--enablerepo='{0}'".format(repo))
+        if self._get("use_repo_args"):
+            reposdir = self._get("reposdir")
+            if reposdir:
+                result.append("--setopt=reposdir={0}".format(reposdir))
+
+            result.append(self.disable_repos_option)
+            repos = self._get("repos") or []
+            for repo in repos:
+                result.append("--enablerepo='{0}'".format(repo))
 
         disable_plugins = self._get("disable_plugins")
         if disable_plugins:

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -94,6 +94,8 @@ class DNFContext(object):
     def __init__(self, userdata, force_installroot=False):
         self._scenario_data = {}
 
+        self.repos = {}
+
         self.tempdir = tempfile.mkdtemp(prefix="dnf_ci_tempdir_")
         # some tests need to be run inside the installroot, it can be forced
         # per scenario by using @force_installroot decorator

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -317,6 +317,8 @@ def before_all(context):
     if os:
         active_tag_value_provider["os"] = os
 
+    context.repos = {}
+
 
 def after_all(context):
     pass

--- a/dnf-behave-tests/features/errorlevel.feature
+++ b/dnf-behave-tests/features/errorlevel.feature
@@ -2,7 +2,7 @@ Feature: Tests for --errorlevel / -e cmdline option
 
 
 Background: Enable dnf-ci-thirdparty-updates
-Given I use the repository "dnf-ci-thirdparty-updates"
+Given I use repository "dnf-ci-thirdparty-updates"
 
 
 Scenario: Test for errorlevel 0
@@ -19,7 +19,7 @@ Scenario: Test for errorlevel 1
 
 
 Scenario: Test for errorlevel 5
-Given I use the repository "dnf-ci-thirdparty"
+Given I use repository "dnf-ci-thirdparty"
  When I execute dnf with args "-e=5 install CQRlib-extension"
  Then the exit code is 1
   And stderr contains "package.*but none of the providers can be installed"

--- a/dnf-behave-tests/features/excludes-includes-disabled.feature
+++ b/dnf-behave-tests/features/excludes-includes-disabled.feature
@@ -2,7 +2,7 @@ Feature: Test config options includepkgs and excludepkgs with option --disableex
 
 
 Scenario Outline: Install an RPM that is NOT in includepkgs in <conf>, with option --disableexcludepkgs equal to <disable-conf>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac --setopt=<prefix>includepkgs=setup --disableexcludepkgs=<disable-conf>"
    Then the exit code is 0
     And Transaction is following
@@ -18,7 +18,7 @@ Examples:
 
 
 Scenario Outline: Install an RPM that is in excludepkgs in <conf>, with option --disableexcludepkgs equal to <disable-conf>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac --setopt=<prefix>excludepkgs=flac --disableexcludepkgs=<disable-conf>"
    Then the exit code is 0
     And Transaction is following
@@ -34,28 +34,28 @@ Examples:
 
 
 Scenario: Fail to install an RPM that is NOT in includepkgs in main conf, with option --disableexcludepkgs equal to <repo-id>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac --setopt=includepkgs=setup --disableexcludepkgs=dnf-ci-fedora"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Fail to install an RPM that is in excludepkgs in main conf, with option --disableexcludepkgs equal to <repo-id>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac --setopt=excludepkgs=flac --disableexcludepkgs=dnf-ci-fedora"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Fail to install an RPM that is NOT in includepkgs in repo conf, with option --disableexcludepkgs equal to main
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac --setopt=dnf-ci-fedora.includepkgs=setup --disableexcludepkgs=main"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Fail to install an RPM that is in excludepkgs in repo conf, with option --disableexcludepkgs equal to main
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac --setopt=dnf-ci-fedora.excludepkgs=flac --disableexcludepkgs=main"
    Then the exit code is 1
     And Transaction is empty

--- a/dnf-behave-tests/features/excludes-includes.feature
+++ b/dnf-behave-tests/features/excludes-includes.feature
@@ -2,7 +2,7 @@ Feature: Test config options includepkgs and excludepkgs
 
 
 Scenario: Install RPMs that are in includepkgs in main conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=includepkgs=flac-libs,setup"
    Then the exit code is 0
     And Transaction is following
@@ -11,7 +11,7 @@ Scenario: Install RPMs that are in includepkgs in main conf
 
 
 Scenario: Install RPMs that are in includepkgs in repo conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=dnf-ci-fedora.includepkgs=flac-libs,setup"
    Then the exit code is 0
     And Transaction is following
@@ -20,21 +20,21 @@ Scenario: Install RPMs that are in includepkgs in repo conf
 
 
 Scenario: Fail to install RPMs when some RPM is NOT in includepkgs in main conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac flac-libs --setopt=includepkgs=flac-libs,setup"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Fail to install RPMs when some RPM is NOT in includepkgs in repo conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac flac-libs --setopt=dnf-ci-fedora.includepkgs=flac-libs,setup"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Install RPMs that are NOT in excludepkgs in main conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=excludepkgs=flac,glibc"
    Then the exit code is 0
     And Transaction is following
@@ -43,7 +43,7 @@ Scenario: Install RPMs that are NOT in excludepkgs in main conf
 
 
 Scenario: Install RPMs that are NOT in excludepkgs in repo conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=dnf-ci-fedora.excludepkgs=flac,glibc"
    Then the exit code is 0
     And Transaction is following
@@ -52,21 +52,21 @@ Scenario: Install RPMs that are NOT in excludepkgs in repo conf
 
 
 Scenario: Fail to install RPMs when some RPM is in excludepkgs in main conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac flac-libs --setopt=excludepkgs=flac,flac-libs,glibc"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Fail to install RPMs when some RPM is in excludepkgs in repo conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac flac-libs --setopt=dnf-ci-fedora.excludepkgs=flac,flac-libs,glibc"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Install RPMs that are in includepkgs and NOT in excludepkgs in main conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=includepkgs=flac,flac-libs,setup  --setopt=excludepkgs=flac,glibc"
    Then the exit code is 0
     And Transaction is following
@@ -75,7 +75,7 @@ Scenario: Install RPMs that are in includepkgs and NOT in excludepkgs in main co
 
 
 Scenario: Install RPMs that are in includepkgs and NOT in excludepkgs in repo conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=dnf-ci-fedora.includepkgs=flac,flac-libs,setup  --setopt=excludepkgs=flac,glibc"
    Then the exit code is 0
     And Transaction is following
@@ -84,21 +84,21 @@ Scenario: Install RPMs that are in includepkgs and NOT in excludepkgs in repo co
 
 
 Scenario: Fail to install RPMs when there is a non-existent RPM in includedpkgs in main conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=includepkgs=non-existent-pkg"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Fail to install RPMs when there is a non-existent RPM in includedpkgs in repo conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=dnf-ci-fedora.includepkgs=non-existent-pkg"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Install RPMs when there is a non-existent RPM in excludepkgs in main conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=excludepkgs=non-existent-pkg"
    Then the exit code is 0
     And Transaction is following
@@ -108,7 +108,7 @@ Scenario: Install RPMs when there is a non-existent RPM in excludepkgs in main c
 
 
 Scenario: Install RPMs when there is a non-existent RPM in excludepkgs in repo conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=dnf-ci-fedora.excludepkgs=non-existent-pkg"
    Then the exit code is 0
     And Transaction is following
@@ -118,7 +118,7 @@ Scenario: Install RPMs when there is a non-existent RPM in excludepkgs in repo c
 
 
 Scenario: Install RPMs that are in includepkgs in main conf and NOT in excludepkgs in repo conf
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac* --setopt=includepkgs=flac,flac-libs,setup  --setopt=excludepkgs=flac,glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/fail-safe.feature
+++ b/dnf-behave-tests/features/fail-safe.feature
@@ -2,26 +2,17 @@ Feature: Fail-safe
 
 
 Background: Copy the dnf-ci-fedora-modular repo (to allow modulemd removal and so on), and enable nodejs:5 (containing the oldest nodejs package) -> this makes fail-safe copy of nodejs:5
-  Given I copy directory "{context.dnf.repos_location}/dnf-ci-fedora-modular" to "/temp-repos/dnf-ci-fedora-modular"
-   And I create and substitute file "/etc/yum.repos.d/dnf-ci-fedora-modular.repo" with
-       """
-       [dnf-ci-fedora-modular]
-       name=dnf-ci-fedora-modular
-       baseurl={context.dnf.installroot}/temp-repos/dnf-ci-fedora-modular
-       enabled=1
-       gpgcheck=0
-       skip_if_unavailable=1
-       """
-    And I copy file "{context.dnf.reposdir}/dnf-ci-fedora.repo" to "/etc/yum.repos.d/dnf-ci-fedora.repo"
-    And I copy file "{context.dnf.reposdir}/dnf-ci-fedora-updates.repo" to "/etc/yum.repos.d/dnf-ci-fedora-updates.repo"
-    And I copy file "{context.dnf.reposdir}/dnf-ci-fedora-modular-updates.repo" to "/etc/yum.repos.d/dnf-ci-fedora-modular-updates.repo"
-    And I copy file "{context.dnf.reposdir}/dnf-ci-fedora-modular-hotfix.repo" to "/etc/yum.repos.d/dnf-ci-fedora-modular-hotfix.repo"
-    And I copy file "{context.dnf.reposdir}/dnf-ci-fourthparty-modular.repo" to "/etc/yum.repos.d/dnf-ci-fourthparty-modular.repo"
-    And I copy file "{context.dnf.reposdir}/fail-safe-hotfix.repo" to "/etc/yum.repos.d/fail-safe-hotfix.repo"
-    And I do not set reposdir
-    And I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
-
+  Given I copy repository "dnf-ci-fedora-modular" for modification
+    And I use repository "dnf-ci-fedora-modular" with configuration
+        | key                 | value |
+        | skip_if_unavailable | 1     |
+    And I configure repository "dnf-ci-fedora-modular-hotfix" with
+        | key             | value |
+        | module_hotfixes | 1     |
+    And I configure repository "fail-safe-hotfix" with
+        | key             | value |
+        | module_hotfixes | 1     |
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "module enable nodejs:5"
    Then the exit code is 0
     And Transaction contains
@@ -64,7 +55,7 @@ Background: Copy the dnf-ci-fedora-modular repo (to allow modulemd removal and s
 @bz1616167
 @bz1623128
 Scenario: When modulemd is available, 'module list' does NOT show fail-safe modules
-   When I use the repository "dnf-ci-fedora-modular-updates"
+  Given I use repository "dnf-ci-fedora-modular-updates"
    When I execute dnf with args "module enable postgresql:10"
    Then the exit code is 0
     And Transaction contains
@@ -101,7 +92,7 @@ Scenario: When modulemd is available, 'module list' does NOT show fail-safe modu
 @bz1616167
 @bz1623128
 Scenario Outline: When modulemd is not available, 'module list' shows fail-safe modules
-   When I use the repository "dnf-ci-fedora-modular-updates"
+  Given I use repository "dnf-ci-fedora-modular-updates"
    When I execute dnf with args "module enable postgresql:10"
    Then the exit code is 0
     And Transaction contains
@@ -127,10 +118,10 @@ Scenario Outline: When modulemd is not available, 'module list' shows fail-safe 
         | @modulefailsafe               | nodejs        | 5 [e]     | development, default, minimal |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -144,10 +135,10 @@ Scenario Outline: When modulemd is not available, 'module info' can show details
     And stdout contains "Stream.*5"
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -160,10 +151,10 @@ Scenario Outline: When modulemd is not available, module profile from enabled st
     And Transaction is empty
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -176,10 +167,10 @@ Scenario Outline: When modulemd is not available, module profile from non-enable
     And Transaction is empty
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -205,10 +196,10 @@ Scenario Outline: When modulemd is not available, module profile from enabled st
         | nodejs         | enabled   | 5         |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -216,8 +207,8 @@ Examples:
 Scenario Outline: When modulemd is not available, repoquery doesn't show RPMs with the same name as in the enabled stream (non-modular or from different streams or modules), only from hotfix repos
   Given I execute step "<step>"
     And I execute dnf with args "clean all"
-    And I use the repository "dnf-ci-fedora-modular-updates"
-    And I use the repository "dnf-ci-fourthparty-modular"
+    And I use repository "dnf-ci-fedora-modular-updates"
+    And I use repository "dnf-ci-fourthparty-modular"
    When I execute dnf with args "repoquery nodejs.x86_64"
    Then the exit code is 0
     And stdout is empty
@@ -229,10 +220,10 @@ Scenario Outline: When modulemd is not available, repoquery doesn't show RPMs wi
     And stdout contains "nodejs-1:8.11.5-1.module_2030\+42747d40.x86_64"
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -245,8 +236,8 @@ Scenario Outline: When modular RPM is installed and modulemd is not available, t
         | install                   | nodejs-1:5.3.1-1.module_2011+41787af0.x86_64       |
   Given I execute step "<step>"
     And I execute dnf with args "clean all"
-    And I use the repository "dnf-ci-fedora-modular-updates"
-    And I use the repository "dnf-ci-fourthparty-modular"
+    And I use repository "dnf-ci-fedora-modular-updates"
+    And I use repository "dnf-ci-fourthparty-modular"
    When I execute dnf with args "upgrade nodejs"
    Then the exit code is 0
     And Transaction is empty
@@ -255,10 +246,10 @@ Scenario Outline: When modular RPM is installed and modulemd is not available, t
         | nodejs         | enabled   | 5         |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -271,7 +262,7 @@ Scenario Outline: When modular RPM is installed and modulemd is not available, t
         | install                   | nodejs-1:5.3.1-1.module_2011+41787af0.x86_64       |
   Given I execute step "<step>"
     And I execute dnf with args "clean all"
-    And I use the repository "dnf-ci-fedora-modular-hotfix"
+    And I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "upgrade nodejs"
    Then the exit code is 0
     And Transaction is following
@@ -283,10 +274,10 @@ Scenario Outline: When modular RPM is installed and modulemd is not available, t
         | nodejs         | enabled   | 5         |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -299,7 +290,7 @@ Scenario Outline: When modular RPM is installed and modulemd is not available, t
         | install                   | nodejs-1:5.3.1-1.module_2011+41787af0.x86_64       |
   Given I execute step "<step>"
     And I execute dnf with args "clean all"
-    And I use the repository "fail-safe-hotfix"
+    And I use repository "fail-safe-hotfix"
    When I execute dnf with args "upgrade nodejs"
    Then the exit code is 0
     And Transaction is following
@@ -311,10 +302,10 @@ Scenario Outline: When modular RPM is installed and modulemd is not available, t
         | nodejs         | enabled   | 5         |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -337,10 +328,10 @@ Scenario Outline: When modular RPM is installed and modulemd is not available, t
         | nodejs         | enabled   | 5         |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -353,8 +344,8 @@ Scenario Outline: When non-modular RPM is installed and modulemd is not availabl
         | install                   | http-parser-0:2.4.0-1.fc29.x86_64                  |
   Given I execute step "<step>"
     And I execute dnf with args "clean all"
-    And I use the repository "dnf-ci-fedora-modular-updates"
-    And I use the repository "dnf-ci-fourthparty-modular"
+    And I use repository "dnf-ci-fedora-modular-updates"
+    And I use repository "dnf-ci-fourthparty-modular"
    When I execute dnf with args "upgrade http-parser"
    Then the exit code is 0
     And Transaction is empty
@@ -363,10 +354,10 @@ Scenario Outline: When non-modular RPM is installed and modulemd is not availabl
         | nodejs         | enabled   | 5         |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -379,7 +370,7 @@ Scenario Outline: When non-modular RPM is installed and modulemd is not availabl
         | install                   | http-parser-0:2.4.0-1.fc29.x86_64                  |
   Given I execute step "<step>"
     And I execute dnf with args "clean all"
-    And I use the repository "dnf-ci-fedora-modular-hotfix"
+    And I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "upgrade http-parser"
    Then the exit code is 0
     And Transaction is following
@@ -390,10 +381,10 @@ Scenario Outline: When non-modular RPM is installed and modulemd is not availabl
         | nodejs         | enabled   | 5         |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -416,10 +407,10 @@ Scenario Outline: When non-modular RPM is installed and modulemd is not availabl
         | nodejs         | enabled   | 5         |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -443,10 +434,10 @@ Scenario Outline: When modulemd is not available, non-modular RPMs can be instal
         | upgrade               | wget-0:1.19.6-5.fc29.x86_64        |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -464,10 +455,10 @@ Scenario Outline: When modulemd is not available, the enabled module can be disa
         | nodejs         | disabled  |           |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -485,10 +476,10 @@ Scenario Outline: When modulemd is not available, the enabled module can be rese
         | nodejs         |           |           |           |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -515,7 +506,9 @@ Scenario Outline: When modulemd is not available, RPM from the enabled stream ca
         gpgcheck=0
         skip_if_unavailable=0
         """
-    And I use the repository "short-modular-updates"
+      # since we're configuring the repo ourselves, force generation of repodata by using and unusing it
+    And I use repository "dnf-ci-fedora-modular-updates"
+    And I drop repository "dnf-ci-fedora-modular-updates"
    When I execute dnf with args "install nodejs"
    Then the exit code is 0
     And Transaction contains
@@ -523,10 +516,10 @@ Scenario Outline: When modulemd is not available, RPM from the enabled stream ca
         | install        | nodejs-1:10.14.1-1.module_2533+7361f245.x86_64   |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |
 
 
 @bz1616167
@@ -549,7 +542,7 @@ Scenario Outline: When modulemd is not available, RPM from the enabled stream ca
         | remove         | nodejs-1:5.3.1-1.module_2011+41787af0.x86_64     |
 
 Examples:
-    | step                                                                                       |
-    | Given I disable the repository "dnf-ci-fedora-modular"                                     |
-    | Given I delete directory "/temp-repos/dnf-ci-fedora-modular"                               |
-    | Given I delete file "/temp-repos/dnf-ci-fedora-modular/repodata/*modules.yaml*" with globs |
+    | step                                                                                                      |
+    | Given I drop repository "dnf-ci-fedora-modular"                                                           |
+    | Given I delete directory "/{context.dnf.repos[dnf-ci-fedora-modular].path}"                               |
+    | Given I delete file "/{context.dnf.repos[dnf-ci-fedora-modular].path}/repodata/*modules.yaml*" with globs |

--- a/dnf-behave-tests/features/fail-safe.feature
+++ b/dnf-behave-tests/features/fail-safe.feature
@@ -221,8 +221,8 @@ Scenario Outline: When modulemd is not available, repoquery doesn't show RPMs wi
    When I execute dnf with args "repoquery nodejs.x86_64"
    Then the exit code is 0
     And stdout is empty
-   When I use the repository "fail-safe-hotfix"
-    And I use the repository "dnf-ci-fedora-modular-hotfix"
+   When I use repository "fail-safe-hotfix"
+    And I use repository "dnf-ci-fedora-modular-hotfix"
     And I execute dnf with args "repoquery nodejs.x86_64"
    Then the exit code is 0
     And stdout contains "nodejs-1:5.12.1-1.fc29.x86_64"
@@ -435,7 +435,7 @@ Scenario Outline: When modulemd is not available, non-modular RPMs can be instal
     And modules state is following
         | Module         | State     | Stream    | Profiles  |
         | nodejs         | enabled   | 5         |           |
-    And I use the repository "dnf-ci-fedora-updates"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade wget"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/gpg.feature
+++ b/dnf-behave-tests/features/gpg.feature
@@ -17,7 +17,10 @@ Feature: Testing gpgcheck
 
 
 Background: Add repository with gpgcheck=1
-  Given I use the repository "dnf-ci-gpg"
+  Given I use repository "dnf-ci-gpg" with configuration
+        | key      | value                                                                                                                                                               |
+        | gpgcheck | 1                                                                                                                                                                   |
+        | gpgkey   | file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg/dnf-ci-gpg-public,file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg-subkey/dnf-ci-gpg-subkey-public |
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout contains "dnf-ci-gpg\s+dnf-ci-gpg"
@@ -76,8 +79,10 @@ Scenario: Fail to install signed package with incorrect checksum
 
 
 Scenario: Install masterkey signed, unsigned and masterkey signed with unknown key packages from repo with gpgcheck=0 in repofile
-  Given I use the repository "dnf-ci-gpg-nocheck"
-    And I disable the repository "dnf-ci-gpg"
+  Given I configure repository "dnf-ci-gpg" with
+        | key      | value                                                                      |
+        | gpgcheck | 0                                                                          |
+        | gpgkey   | file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg/dnf-ci-gpg-public |
    # install masterkey signed package
    When I execute dnf with args "install setup"
    Then the exit code is 0
@@ -90,8 +95,10 @@ Scenario: Install masterkey signed, unsigned and masterkey signed with unknown k
 
 
 Scenario: Install unsigned package from repositorory without gpgcheck set using option --nogpgcheck
-  Given I disable the repository "dnf-ci-gpg"
-    And I use the repository "dnf-ci-gpgcheck-undefined"
+  Given I configure repository "dnf-ci-gpg" with
+        | key      | value |
+        | gpgcheck |       |
+        | gpgkey   |       |
    When I execute dnf with args "install flac --nogpgcheck"
    Then the exit code is 0
     And Transaction is following
@@ -101,8 +108,10 @@ Scenario: Install unsigned package from repositorory without gpgcheck set using 
 
 @bz1314405
 Scenario: Fail to install package with incorrect checksum when gpgcheck=0
-  Given I disable the repository "dnf-ci-gpg"
-    And I use the repository "dnf-ci-gpgcheck-undefined"
+  Given I configure repository "dnf-ci-gpg" with
+        | key      | value |
+        | gpgcheck |       |
+        | gpgkey   |       |
    When I execute dnf with args "install broken-package --nogpgcheck"
    Then the exit code is 1
     And DNF Transaction is following

--- a/dnf-behave-tests/features/group-mark.feature
+++ b/dnf-behave-tests/features/group-mark.feature
@@ -7,8 +7,8 @@ Feature: Testing group mark
 #   conditional: wget, requires filesystem-content
 
 Scenario: Mark group as installed
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "group list DNF-CI-Testgroup"
    Then the exit code is 0
     And stdout contains "Available Groups"
@@ -31,8 +31,8 @@ Scenario: Mark group as installed
 
 
 Scenario: unMark group as installed
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "group mark install DNF-CI-Testgroup"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/group.feature
+++ b/dnf-behave-tests/features/group.feature
@@ -7,8 +7,8 @@ Feature: Testing groups
 #   conditional: wget, requires filesystem-content
 
 Scenario: Install and remove group
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "group install DNF-CI-Testgroup"
    Then the exit code is 0
     And Transaction is following
@@ -30,8 +30,8 @@ Scenario: Install and remove group
 
 
 Scenario: Install and remove group with excluded package
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "group install --exclude=lame DNF-CI-Testgroup"
    Then the exit code is 0
     And Transaction is following
@@ -49,8 +49,8 @@ Scenario: Install and remove group with excluded package
 
 @bz1707624
 Scenario: Install installed group when group is not available
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "group install --exclude=lame DNF-CI-Testgroup"
    Then the exit code is 0
     And Transaction is following
@@ -64,8 +64,8 @@ Scenario: Install installed group when group is not available
     And stderr does not contain "ValueError"
 
 Scenario: Install and remove group with excluded package dependency
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "group install --exclude=setup DNF-CI-Testgroup"
    Then the exit code is 1
     And stderr contains "Problem: package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed"
@@ -74,8 +74,8 @@ Scenario: Install and remove group with excluded package dependency
 @xfail
 @bz1673851
 Scenario: Install condidional package if required package is about to be installed
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "install @DNF-CI-Testgroup filesystem-content"
    Then the exit code is 0
     And Transaction is following
@@ -102,8 +102,8 @@ Scenario: Install condidional package if required package is about to be install
 @xfail
 @bz1673851
 Scenario: Install condidional package if required package has been installed
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem-content"
    Then the exit code is 0
     And Transaction is following
@@ -123,8 +123,8 @@ Scenario: Install condidional package if required package has been installed
 
 # basesystem requires filesystem (part of DNF-CI-Testgroup)
 Scenario: Group remove does not remove packages required by user installed packages
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "group install DNF-CI-Testgroup"
    Then the exit code is 0
     And Transaction is following
@@ -160,8 +160,8 @@ Scenario: Group remove does not remove packages required by user installed packa
 
 
 Scenario: Group remove does not remove user installed packages
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/history-list.feature
+++ b/dnf-behave-tests/features/history-list.feature
@@ -1,7 +1,7 @@
 Feature: history list
 
 Background:
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
   # create some history to start with
   And I successfully execute dnf with args "install abcde basesystem"
   And I successfully execute dnf with args "remove abcde"

--- a/dnf-behave-tests/features/history-redo.feature
+++ b/dnf-behave-tests/features/history-redo.feature
@@ -1,7 +1,7 @@
 Feature: Transaction history redo
 
 Scenario: Redo last transaction
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/history-rpmdb.feature
+++ b/dnf-behave-tests/features/history-rpmdb.feature
@@ -3,7 +3,7 @@ Feature: DNF/Behave test rpmdb version
 
 @bz1658120
 Scenario: Compute rpmdb version in repeatable manner
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute rpm with args "-U {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm"
    Then the exit code is 0
    Then I execute dnf with args "install dwm"

--- a/dnf-behave-tests/features/history-undo-dependant.feature
+++ b/dnf-behave-tests/features/history-undo-dependant.feature
@@ -2,8 +2,8 @@ Feature: Transaction history undo
 
 @bz1700529
 Scenario: Undo module install with dependent userinstalled package
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-modular"
    # install module that contains postgresql-server
    When I execute dnf with args "module install postgresql/server"
    Then the exit code is 0

--- a/dnf-behave-tests/features/history-undo-obsoletes.feature
+++ b/dnf-behave-tests/features/history-undo-obsoletes.feature
@@ -4,7 +4,7 @@ Feature: Transaction history undo with obsoletes
 # Package glibc obsoletes glibc-profile < 2.4
 
 Scenario: Undo with obsoletes
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
 
    When I execute dnf with args "install glibc-profile"
    Then the exit code is 0
@@ -12,7 +12,7 @@ Scenario: Undo with obsoletes
         | Action        | Package                                   |
         | install       | glibc-profile-0:2.3.1-10.x86_64           |
 
-   When I use the repository "dnf-ci-fedora"
+   When I use repository "dnf-ci-fedora"
     And I execute dnf with args "install glibc-all-langpacks"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/history-undo.feature
+++ b/dnf-behave-tests/features/history-undo.feature
@@ -1,7 +1,7 @@
 Feature: Transaction history undo
 
 Background:
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
 
 Scenario: Undoing transactions
   Given I successfully execute dnf with args "install filesystem"
@@ -50,8 +50,8 @@ Scenario: Handle missing packages required for undoing the transaction
          | Action        | Package                      |
          | install       | wget-0:1.19.5-5.fc29.x86_64  |
          | install       | flac-0:1.3.2-8.fc29.x86_64   |
-   When I disable the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+   When I drop repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    Then I execute dnf with args "update"
     Then the exit code is 0
      And Transaction is following

--- a/dnf-behave-tests/features/history-update.feature
+++ b/dnf-behave-tests/features/history-update.feature
@@ -1,7 +1,7 @@
 Feature: History of update
 
 Background:
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
 
 Scenario: History of update packages
    # `install setup` step added so that `install abcde` was not the first
@@ -20,7 +20,7 @@ Scenario: History of update packages
         | install       | abcde-0:2.9.2-1.fc29.noarch               |
         | install       | flac-0:1.3.2-8.fc29.x86_64                |
         | install       | wget-0:1.19.5-5.fc29.x86_64               |
-   When I use the repository "dnf-ci-fedora-updates"
+   When I use repository "dnf-ci-fedora-updates"
     And I execute dnf with args "update"
    Then the exit code is 0
     And Transaction is following
@@ -39,7 +39,7 @@ Scenario: History of update packages
 Scenario: Rollback update
   Given I successfully execute dnf with args "install setup"
     And I execute dnf with args "install abcde"
-    And I use the repository "dnf-ci-fedora-updates"
+    And I use repository "dnf-ci-fedora-updates"
     And I successfully execute dnf with args "update"
    When I execute dnf with args "history rollback last-1"
    Then the exit code is 0

--- a/dnf-behave-tests/features/history-view.feature
+++ b/dnf-behave-tests/features/history-view.feature
@@ -1,7 +1,7 @@
 Feature: Transaction history userinstalled, list and info
 
 Background:
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
 
 Scenario: List userinstalled packages
    When I execute dnf with args "install abcde basesystem"
@@ -47,7 +47,7 @@ Scenario: History info in range - transaction merging
   Given I successfully execute dnf with args "install abcde"
   Given I successfully execute dnf with args "remove abcde"
   Given I successfully execute dnf with args "install abcde"
-   When I use the repository "dnf-ci-fedora-updates"
+   When I use repository "dnf-ci-fedora-updates"
     And I execute dnf with args "update"
    Then the exit code is 0
     And History info should match

--- a/dnf-behave-tests/features/install-exclude.feature
+++ b/dnf-behave-tests/features/install-exclude.feature
@@ -2,28 +2,28 @@ Feature: Install RPMs with --exclude
 
 
 Scenario: Install an RPM that is excluded
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem --exclude filesystem"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Install an RPM that requires excluded RPM
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem --exclude setup"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Install RPMs while excluding part of them
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup filesystem --exclude filesystem"
    Then the exit code is 1
     And Transaction is empty
 
 
 Scenario: Install RPMs while excluding part of them (strict=false)
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup filesystem --exclude filesystem --setopt=strict=false"
    Then the exit code is 0
     And Transaction is following
@@ -32,7 +32,7 @@ Scenario: Install RPMs while excluding part of them (strict=false)
 
 
 Scenario: Install RPMs while excluding another RPM
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem --exclude glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/install-fails.feature
+++ b/dnf-behave-tests/features/install-fails.feature
@@ -2,7 +2,7 @@ Feature: Installing attemps fail
 
 @bz1568965
 Scenario: Report all missing dependencies
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
     When I execute dnf with args "install SuperRipper anitras-dance"
     Then stderr contains "nothing provides abcde needed by SuperRipper-1.0-1.x86_64"
     Then stderr contains "nothing provides nodejs needed by anitras-dance-1.0-1.x86_64"

--- a/dnf-behave-tests/features/install-installed-different-version.feature
+++ b/dnf-behave-tests/features/install-installed-different-version.feature
@@ -2,7 +2,7 @@ Feature: Install different version of installed RPMs
 
 
 Scenario: Install higher versions of installed RPMs
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -13,7 +13,7 @@ Scenario: Install higher versions of installed RPMs
         | install       | glibc-0:2.28-9.fc29.x86_64                 |
         | install       | glibc-common-0:2.28-9.fc29.x86_64          |
         | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64   |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc-2.28-26.fc29"
    Then the exit code is 0
     And Transaction is following
@@ -24,8 +24,8 @@ Scenario: Install higher versions of installed RPMs
 
 
 Scenario: Install lower versions of installed RPMs
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/install-installed.feature
+++ b/dnf-behave-tests/features/install-installed.feature
@@ -2,7 +2,7 @@ Feature: Install installed RPMs
 
 
 Scenario: Install installed RPM when upgrade is available with --best
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -13,7 +13,7 @@ Scenario: Install installed RPM when upgrade is available with --best
         | install       | glibc-0:2.28-9.fc29.x86_64                |
         | install       | glibc-common-0:2.28-9.fc29.x86_64         |
         | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc --best"
    Then the exit code is 0
     And Transaction is following
@@ -25,7 +25,7 @@ Scenario: Install installed RPM when upgrade is available with --best
 
 @bz1670776 @bz1671683
 Scenario: Install installed RPM when upgrade is available with best=True (in dnf.conf)
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I do not set config file
     And I create file "/etc/dnf/dnf.conf" with
     """
@@ -45,7 +45,7 @@ Scenario: Install installed RPM when upgrade is available with best=True (in dnf
         | install       | glibc-0:2.28-9.fc29.x86_64                |
         | install       | glibc-common-0:2.28-9.fc29.x86_64         |
         | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -57,7 +57,7 @@ Scenario: Install installed RPM when upgrade is available with best=True (in dnf
 
 @bz1670776 @bz1671683
 Scenario: Install installed RPM when upgrade is available with best=False (in dnf.conf)
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I do not set config file
     And I create file "/etc/dnf/dnf.conf" with
     """
@@ -77,7 +77,7 @@ Scenario: Install installed RPM when upgrade is available with best=False (in dn
         | install       | glibc-0:2.28-9.fc29.x86_64                |
         | install       | glibc-common-0:2.28-9.fc29.x86_64         |
         | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is empty
@@ -85,7 +85,7 @@ Scenario: Install installed RPM when upgrade is available with best=False (in dn
 
 @bz1670776 @bz1671683
 Scenario: Install installed RPM when upgrade is available with option --nobest
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -96,15 +96,15 @@ Scenario: Install installed RPM when upgrade is available with option --nobest
         | install       | glibc-0:2.28-9.fc29.x86_64                |
         | install       | glibc-common-0:2.28-9.fc29.x86_64         |
         | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc --nobest"
    Then the exit code is 0
     And Transaction is empty
 
 
 Scenario: Install installed RPM when downgrade is available
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -121,7 +121,7 @@ Scenario: Install installed RPM when downgrade is available
 
 
 Scenario: Install installed RPM by NEVR when upgrade is available
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -132,15 +132,15 @@ Scenario: Install installed RPM by NEVR when upgrade is available
         | install       | glibc-0:2.28-9.fc29.x86_64                |
         | install       | glibc-common-0:2.28-9.fc29.x86_64         |
         | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc-0:2.28-9.fc29"
    Then the exit code is 0
     And Transaction is empty
 
 
 Scenario: Install installed RPM by NEVR when downgrade is available
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/install-non-existent.feature
+++ b/dnf-behave-tests/features/install-non-existent.feature
@@ -3,7 +3,7 @@ Feature: Test for installation of non-existent rpm or package
 
 @bz1578369
 Scenario: Try to install a non-existent rpm
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install non-existent.rpm"
    Then the exit code is 1
     And stderr contains "Can not load RPM file"
@@ -11,7 +11,7 @@ Scenario: Try to install a non-existent rpm
 
 
 Scenario: Try to install a non-existent package
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install non-existent-package"
    Then the exit code is 1
     And stdout contains "No match for argument"
@@ -20,7 +20,7 @@ Scenario: Try to install a non-existent package
 
 @bz1717429
 Scenario: Install an existent and an non-existent package
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup non-existent-package"
    Then the exit code is 1
     And stdout contains "No match for argument: non-existent-package"
@@ -29,7 +29,7 @@ Scenario: Install an existent and an non-existent package
 
 @bz@1717429
 Scenario: Install an existent and an non-existent package with --skip-broken
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup non-existent-package --skip-broken"
    Then the exit code is 0
     And stdout contains "No match for argument: non-existent-package"

--- a/dnf-behave-tests/features/install-obsoletes.feature
+++ b/dnf-behave-tests/features/install-obsoletes.feature
@@ -2,7 +2,7 @@ Feature: Install an obsoleted RPM
 
 
 Scenario: Install an obsoleted RPM
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install glibc-profile"
    Then the exit code is 0
     And Transaction is following
@@ -11,8 +11,8 @@ Scenario: Install an obsoleted RPM
 
 
 Scenario: Install an obsoleted RPM when the obsoleting RPM is available
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install glibc-profile"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/install-path.feature
+++ b/dnf-behave-tests/features/install-path.feature
@@ -48,8 +48,8 @@ Scenario: I can install an RPM from path, when specifying the RPM multiple times
 
 @fixture.httpd
 Scenario: I can install an RPM from url, where url is http address
-  Given I use the http repository based on "dnf-ci-fedora"
-  And I execute dnf with args "install http://localhost:{context.dnf.ports[http-dnf-ci-fedora]}/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm"
+  Given I use repository "dnf-ci-fedora" as http
+  And I execute dnf with args "install http://localhost:{context.dnf.ports[dnf-ci-fedora]}/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
@@ -58,8 +58,8 @@ Scenario: I can install an RPM from url, where url is http address
 
 @fixture.ftpd
 Scenario: I can install an RPM from url, where url is ftp address
-  Given I use the ftp repository based on "dnf-ci-fedora"
-  And I execute dnf with args "install ftp://localhost:{context.dnf.ports[ftp-dnf-ci-fedora]}/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm"
+  Given I use repository "dnf-ci-fedora" as ftp
+  And I execute dnf with args "install ftp://localhost:{context.dnf.ports[dnf-ci-fedora]}/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |

--- a/dnf-behave-tests/features/install-pkgspec.feature
+++ b/dnf-behave-tests/features/install-pkgspec.feature
@@ -1,7 +1,7 @@
 Feature: Install RPMs by pkgspec
 
 Background: Use dnf-ci-fedora repository
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
 
 @tier1
 Scenario: Install an RPM by name
@@ -50,7 +50,7 @@ Scenario: Install an RPM by name-epoch:version-release.arch
 
 
 Scenario: I can install an RPM by $pkgspec where $pkgspec is name.arch
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
     And I execute dnf with args "install flac.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -59,7 +59,7 @@ Scenario: I can install an RPM by $pkgspec where $pkgspec is name.arch
 
 
 Scenario: I can install an RPM by $pkgspec where $pkgspec contains name with dashes
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
     And I execute dnf with args "install CQRlib-devel"
    Then the exit code is 0
     And Transaction is following
@@ -69,7 +69,7 @@ Scenario: I can install an RPM by $pkgspec where $pkgspec contains name with das
 
 
 Scenario: I can install an RPM by $pkgspec where $pkgspec contains wildcards
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
     And I execute dnf with args "install flac-*.3-2.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/install-provides.feature
+++ b/dnf-behave-tests/features/install-provides.feature
@@ -2,7 +2,7 @@ Feature: Install RPMs by provides
 
 
 Scenario: Install an RPM by provide that equals to e:v-r
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install 'filesystem = 0:3.9-2.fc29'"
    Then the exit code is 0
     And Transaction is following
@@ -12,7 +12,7 @@ Scenario: Install an RPM by provide that equals to e:v-r
 
 
 Scenario: Install an RPM by provide that is greater than e:vr
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install 'filesystem > 0:3.9-2'"
    Then the exit code is 0
     And Transaction is following
@@ -22,7 +22,7 @@ Scenario: Install an RPM by provide that is greater than e:vr
 
 
 Scenario: Install an RPM by provide that is greater or equal to e:vr
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install 'filesystem >= 0:3.9-2'"
    Then the exit code is 0
     And Transaction is following
@@ -32,8 +32,8 @@ Scenario: Install an RPM by provide that is greater or equal to e:vr
 
 
 Scenario: Install an RPM by provide that is lower than e:vr
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install 'glibc < 0:2.28-26.fc29'"
    Then the exit code is 0
     And Transaction is following
@@ -47,8 +47,8 @@ Scenario: Install an RPM by provide that is lower than e:vr
 
 
 Scenario: Install an RPM by provide that is lower or equal to e:vr
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install 'glibc <= 0:2.28-26.fc29'"
    Then the exit code is 0
     And Transaction is following
@@ -62,7 +62,7 @@ Scenario: Install an RPM by provide that is lower or equal to e:vr
 
 
 Scenario: I can install an RPM by $provide where $provide is key
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "install webclient"
    Then the exit code is 0
     And Transaction is following
@@ -71,7 +71,7 @@ Scenario: I can install an RPM by $provide where $provide is key
 
 
 Scenario Outline: I can install an RPM by <provide type>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "install <provide> "
  Then the exit code is 0
   And Transaction is following

--- a/dnf-behave-tests/features/install-remove.feature
+++ b/dnf-behave-tests/features/install-remove.feature
@@ -1,7 +1,7 @@
 Feature: Install remove test
 
 Background: Use install-remove repository
-  Given I use the repository "dnf-ci-install-remove"
+  Given I use repository "dnf-ci-install-remove"
 
 # tea requires water and provides hot-beverage
 Scenario Outline: Install remove <spec type> that requires only name

--- a/dnf-behave-tests/features/installonly.feature
+++ b/dnf-behave-tests/features/installonly.feature
@@ -2,7 +2,7 @@ Feature: Test upgrading installonly packages
 
 
 Background:
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
 
 
 @bz1668256 @bz1616191 @bz1639429
@@ -13,7 +13,7 @@ Scenario: Install multiple versions of an installonly package with a limit of 2
     And Transaction is following
         | Action        | Package                               |
         | install       | kernel-core-0:4.18.16-300.fc29.x86_64 |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade"
    Then the exit code is 0
     And Transaction is following
@@ -24,7 +24,7 @@ Scenario: Install multiple versions of an installonly package with a limit of 2
    Then the exit code is 0
    Then stderr does not contain "cannot install both"
     And Transaction is empty
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "upgrade"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/list-showduplicates.feature
+++ b/dnf-behave-tests/features/list-showduplicates.feature
@@ -2,9 +2,9 @@ Feature: for list --showduplicates option
 
 
 Background: Enable repositories
-Given I use the repository "dnf-ci-fedora"
-  And I use the repository "dnf-ci-fedora-updates"
-  And I use the repository "dnf-ci-fedora-updates-testing"
+Given I use repository "dnf-ci-fedora"
+  And I use repository "dnf-ci-fedora-updates"
+  And I use repository "dnf-ci-fedora-updates-testing"
 
 
 @bz1671731
@@ -90,8 +90,8 @@ Scenario: Test for list without --showduplicates when the package is not install
 
 @bz1655605
 Scenario: Test for list --available --showduplicates when package is installed and repository is disabled
- When I disable the repository "dnf-ci-fedora"
-  And I disable the repository "dnf-ci-fedora-updates-testing"
+ When I drop repository "dnf-ci-fedora"
+  And I drop repository "dnf-ci-fedora-updates-testing"
   And I execute dnf with args "install flac-1.3.3-1.fc29.x86_64"
  Then the exit code is 0
   And Transaction is following
@@ -109,7 +109,7 @@ Scenario: Test for list --available --showduplicates when package is installed a
  flac.src\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
  flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
  """
- When I disable the repository "dnf-ci-fedora-updates"
+ When I drop repository "dnf-ci-fedora-updates"
   And I execute dnf with args "list --available --showduplicates flac"
  Then the exit code is 1
   And stdout is empty

--- a/dnf-behave-tests/features/list.feature
+++ b/dnf-behave-tests/features/list.feature
@@ -2,7 +2,7 @@ Feature: Test for dnf list (including all documented suboptions and yum compatib
 
 
 Background: Enable dnf-ci-fedora repository
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
 
 
 Scenario: dnf list nonexistentpkg
@@ -24,7 +24,7 @@ Scenario: List all packages available
 Scenario Outline: dnf list <extras alias> (installed pkgs, not from known repos)
  When I execute dnf with args "install setup"
  Then the exit code is 0
-Given I disable the repository "dnf-ci-fedora"
+Given I drop repository "dnf-ci-fedora"
   And I execute dnf with args "list <extras alias>"
  Then the exit code is 0
  Then stdout section "Extra Packages" contains "setup.noarch\s+2.12.1-1.fc29\s+@dnf-ci-fedora"
@@ -38,7 +38,7 @@ Examples:
 Scenario: dnf list setup (when setup is installed)
  When I execute dnf with args "install setup"
  Then the exit code is 0
-Given I disable the repository "dnf-ci-fedora"
+Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "list setup"
  Then stdout section "Installed Packages" contains "setup.noarch\s+2.12.1-1.fc29\s+@dnf-ci-fedora"
  Then stdout does not contain "Available Packages"
@@ -53,7 +53,7 @@ Scenario: dnf list setup (when setup is not installed but it is available)
 Scenario Outline: dnf list <installed alias> setup (when setup is installed)
  When I execute dnf with args "install setup"
  Then the exit code is 0
-Given I disable the repository "dnf-ci-fedora"
+Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "list <installed alias> setup"
  Then stdout section "Installed Packages" contains "setup.noarch\s+2.12.1-1.fc29\s+@dnf-ci-fedora"
  Then stdout does not contain "Available Packages"
@@ -138,7 +138,7 @@ Scenario: dnf list setup basesystem (when both are installed)
 Scenario: dnf list glibc\* 
  When I execute dnf with args "install glibc"
  Then the exit code is 0
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "list glibc\*"
  Then stdout section "Installed Packages" contains "glibc.x86_64\s+2.28-9.fc29\s+@dnf-ci-fedora"
  Then stdout section "Installed Packages" contains "glibc-common.x86_64\s+2.28-9.fc29\s+@dnf-ci-fedora"
@@ -150,7 +150,7 @@ Given I use the repository "dnf-ci-fedora-updates"
 Scenario Outline: dnf list <upgrades alias>
  When I execute dnf with args "install glibc"
  Then the exit code is 0
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "list <upgrades alias>"
  Then the exit code is 0
  Then stdout section "Available Upgrades" contains "glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates"
@@ -165,7 +165,7 @@ Examples:
         
 
 Scenario: dnf list upgrades glibc (when glibc is not installed)
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "list upgrades glibc"
  Then the exit code is 1
  Then stderr contains "No matching Packages"
@@ -175,7 +175,7 @@ Given I use the repository "dnf-ci-fedora-updates"
 Scenario Outline: dnf list <obsoletes alias>
  When I execute dnf with args "install glibc"
  Then the exit code is 0
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "list <obsoletes alias>"
  Then the exit code is 0
  Then stdout section "Obsoleting Packages" contains "glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates"
@@ -198,7 +198,7 @@ Scenario: dnf list obsoletes setup (when setup is not obsoleted)
 Scenario Outline: dnf list <all alias> glibc\*
  When I execute dnf with args "install glibc"
  Then the exit code is 0
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "list <all alias>"
  Then the exit code is 0
  Then stdout section "Installed Packages" contains "glibc.x86_64\s+2.28-9.fc29\s+@dnf-ci-fedora"

--- a/dnf-behave-tests/features/list.feature
+++ b/dnf-behave-tests/features/list.feature
@@ -215,7 +215,8 @@ Examples:
 
 @1550560
 Scenario: dnf list available pkgs with long names piped to grep
+Given I use repository "dnf-ci-thirdparty"
  When I execute dnf with args "clean all"
- When I execute "eval dnf -y --setopt=reposdir={context.dnf.reposdir} --disablerepo='*' --enablerepo='dnf-ci-thirdparty' --releasever={context.dnf.releasever} --installroot={context.dnf.installroot} --config={context.dnf.config} --setopt=module_platform_id={context.dnf.module_platform_id} --disableplugin='*' list available | grep 1" in "{context.dnf.installroot}"
+ When I execute "eval dnf -y --releasever={context.dnf.releasever} --installroot={context.dnf.installroot} --config={context.dnf.config} --setopt=module_platform_id={context.dnf.module_platform_id} --disableplugin='*' list available | grep 1" in "{context.dnf.installroot}"
  Then the exit code is 0
  Then stdout contains "forTestingPurposesWeEvenHaveReallyLongVersions.x86_64\s+1435347658326856238756823658aaaa-1\s+dnf-ci-thirdparty"

--- a/dnf-behave-tests/features/log-rotate.feature
+++ b/dnf-behave-tests/features/log-rotate.feature
@@ -3,7 +3,7 @@ Feature: Log rotation
 
 @bz1702690
 Scenario: Size and number of log files respects log_size and log_rotate options
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 install glibc"
     And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 remove glibc"
     And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 install glibc"

--- a/dnf-behave-tests/features/logs.feature
+++ b/dnf-behave-tests/features/logs.feature
@@ -4,7 +4,7 @@ Feature: Logs
 @not.with_os=rhel__eq__8
 @bz1739457
 Scenario: dnf.rpm.log doesn't contain duplicate entries ()
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
     And I execute dnf with args "install flac"
     And I execute dnf with args "reinstall flac"
     And I execute dnf with args "downgrade flac"

--- a/dnf-behave-tests/features/mark-install.feature
+++ b/dnf-behave-tests/features/mark-install.feature
@@ -2,13 +2,13 @@ Feature: Mark install
 
 
 Scenario: Marking non-existing package for fails
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "mark install i-dont-exist"
    Then the exit code is 1
 
 
 Scenario: Marking dependency as user-installed should not remove it automatically
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/mark-remove.feature
+++ b/dnf-behave-tests/features/mark-remove.feature
@@ -1,7 +1,7 @@
 Feature: Mark remove
 
 Scenario: Marking toplevel package for removal should not remove shared dependencies
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install nss_hesiod libnsl"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/metadata.feature
+++ b/dnf-behave-tests/features/metadata.feature
@@ -12,8 +12,6 @@ Given I create directory "/temp-repos/temp-repo"
   gpgcheck=0
   metadata_expire=1s
   """
-  And I do not set reposdir
-  And I use the repository "testrepo"
   And I execute "createrepo_c --update ." in "{context.dnf.installroot}/temp-repos/temp-repo"
  Then the exit code is 0
  When I execute dnf with args "list all"

--- a/dnf-behave-tests/features/module-defaults-from-config-file.feature
+++ b/dnf-behave-tests/features/module-defaults-from-config-file.feature
@@ -9,8 +9,8 @@ Feature: On-disk modulemd data are preferred over repodata in case of a conflict
 #    found in repodata, but never delete stream profiles.
 
 Background: Setup local module defaults
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
     And I create file "/etc/dnf/modules.defaults.d/local_defaults_a.yaml" with
         """
         ---

--- a/dnf-behave-tests/features/module-defaults-profiles.feature
+++ b/dnf-behave-tests/features/module-defaults-profiles.feature
@@ -2,8 +2,8 @@ Feature: Non-default profiles can be installed when explicitly specified on comm
 
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
 
 # module nodejs:
 #   streams: 8 [d], 10

--- a/dnf-behave-tests/features/module-defaults-streams.feature
+++ b/dnf-behave-tests/features/module-defaults-streams.feature
@@ -1,8 +1,8 @@
 Feature: Default streams are properly switched to enabled 
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
 
 
 @bz1657213
@@ -20,7 +20,7 @@ Scenario: The default stream is enabled when requiring module is enabled
 # DnfCiModulePackageDep:moduledep requires nodejs module
 
 Scenario Outline: The default stream is enabled when its package is required by installed package of another module <description>
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "module enable DnfCiModulePackageDep:<stream>"
    Then the exit code is 0
    When I execute dnf with args "install morning-mood"
@@ -41,7 +41,7 @@ Scenario Outline: The default stream is enabled when its package is required by 
 
 
 Scenario: The default stream is enabled when its package is required by installed non-modular package
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install anitras-dance"
    Then the exit code is 0
     And Transaction contains

--- a/dnf-behave-tests/features/module-defaults.feature
+++ b/dnf-behave-tests/features/module-defaults.feature
@@ -1,8 +1,8 @@
 Feature: Modulemd defaults are followed by dnf module commands
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
 
 
 Scenario: The default stream is used when enabling a module

--- a/dnf-behave-tests/features/module-disable-errors.feature
+++ b/dnf-behave-tests/features/module-disable-errors.feature
@@ -2,8 +2,8 @@ Feature: Disabling module - error handling
 
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora"
 
 
 Scenario Outline: Disabling a module by referring the <spec> should fail

--- a/dnf-behave-tests/features/module-disable.feature
+++ b/dnf-behave-tests/features/module-disable.feature
@@ -2,8 +2,8 @@ Feature: Disabling module stream
 
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora"
 
 
 @bz1677640

--- a/dnf-behave-tests/features/module-enable-confirmation.feature
+++ b/dnf-behave-tests/features/module-enable-confirmation.feature
@@ -3,7 +3,7 @@ Feature: Enable module requires confirmation
 
 Background: Do not assume yes
   Given I do not assume yes
-    And I use the repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora-modular"
 
 
 Scenario: Enable a module stream with --assumeyes

--- a/dnf-behave-tests/features/module-enable-contexts.feature
+++ b/dnf-behave-tests/features/module-enable-contexts.feature
@@ -1,7 +1,7 @@
 Feature: Dependency resolution must occur to determine the appropriate dependent stream+context to use
 
 Background:
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
 
 Scenario: Appropriate context is selected depending on the enabled required module stream
    When I execute dnf with args "module enable biotope:wood"

--- a/dnf-behave-tests/features/module-enable-dependencies.feature
+++ b/dnf-behave-tests/features/module-enable-dependencies.feature
@@ -2,7 +2,7 @@ Feature: Enable module streams with modular dependencies
 
 
 Background:
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
 
 
 Scenario: Enabling a default stream depending on a default stream
@@ -333,7 +333,7 @@ Scenario: Enable a module stream dependent on a module with a default stream
 
 
 Scenario: Enable a module stream dependent on a module without default stream
-  Given I use the repository "dnf-ci-fedora-modular-updates"
+  Given I use repository "dnf-ci-fedora-modular-updates"
    When I execute dnf with args "module enable nodejs:12"
    Then the exit code is 0
     And Transaction contains

--- a/dnf-behave-tests/features/module-enable-errors.feature
+++ b/dnf-behave-tests/features/module-enable-errors.feature
@@ -2,7 +2,7 @@ Feature: Enabling module streams - error handling
 
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular-updates"
+  Given I use repository "dnf-ci-fedora-modular-updates"
 
 
 Scenario: Fail to enable a different stream of an already enabled module
@@ -132,7 +132,7 @@ Scenario: Fail to enable a module stream when specifying more streams of the sam
 
 
 Scenario: Enabling a stream depending on other than enabled stream should fail
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
     And I create file "/etc/dnf/modules.defaults.d/defaults.yaml" with
         """
         ---
@@ -166,7 +166,7 @@ Scenario: Enabling a stream depending on other than enabled stream should fail
 
 
 Scenario: Enabling a stream depending on a disabled stream should fail
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
     And I create file "/etc/dnf/modules.defaults.d/defaults.yaml" with
         """
         ---
@@ -203,7 +203,7 @@ Scenario: Enabling a stream depending on a disabled stream should fail
 # side-dish:chip requires fluid:oil
 # beverage:beer requires fluid:water
 Scenario: Enabling two modules both requiring different streams of another module
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
    When I execute dnf with args "module enable side-dish:chips beverage:beer"
    Then the exit code is 1
     And stderr contains "Modular dependency problems:"
@@ -214,7 +214,7 @@ Scenario: Enabling two modules both requiring different streams of another modul
 # beverage:beer requires fluid:water
 @bz1651280
 Scenario: Enabling module stream and another module requiring another stream
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
    When I execute dnf with args "module enable fluid:oil beverage:beer"
    Then the exit code is 1
     And stderr contains "Modular dependency problems:"

--- a/dnf-behave-tests/features/module-enable.feature
+++ b/dnf-behave-tests/features/module-enable.feature
@@ -2,7 +2,7 @@ Feature: Enabling module streams
 
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora-modular"
 
 
 Scenario Outline: Enable a module stream by <modulespec-type>

--- a/dnf-behave-tests/features/module-filter-rpms.feature
+++ b/dnf-behave-tests/features/module-filter-rpms.feature
@@ -3,11 +3,11 @@ Feature: Filter RPMs by enabled and default module streams
 
 
 Background:
-Given I use the repository "dnf-ci-fedora-modular"
+Given I use repository "dnf-ci-fedora-modular"
 
 
 Scenario: default from module is preferred over ursine pkg
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install ninja-build"
  Then the exit code is 0
   And Transaction is following
@@ -23,7 +23,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: enabled module is preferred over ursine pkg
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "module enable ninja" 
  Then the exit code is 0
  When I execute dnf with args "install ninja-build"
@@ -40,7 +40,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: disabled module is not used
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "module disable ninja" 
  Then the exit code is 0
  When I execute dnf with args "install ninja-build"
@@ -51,7 +51,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: ursine pkg is preferred over module without default
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install dwm"
  Then the exit code is 0
   And Transaction is following

--- a/dnf-behave-tests/features/module-filtering.feature
+++ b/dnf-behave-tests/features/module-filtering.feature
@@ -1,7 +1,7 @@
 Feature: Modular filtering must provide onlu relevant source packages
 
 Background:
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
 
 @bz1702729
 Scenario: Check that only module packages including src are available

--- a/dnf-behave-tests/features/module-hotfixes.feature
+++ b/dnf-behave-tests/features/module-hotfixes.feature
@@ -2,8 +2,11 @@ Feature: hotfix repo content is not masked by a modular content
 
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
+    And I configure repository "dnf-ci-fedora-modular-hotfix" with
+        | key             | value |
+        | module_hotfixes | 1     |
 
 
 # dnf-ci-fedora-modular:        nodejs-1:8.11.4-1.module_2030+42747d40.x86_64
@@ -11,7 +14,7 @@ Background:
 
 @bz1654738
 Scenario: hotfix content updates are used when installing a module stream
-  Given I use the repository "dnf-ci-fedora-modular-hotfix"
+  Given I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "module install nodejs:8/minimal"
    Then the exit code is 0
     And Transaction contains
@@ -22,7 +25,7 @@ Scenario: hotfix content updates are used when installing a module stream
 
 
 Scenario: hotfix content update is used when installing a package
-  Given I use the repository "dnf-ci-fedora-modular-hotfix"
+  Given I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "module enable nodejs:8"
    Then the exit code is 0
     And Transaction is following
@@ -41,7 +44,7 @@ Scenario: hotfix content updates are used for updating a module
     And Transaction contains
         | Action                    | Package                                       |
         | install                   | nodejs-1:8.11.4-1.module_2030+42747d40.x86_64 |
-  Given I use the repository "dnf-ci-fedora-modular-hotfix"
+  Given I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "module update nodejs"
    Then the exit code is 0
     And Transaction contains
@@ -52,7 +55,7 @@ Scenario: hotfix content updates are used for updating a module
 Scenario: hotfix content is used when listing available updates
    When I execute dnf with args "module install nodejs:8/minimal"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-modular-hotfix"
+  Given I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "check-update"
    Then the exit code is 100
     And stdout contains "nodejs\.x86_64\s+1:8\.11\.5-1\.module_2030\+42747d40\s+dnf-ci-fedora-modular-hotfix"
@@ -61,7 +64,7 @@ Scenario: hotfix content is used when listing available updates
 Scenario: hotfix content updates are used for updating a system
    When I execute dnf with args "module install nodejs:8/minimal"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-modular-hotfix"
+  Given I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "upgrade"
    Then the exit code is 0
     And Transaction contains

--- a/dnf-behave-tests/features/module-info.feature
+++ b/dnf-behave-tests/features/module-info.feature
@@ -2,8 +2,8 @@ Feature: Module info
 
 
 Background:
-Given I use the repository "dnf-ci-fedora"
-Given I use the repository "dnf-ci-fedora-modular"
+Given I use repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora-modular"
  When I execute dnf with args "module enable nodejs:8"
  Then the exit code is 0
   And modules state is following
@@ -16,7 +16,7 @@ Given I use the repository "dnf-ci-fedora-modular"
       | install                   | nodejs-1:8.11.4-1.module_2030+42747d40.x86_64 |
       | install                   | npm-1:8.11.4-1.module_2030+42747d40.x86_64    |
       | module-profile-install    | nodejs/default                                |
-Given I use the repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
  When I execute dnf with args "module enable postgresql:11"
  Then the exit code is 0
  When I execute dnf with args "module install postgresql/client"

--- a/dnf-behave-tests/features/module-install-default.feature
+++ b/dnf-behave-tests/features/module-install-default.feature
@@ -2,7 +2,7 @@ Feature: Installing modules without profile specification using defaults from re
 
 
 Background:
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
 
 @bz1724564
 Scenario: Install module, no default profile defined, expecting no profile selection

--- a/dnf-behave-tests/features/module-install-dependency.feature
+++ b/dnf-behave-tests/features/module-install-dependency.feature
@@ -2,7 +2,7 @@ Feature: Installing modules with modular dependencies
 
 
 Background:
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
 
 
 Scenario: Install a module that requires a module, specifying one stream in Requires

--- a/dnf-behave-tests/features/module-install-errors.feature
+++ b/dnf-behave-tests/features/module-install-errors.feature
@@ -1,8 +1,8 @@
 Feature: Installing module profiles - error handling
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
 
 
 Scenario: A proper error message is displayed when I try to install a non-existent module
@@ -71,7 +71,7 @@ Scenario: A proper error message is displayed when I try to install a non-existe
 
 @xfail @bz1656782
 Scenario: Profile is not installed after its artifact failed to get installed
-  Given I use the repository "dnf-ci-fileconflicts"
+  Given I use repository "dnf-ci-fileconflicts"
    When I execute dnf with args "install FileConflict-1.0-1.x86_64"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/module-install-globs.feature
+++ b/dnf-behave-tests/features/module-install-globs.feature
@@ -2,8 +2,8 @@ Feature: Installing module profiles with globs
 
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
 
 
 Scenario: Install a module profile with glob in name
@@ -27,7 +27,7 @@ Scenario: Install a module profile with glob in name and stream
 
 
 Scenario: Install a module profile with glob in version
-  Given I use the repository "dnf-ci-fedora-modular-updates"
+  Given I use repository "dnf-ci-fedora-modular-updates"
    When I execute dnf with args "module install nodejs:10:20180920*"
    # By selecting module version that is not the latest,
    # older nodejs package from dnf-ci-fedora-modular gets installed.

--- a/dnf-behave-tests/features/module-install-local-package.feature
+++ b/dnf-behave-tests/features/module-install-local-package.feature
@@ -2,8 +2,8 @@ Feature: RPMs can be installed locally regardless the modular content
 
 
 Background: Enable dnf-ci-fedora and dnf-ci-fedora-modular
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-modular"
 
 
 @bz1582105

--- a/dnf-behave-tests/features/module-install-package-ursine.feature
+++ b/dnf-behave-tests/features/module-install-package-ursine.feature
@@ -1,8 +1,8 @@
 Feature: Installing package from ursine repo
 
 Background: Enable repositories
-  Given I use the repository "dnf-ci-thirdparty"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora"
 
 
 @bz1636390

--- a/dnf-behave-tests/features/module-install-package.feature
+++ b/dnf-behave-tests/features/module-install-package.feature
@@ -2,8 +2,8 @@ Feature: Installing package from module
 
 
 Scenario: I can install a specific package from a module
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
     And I execute dnf with args "module enable ninja:master"
    When I execute dnf with args "install ninja-build"
    Then the exit code is 0
@@ -13,7 +13,7 @@ Scenario: I can install a specific package from a module
 
 
 Scenario: I can install a package from modular repo not belonging to a module
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install solveigs-song"
    Then the exit code is 0
     And Transaction is following
@@ -22,7 +22,7 @@ Scenario: I can install a package from modular repo not belonging to a module
 
 
 Scenario: I cannot install a specific package from not enabled module when default stream is not defined
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install arabian-dance"
    Then the exit code is 1
     And stderr contains "Error: Unable to find a match"
@@ -34,8 +34,8 @@ Scenario: I cannot install a specific package from not enabled module when defau
 # ursine repo contains ninja-build-0:1.8.2-5.fc29.x86_64
 
 Scenario: module content masks ursine content - module not enabled, default stream exists
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "install ninja-build-0:1.8.2-5.fc29.x86_64"
    Then the exit code is 1
     And stderr contains "Error: Unable to find a match"
@@ -43,8 +43,8 @@ Scenario: module content masks ursine content - module not enabled, default stre
 
 
 Scenario: module content masks ursine content - non-default stream enabled
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "module enable ninja:development"
    Then the exit code is 0
    When I execute dnf with args "install ninja-build-0:1.8.2-5.fc29.x86_64"
@@ -54,8 +54,8 @@ Scenario: module content masks ursine content - non-default stream enabled
 
 
 Scenario: a package from a non-enabled module is preferred when default stream is defined
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "install ninja-build"
    Then the exit code is 0
     And Transaction contains
@@ -68,8 +68,8 @@ Scenario: a package from a non-enabled module is preferred when default stream i
 
 
 Scenario: rpm from enabled stream is preferred regardless of NVRs
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "module enable ninja:legacy"
    Then the exit code is 0
    When I execute dnf with args "install ninja-build"

--- a/dnf-behave-tests/features/module-install.feature
+++ b/dnf-behave-tests/features/module-install.feature
@@ -1,8 +1,8 @@
 Feature: Installing module profiles
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora"
 
 
 Scenario: I can install a module profile for an enabled module stream
@@ -61,7 +61,7 @@ Scenario: Installing a module and its dependencies, non-modular dependency avail
 
 @bz1618421
 Scenario: Installing a module and its dependencies, non-modular dependency is not available
-  Given I disable the repository "dnf-ci-fedora"
+  Given I drop repository "dnf-ci-fedora"
    When I execute dnf with args "module install meson:master/default"
    Then the exit code is 1
     And stderr contains lines
@@ -95,7 +95,7 @@ Scenario: Install a module of which all packages and requires are already instal
 
 @bz1592408
 Scenario: Install a module of which all packages are non-modular
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "module install DnfCiModuleNoArtifacts:master/default"
    Then the exit code is 0
     And Transaction is following
@@ -110,9 +110,8 @@ Scenario: Install a module of which all packages are non-modular
 
 
 Scenario: I can install a module profile for a stream that was enabled as dependency
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
-    And I use the repository "dnf-ci-fedora-modular-updates"
+  Given I use repository "dnf-ci-fedora-updates"
+    And I use repository "dnf-ci-fedora-modular-updates"
    When I execute dnf with args "module enable nodejs:11"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/module-list.feature
+++ b/dnf-behave-tests/features/module-list.feature
@@ -1,9 +1,9 @@
 Feature: Modules listing
 
 Background:
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora-modular-updates"
-    And I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora-modular-updates"
+    And I use repository "dnf-ci-fedora"
     And I successfully execute dnf with args "module enable nodejs:8"
     And I successfully execute dnf with args "module install nodejs:8/minimal"
     And I successfully execute dnf with args "module enable postgresql:11"
@@ -155,7 +155,7 @@ Scenario: I can limit the scope of disabled modules through providing specific m
 Scenario: Modules are ordered by repository then module name and stream name
    When I execute dnf with args "module list"
    Then the exit code is 0
-    And stdout section "dnf-ci-fedora-modular" contains "nodejs\s+5.*\n\s*nodejs\s+8.*\n\s*nodejs\s+10.*\n\s*nodejs\s+11"
-    And stdout section "dnf-ci-fedora-modular" contains "postgresql\s+6.*\n\s*postgresql\s+9.6"
-    And stdout section "dnf-ci-fedora-modular-updates" contains "nodejs\s+8.*\n\s*nodejs\s+10.*\n\s*nodejs\s+11.*\n\s*nodejs\s+12"
-    And stdout section "dnf-ci-fedora-modular-updates" contains "postgresql\s+9.6.*\n\s*postgresql\s+10.*\n\s*postgresql\s+11"
+    And stdout section "dnf-ci-fedora-modular test repository" contains "nodejs\s+5.*\n\s*nodejs\s+8.*\n\s*nodejs\s+10.*\n\s*nodejs\s+11"
+    And stdout section "dnf-ci-fedora-modular test repository" contains "postgresql\s+6.*\n\s*postgresql\s+9.6"
+    And stdout section "dnf-ci-fedora-modular-updates test repository" contains "nodejs\s+8.*\n\s*nodejs\s+10.*\n\s*nodejs\s+11.*\n\s*nodejs\s+12"
+    And stdout section "dnf-ci-fedora-modular-updates test repository" contains "postgresql\s+9.6.*\n\s*postgresql\s+10.*\n\s*postgresql\s+11"

--- a/dnf-behave-tests/features/module-platform-detection.feature
+++ b/dnf-behave-tests/features/module-platform-detection.feature
@@ -2,7 +2,7 @@
 Feature: Detecting proper modular platform
 
 Background:
-  Given I use the repository "dnf-ci-pseudo-platform-modular"
+  Given I use repository "dnf-ci-pseudo-platform-modular"
 
 Scenario: Platform pseudo module name:stream is created based on /usr/lib/os-release
   Given I do not set default module platformid
@@ -76,7 +76,7 @@ Scenario: Platform is detected using virtual provide of installed os-release pac
 
 Scenario: Platform is detected using virtual provide of os-release package in enabled repo
   Given I do not set default module platformid
-    And I use the repository "dnf-ci-pseudo-platform"
+    And I use repository "dnf-ci-pseudo-platform"
     And I create file "/etc/os-release" with
         """
         NAME=PsedoDistro
@@ -94,7 +94,7 @@ Scenario: Platform is detected using virtual provide of os-release package in en
 
 
 Scenario: Platform is detected from command line --setopt option
-  Given I use the repository "dnf-ci-pseudo-platform"
+  Given I use repository "dnf-ci-pseudo-platform"
     And I set default module platformid to "cmdline_pseudoplatform:6.0"
    When I execute dnf with args "module enable dwm:6.0"
    Then the exit code is 1

--- a/dnf-behave-tests/features/module-platform.feature
+++ b/dnf-behave-tests/features/module-platform.feature
@@ -3,7 +3,7 @@ Feature: platform pseudo-module based on /etc/os-release
 
 
 Background: allow repo
-Given I use the repository "dnf-ci-pseudo-platform-modular"
+Given I use repository "dnf-ci-pseudo-platform-modular"
 Given I create file "/etc/os-release" with
     """
     NAME=PsedoDistro

--- a/dnf-behave-tests/features/module-provides.feature
+++ b/dnf-behave-tests/features/module-provides.feature
@@ -2,8 +2,8 @@ Feature: Module provides command
 
 
 Background:
-Given I use the repository "dnf-ci-fedora-modular"
-  And I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora-modular"
+  And I use repository "dnf-ci-fedora"
 
 
 @xfail @bz1629667

--- a/dnf-behave-tests/features/module-remove.feature
+++ b/dnf-behave-tests/features/module-remove.feature
@@ -2,8 +2,8 @@ Feature: Module profile removal
 
 
 Background:
-Given I use the repository "dnf-ci-fedora-modular"
-  And I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora-modular"
+  And I use repository "dnf-ci-fedora"
  When I execute dnf with args "module enable nodejs:8"
  Then the exit code is 0
   And modules state is following
@@ -134,8 +134,8 @@ Scenario: I can remove an installed module profile using "remove @<module_spec>"
 
 @bz1700529
 Scenario: Remove module profile when userinstalled package requires its package
-Given I use the repository "dnf-ci-fifthparty"
-  And I use the repository "dnf-ci-fifthparty-modular"
+Given I use repository "dnf-ci-fifthparty"
+  And I use repository "dnf-ci-fifthparty-modular"
    # install module that contains package luke
    When I execute dnf with args "module install jedi:1/duo"
    Then the exit code is 0

--- a/dnf-behave-tests/features/module-reset.feature
+++ b/dnf-behave-tests/features/module-reset.feature
@@ -2,7 +2,7 @@ Feature: Reset modules
 
 
 Background:
-Given I use the repository "dnf-ci-fedora-modular"
+Given I use repository "dnf-ci-fedora-modular"
 
 
 # rely on merging bz1677640 fix

--- a/dnf-behave-tests/features/module-update.feature
+++ b/dnf-behave-tests/features/module-update.feature
@@ -2,8 +2,8 @@ Feature: Updating module profiles
 
 
 Background:
-Given I use the repository "dnf-ci-fedora-modular"
-  And I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora-modular"
+  And I use repository "dnf-ci-fedora"
   
 
 Scenario: I can update a module profile to a newer version
@@ -19,7 +19,7 @@ Scenario: I can update a module profile to a newer version
       | install                   | nodejs-1:8.11.4-1.module_2030+42747d40.x86_64 |
       | install                   | npm-1:8.11.4-1.module_2030+42747d40.x86_64    |
       | module-profile-install    | nodejs/default                                |
-Given I use the repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
  When I execute dnf with args "module update nodejs/default"
  Then the exit code is 0
   And Transaction is following
@@ -33,7 +33,7 @@ Scenario: Disabled but installed profile should not be receiving updates
  Then the exit code is 0
  When I execute dnf with args "module disable nodejs"
  Then the exit code is 0
-Given I use the repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
  When I execute dnf with args "module update nodejs/default"
  Then the exit code is 0
   And Transaction is empty
@@ -74,7 +74,7 @@ Scenario: I can update a module profile with package changes
       | install                   | nodejs-1:10.11.0-1.module_2200+adbac02b.x86_64 |
       | install                   | npm-1:10.11.0-1.module_2200+adbac02b.x86_64    |
       | module-profile-install    | nodejs/default                                 |
-Given I use the repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
  When I execute dnf with args "module update nodejs/default"
  Then the exit code is 0
  And Transaction contains
@@ -98,7 +98,7 @@ Scenario: default stream is used for new deps during an update
       | install                   | nodejs-1:11.0.0-1.module_2311+8d497411.x86_64 |
       | install                   | npm-1:11.0.0-1.module_2311+8d497411.x86_64    |
       | module-profile-install    | nodejs/default                                |
-Given I use the repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
  When I execute dnf with args "module update nodejs"
  Then the exit code is 0
   And Transaction is following
@@ -122,7 +122,7 @@ Scenario: Both ursine packages and modules are updated during dnf update
   And modules state is following
       | Module    | State     | Stream    | Profiles  |
       | nodejs    | enabled   | 8         |           |
-Given I use the repository "dnf-ci-thirdparty"
+Given I use repository "dnf-ci-thirdparty"
  When I execute dnf with args "install CQRlib CQRlib-extension"
  Then the exit code is 0
   And Transaction is following
@@ -136,8 +136,8 @@ Given I use the repository "dnf-ci-thirdparty"
       | install                   | nodejs-1:8.11.4-1.module_2030+42747d40.x86_64 |
       | install                   | npm-1:8.11.4-1.module_2030+42747d40.x86_64    |
       | module-profile-install    | nodejs/default                                |
-Given I use the repository "dnf-ci-fedora-modular-updates"
-Given I use the repository "dnf-ci-thirdparty-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-thirdparty-updates"
  When I execute dnf with args "update"
  Then the exit code is 0
    And Transaction is following
@@ -160,7 +160,7 @@ Scenario: Update module packages even if no profiles are installed
   And modules state is following
       | Module    | State     | Stream    | Profiles  |
       | nodejs    | enabled   | 11        |           |
-Given I use the repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
 When I execute dnf with args "module update nodejs"
  Then the exit code is 0
   And Transaction contains
@@ -173,7 +173,7 @@ When I execute dnf with args "module update nodejs"
 
 @bz1647429
 Scenario: Update module packages and dependent packages when no profiles are installed
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
    When I execute dnf with args "module enable cookbook:1 ingredience:egg"
    Then the exit code is 0
    When I execute dnf with args "install axe egg blender whisk"
@@ -187,7 +187,7 @@ Scenario: Update module packages and dependent packages when no profiles are ins
     And modules state is following
         | Module      | State      | Stream    | Profiles      |
         | cookbook    | enabled    | 1         |               |
-  Given I use the repository "dnf-ci-thirdparty-modular-updates"
+  Given I use repository "dnf-ci-thirdparty-modular-updates"
    When I execute dnf with args "module update cookbook"
    Then the exit code is 0
     And Transaction is following
@@ -203,7 +203,7 @@ Scenario: Update module packages and dependent packages when no profiles are ins
 
 @bz1647429
 Scenario: Update module packages and dependent packages when some profiles are installed
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
    When I execute dnf with args "module enable cookbook:1 ingredience:egg"
    Then the exit code is 0
    When I execute dnf with args "module install cookbook:1/axe-soup"
@@ -228,7 +228,7 @@ Scenario: Update module packages and dependent packages when some profiles are i
     And modules state is following
         | Module      | State      | Stream    | Profiles      |
         | cookbook    | enabled    | 1         | axe-soup, ham-and-eggs   |
-  Given I use the repository "dnf-ci-thirdparty-modular-updates"
+  Given I use repository "dnf-ci-thirdparty-modular-updates"
    When I execute dnf with args "module update cookbook"
    Then the exit code is 0
     And Transaction is following
@@ -245,7 +245,7 @@ Scenario: Update module packages and dependent packages when some profiles are i
 
 @bz1647429
 Scenario: Update module profiles that contains non-modular packages and packages from different modules
-  Given I use the repository "dnf-ci-thirdparty-modular"
+  Given I use repository "dnf-ci-thirdparty-modular"
    When I execute dnf with args "module enable cookbook:1 ingredience:egg"
    Then the exit code is 0
    When I execute dnf with args "module install cookbook:1/axe-soup"
@@ -265,7 +265,7 @@ Scenario: Update module profiles that contains non-modular packages and packages
     And modules state is following
         | Module      | State      | Stream    | Profiles      |
         | cookbook    | enabled    | 1         | axe-soup, ham-and-eggs  |
-  Given I use the repository "dnf-ci-thirdparty-modular-updates"
+  Given I use repository "dnf-ci-thirdparty-modular-updates"
    When I execute dnf with args "module update cookbook:1/axe-soup cookbook:1/ham-and-eggs"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/module-updateinfo.feature
+++ b/dnf-behave-tests/features/module-updateinfo.feature
@@ -2,8 +2,8 @@ Feature: Advisory aplicability on a modular system
 
 
 Background:
-Given I use the repository "dnf-ci-fedora-modular"
-  And I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora-modular"
+  And I use repository "dnf-ci-fedora"
 
 
 @bz1622614
@@ -21,7 +21,7 @@ Scenario: List available updates for installed streams (updates available)
       | install                   | postgresql-libs-0:9.6.8-1.module_1710+b535a823.x86_64   |
       | install                   | postgresql-server-0:9.6.8-1.module_1710+b535a823.x86_64 |
       | module-profile-install    | postgresql/default                                      |
-Given I use the repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
  When I execute dnf with args "updateinfo --list"
  Then the exit code is 0
   And stdout contains "FEDORA-2019-0329090518 enhancement postgresql-9.6.11-1.x86_64"
@@ -37,7 +37,7 @@ Scenario: Updates for non enabled streams are hidden
       | install                   | postgresql-server-0:6.1-1.module_2514+aa9aadc5.x86_64 |
       | install                   | postgresql-libs-0:6.1-1.module_2514+aa9aadc5.x86_64   |
       | module-profile-install    | postgresql/default                                    |
-Given I use the repository "dnf-ci-fedora-modular-updates"
+Given I use repository "dnf-ci-fedora-modular-updates"
  Then I execute dnf with args "updateinfo --list"
  Then the exit code is 0
   And stdout does not contain "FEDORA-2019-0329090518 enhancement postgresql-9.6.11-1.x86_64"

--- a/dnf-behave-tests/features/obsoletes.feature
+++ b/dnf-behave-tests/features/obsoletes.feature
@@ -6,7 +6,7 @@ Feature: Obsoleted packages
 # PackageA-Provider which provides PackageA in versin 4.0
 
 Background: Use dnf-ci-obsoletes repository
-  Given I use the repository "dnf-ci-obsoletes"
+  Given I use repository "dnf-ci-obsoletes"
 
 
 Scenario: Install of obsoleted package, but higher version than obsoleted present
@@ -102,14 +102,14 @@ Scenario: Autoremoval of obsoleted package
 @xfail
 @bz1672947
 Scenario: Multilib obsoletes during distro-sync
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install lz4-0:1.7.5-2.fc26.i686 lz4-0:1.7.5-2.fc26.x86_64"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                       |
         | install       | lz4-0:1.7.5-2.fc26.i686       |
         | install       | lz4-0:1.7.5-2.fc26.x86_64     |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "distro-sync"
    Then the exit code is 0
    Then stderr does not contain "TransactionItem not found for key: lz4"

--- a/dnf-behave-tests/features/persistdir.feature
+++ b/dnf-behave-tests/features/persistdir.feature
@@ -2,7 +2,7 @@ Feature: Track information in persistdir
 
 
 Scenario: Persistdir is created during transaction
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then the installroot path "/var/lib/dnf" does NOT exist
    When I execute dnf with args "install filesystem"
    Then the exit code is 0

--- a/dnf-behave-tests/features/plugin-api.feature
+++ b/dnf-behave-tests/features/plugin-api.feature
@@ -29,7 +29,7 @@ Given I create file "/plugins/test.py" with
                    pkg.name + "+" + pkg.version + "+" + pkg.release + "+" + pkg.arch)
 
   """
-  And I use the repository "dnf-ci-fedora"
+  And I use repository "dnf-ci-fedora"
  When I execute dnf with args "install setup filesystem"
  Then stdout contains "Plugin has access to installed pkg: setup\+2.12.1\+1.fc29\+noarch"
  Then stdout contains "Plugin has access to installed pkg: filesystem\+3.9\+2.fc29\+x86_64"

--- a/dnf-behave-tests/features/plugin-api.feature
+++ b/dnf-behave-tests/features/plugin-api.feature
@@ -53,7 +53,7 @@ Given I create file "/plugins/test.py" with
                 "custom_user_key20190218: custom_user_value",
             ])
   """
-  And I have enabled a remote repository
+  And I use repository "dnf-ci-fedora" as http
  When I execute dnf with args "makecache"
  Then every HTTP GET request should match:
     | header                  | value             |

--- a/dnf-behave-tests/features/plugins-core/builddep-modularity.feature
+++ b/dnf-behave-tests/features/plugins-core/builddep-modularity.feature
@@ -2,7 +2,7 @@ Feature: Tests for builddep command on modular system
 
 Background: Enable builddep plugin
   Given I enable plugin "builddep"
-    And I use the repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora"
 
 # dnf-ci-fedora-modular repo:
 #   module ninja:master [d] contains ninja-build-0:1.8.2-4.module_1991+4e5efe2f.x86_64
@@ -24,7 +24,7 @@ Scenario: Builddep installs non-modular build requirements
 @use.with_os=rhel__ge__8
 @bz1677583
 Scenario: Builddep preferes default stream over other streams / non-modular content even though the version is older
-  Given I use the repository "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora-modular"
    When I execute dnf with args "builddep {context.dnf.fixturesdir}/repos/dnf-ci-builddep/src/build-requires-ninja-build-1.0-1.src.rpm"
    Then the exit code is 0
     And Transaction contains
@@ -36,7 +36,7 @@ Scenario: Builddep preferes default stream over other streams / non-modular cont
 @use.with_os=rhel__ge__8
 @bz1677583
 Scenario: Builddep preferes enabled stream over other streams / non-modular content even though the version is older
-  Given I use the repository "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora-modular"
    When I execute dnf with args "module enable ninja:legacy"
    Then the exit code is 0
    When I execute dnf with args "builddep {context.dnf.fixturesdir}/repos/dnf-ci-builddep/src/build-requires-ninja-build-1.0-1.src.rpm"
@@ -49,7 +49,7 @@ Scenario: Builddep preferes enabled stream over other streams / non-modular cont
 # build-requires-ninja-build-0.5-1.src.rpm build requires ninja-build < 1.8
 @1677583
 Scenario: Builddep reports error where required package is available only in non-enabled non-default stream
-  Given I use the repository "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora-modular"
    When I execute dnf with args "builddep {context.dnf.fixturesdir}/repos/dnf-ci-builddep/src/build-requires-ninja-build-0.5-1.src.rpm"
    Then the exit code is 1
     And stderr contains lines
@@ -65,8 +65,8 @@ Scenario: Builddep reports error where required package is available only in non
 @use.with_os=rhel__ge__8
 @bz1677583
 Scenario: Builddep preferes hotfix repo over the default stream
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora-modular-hotfix"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "builddep {context.dnf.fixturesdir}/repos/dnf-ci-builddep/src/build-requires-ninja-build-nodejs-1.0-1.src.rpm"
    Then the exit code is 0
     And Transaction contains
@@ -79,8 +79,8 @@ Scenario: Builddep preferes hotfix repo over the default stream
 @use.with_os=rhel__ge__8
 @bz1677583
 Scenario: Builddep preferes hotfix repo over the enabled stream
-  Given I use the repository "dnf-ci-fedora-modular"
-    And I use the repository "dnf-ci-fedora-modular-hotfix"
+  Given I use repository "dnf-ci-fedora-modular"
+    And I use repository "dnf-ci-fedora-modular-hotfix"
    When I execute dnf with args "module enable nodejs:8"
    Then the exit code is 0
    When I execute dnf with args "builddep {context.dnf.fixturesdir}/repos/dnf-ci-builddep/src/build-requires-ninja-build-nodejs-1.0-1.src.rpm"

--- a/dnf-behave-tests/features/plugins-core/debuginfo-install.feature
+++ b/dnf-behave-tests/features/plugins-core/debuginfo-install.feature
@@ -1,7 +1,7 @@
 Feature: Tests for the debuginfo-install plugin
 
 Background:
-Given I use the repository "debuginfo-install"
+Given I use repository "debuginfo-install"
   And I enable plugin "debuginfo-install"
 
 

--- a/dnf-behave-tests/features/plugins-core/download-binary.feature
+++ b/dnf-behave-tests/features/plugins-core/download-binary.feature
@@ -4,7 +4,7 @@ Feature: dnf download command
 
 Background:
   Given I enable plugin "download"
-    And I use the http repository based on "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora" as http
     And I set working directory to "{context.dnf.tempdir}"
 
 
@@ -92,7 +92,7 @@ Scenario: Download an existing RPM with dependencies into a --destdir where all 
         | {context.dnf.tempdir}/downloaddir/setup-2.12.1-1.fc29.noarch.rpm      | -                                                                                             |
 
 Scenario: Download an existing RPM when there are multiple packages of the same NEVRA
-  Given I use the http repository based on "dnf-ci-gpg"
+  Given I use repository "dnf-ci-gpg" as http
    When I execute dnf with args "download --destdir={context.dnf.installroot}/tmp/download setup filesystem wget"
    Then the exit code is 0
     And stdout contains "setup-2.12.1-1.fc29.noarch.rpm"

--- a/dnf-behave-tests/features/plugins-core/download-debuginfo.feature
+++ b/dnf-behave-tests/features/plugins-core/download-debuginfo.feature
@@ -8,14 +8,14 @@ Background:
 
 
 Scenario: Download a debuginfo for an RPM that doesn't exist
-  Given I use the http repository based on "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora" as http
    When I execute dnf with args "download --debuginfo does-not-exist"
    Then the exit code is 1
     And stderr contains "No package does-not-exist available"
 
 
 Scenario: Download a debuginfo for an existing RPM
-  Given I use the http repository based on "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates" as http
    When I execute dnf with args "download --debuginfo libzstd"
    Then the exit code is 0
     And stdout contains "libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm"
@@ -25,7 +25,7 @@ Scenario: Download a debuginfo for an existing RPM
 
 
 Scenario: Download a debuginfo for an existing RPM with a different name
-  Given I use the http repository based on "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora" as http
    When I execute dnf with args "download --debuginfo nscd"
    Then the exit code is 0
     And stdout contains "glibc-debuginfo-2.28-9.fc29.x86_64.rpm"
@@ -39,7 +39,7 @@ Scenario: Download a debuginfo for an existing RPM with a different name
 
 
 Scenario: Download an existing --debuginfo RPM with --verbose option
-  Given I use the http repository based on "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates" as http
    When I execute dnf with args "download --debuginfo libzstd --verbose"
    Then the exit code is 0
     And stdout contains "libzstd-debuginfo-1.3.6-1.fc29.x86_64.rpm"

--- a/dnf-behave-tests/features/plugins-core/download-source.feature
+++ b/dnf-behave-tests/features/plugins-core/download-source.feature
@@ -4,7 +4,7 @@ Feature: dnf download --source command
 
 Background:
   Given I enable plugin "download"
-    And I use the http repository based on "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora" as http
     And I set working directory to "{context.dnf.tempdir}"
 
 
@@ -55,7 +55,7 @@ Scenario: Download a specified source rpm
 
 @bz1649627
 Scenario Outline: Download a source RPM when there are more versions available
-  Given I use the http repository based on "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing" as http
    When I execute dnf with args "download --source <pkgspec>"
    Then the exit code is 0
     And stdout contains "<srpm>"
@@ -76,7 +76,7 @@ Examples:
 
 @xfail
 Scenario Outline: Download a source RPM when there are more epochs available
-  Given I use the http repository based on "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing" as http
    When I execute dnf with args "download --source <pkgspec>"
    Then the exit code is 0
     And stdout contains "<srpm>"

--- a/dnf-behave-tests/features/plugins-core/enable-plugins.feature
+++ b/dnf-behave-tests/features/plugins-core/enable-plugins.feature
@@ -2,7 +2,7 @@ Feature: Tests for report nonexisting plugin
 
 Background: Enable builddep plugin
   Given I enable plugin "builddep"
-    And I use the repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora"
 
 @bz1673289 @bz1467304
 Scenario: Report nonexisting plugin to disable

--- a/dnf-behave-tests/features/plugins-core/needs-restarting.feature
+++ b/dnf-behave-tests/features/plugins-core/needs-restarting.feature
@@ -3,11 +3,11 @@ Feature: Reboot hint
 
 Background:
     Given I enable plugin "needs_restarting"
-      And I use the repository "dnf-ci-fedora"
+      And I use repository "dnf-ci-fedora"
       And I move the clock backward to "before boot-up"
       And I execute dnf with args "install lame kernel basesystem glibc wget"
       And I move the clock forward to "the present"
-      And I use the repository "dnf-ci-fedora-updates"
+      And I use repository "dnf-ci-fedora-updates"
 
 Scenario: Update core packages
     Given I execute dnf with args "upgrade kernel basesystem"

--- a/dnf-behave-tests/features/plugins-core/reposync.feature
+++ b/dnf-behave-tests/features/plugins-core/reposync.feature
@@ -7,16 +7,16 @@ Background:
 
 
 Scenario: Base functionality of reposync
-  Given I use the http repository based on "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir}"
    Then the exit code is 0
     And stdout contains ": SuperRipper-1\.2-1\."
     And stdout contains ": SuperRipper-1\.3-1\."
-    And the files "{context.dnf.tempdir}/http-dnf-ci-thirdparty-updates/x86_64/CQRlib-extension-1.6-2.x86_64.rpm" and "{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/x86_64/CQRlib-extension-1.6-2.x86_64.rpm" do not differ
+    And the files "{context.dnf.tempdir}/dnf-ci-thirdparty-updates/x86_64/CQRlib-extension-1.6-2.x86_64.rpm" and "{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/x86_64/CQRlib-extension-1.6-2.x86_64.rpm" do not differ
 
 
 Scenario: Reposync with --newest-only option
-  Given I use the http repository based on "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --newest-only"
    Then the exit code is 0
     And stdout contains ": SuperRipper-1\.3-1\."
@@ -25,24 +25,22 @@ Scenario: Reposync with --newest-only option
 
 @bz1653126 @bz1676726
 Scenario: Reposync with --downloadcomps option
-  Given I use the http repository based on "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --downloadcomps"
    Then the exit code is 0
-    And stdout contains "comps.xml for repository http-dnf-ci-thirdparty-updates saved"
-    And the files "{context.dnf.tempdir}/http-dnf-ci-thirdparty-updates/comps.xml" and "{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/comps.xml" do not differ
-   When I execute "createrepo_c --no-database --simple-md-filenames --groupfile comps.xml ." in "{context.dnf.tempdir}/http-dnf-ci-thirdparty-updates"
+    And stdout contains "comps.xml for repository dnf-ci-thirdparty-updates saved"
+    And the files "{context.dnf.tempdir}/dnf-ci-thirdparty-updates/comps.xml" and "{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/comps.xml" do not differ
+   When I execute "createrepo_c --no-database --simple-md-filenames --groupfile comps.xml ." in "{context.dnf.tempdir}/dnf-ci-thirdparty-updates"
    Then the exit code is 0
   Given I create and substitute file "/etc/yum.repos.d/test.repo" with
   """
   [testrepo]
   name=testrepo
-  baseurl={context.dnf.tempdir}/http-dnf-ci-thirdparty-updates
+  baseurl={context.dnf.tempdir}/dnf-ci-thirdparty-updates
   enabled=1
   gpgcheck=0
   """
-    And I do not set reposdir
-    And I disable the repository "http-dnf-ci-thirdparty-updates"
-    And I use the repository "testrepo"
+    And I drop repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "group list"
    Then the exit code is 0
     And stdout matches line by line
@@ -56,36 +54,34 @@ Scenario: Reposync with --downloadcomps option
 
 @bz1676726
 Scenario: Reposync with --downloadcomps option (comps.xml in repo does not exist)
-  Given I use the http repository based on "dnf-ci-rich"
+  Given I use repository "dnf-ci-rich" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --downloadcomps"
    Then the exit code is 0
-    And stdout does not contain "comps.xml for repository http-dnf-ci-rich saved"
+    And stdout does not contain "comps.xml for repository dnf-ci-rich saved"
 
 
 @bz1676726
 Scenario: Reposync with --downloadcomps and --metadata-path options
-  Given I use the http repository based on "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --metadata-path={context.dnf.tempdir}/downloadedmetadata --downloadcomps"
    Then the exit code is 0
-    And stdout contains "comps.xml for repository http-dnf-ci-thirdparty-updates saved"
-    And the files "{context.dnf.tempdir}/downloadedmetadata/http-dnf-ci-thirdparty-updates/comps.xml" and "{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/comps.xml" do not differ
+    And stdout contains "comps.xml for repository dnf-ci-thirdparty-updates saved"
+    And the files "{context.dnf.tempdir}/downloadedmetadata/dnf-ci-thirdparty-updates/comps.xml" and "{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/comps.xml" do not differ
 
 
 Scenario: Reposync with --download-metadata option
-  Given I use the http repository based on "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --download-metadata"
    Then the exit code is 0
   Given I create and substitute file "/etc/yum.repos.d/test.repo" with
   """
   [testrepo]
   name=testrepo
-  baseurl={context.dnf.tempdir}/http-dnf-ci-thirdparty-updates
+  baseurl={context.dnf.tempdir}/dnf-ci-thirdparty-updates
   enabled=1
   gpgcheck=0
   """
-    And I do not set reposdir
-    And I disable the repository "http-dnf-ci-thirdparty-updates"
-    And I use the repository "testrepo"
+    And I drop repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "group list"
    Then the exit code is 0
     And stdout contains lines
@@ -97,28 +93,28 @@ Scenario: Reposync with --download-metadata option
 
 @bz1714788
 Scenario: Reposync downloads packages from all streams of modular repository
-  Given I use the http repository based on "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora-modular" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir}"
    Then the exit code is 0
-    And file "//{context.dnf.tempdir}/http-dnf-ci-fedora-modular/x86_64/nodejs-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
-    And file "//{context.dnf.tempdir}/http-dnf-ci-fedora-modular/x86_64/nodejs-10.11.0-1.module_2200+adbac02b.x86_64.rpm" exists
-    And file "//{context.dnf.tempdir}/http-dnf-ci-fedora-modular/x86_64/nodejs-11.0.0-1.module_2311+8d497411.x86_64.rpm" exists
+    And file "//{context.dnf.tempdir}/dnf-ci-fedora-modular/x86_64/nodejs-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
+    And file "//{context.dnf.tempdir}/dnf-ci-fedora-modular/x86_64/nodejs-10.11.0-1.module_2200+adbac02b.x86_64.rpm" exists
+    And file "//{context.dnf.tempdir}/dnf-ci-fedora-modular/x86_64/nodejs-11.0.0-1.module_2311+8d497411.x86_64.rpm" exists
 
 
 @bz1714788
 Scenario: Reposync downloads packages from all streams of modular repository even if the module is disabled
-  Given I use the http repository based on "dnf-ci-fedora-modular"
+  Given I use repository "dnf-ci-fedora-modular" as http
    When I execute dnf with args "module disable nodejs"
    Then the exit code is 0
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir}"
    Then the exit code is 0
-    And file "//{context.dnf.tempdir}/http-dnf-ci-fedora-modular/x86_64/nodejs-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
-    And file "//{context.dnf.tempdir}/http-dnf-ci-fedora-modular/x86_64/nodejs-10.11.0-1.module_2200+adbac02b.x86_64.rpm" exists
-    And file "//{context.dnf.tempdir}/http-dnf-ci-fedora-modular/x86_64/nodejs-11.0.0-1.module_2311+8d497411.x86_64.rpm" exists
+    And file "//{context.dnf.tempdir}/dnf-ci-fedora-modular/x86_64/nodejs-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
+    And file "//{context.dnf.tempdir}/dnf-ci-fedora-modular/x86_64/nodejs-10.11.0-1.module_2200+adbac02b.x86_64.rpm" exists
+    And file "//{context.dnf.tempdir}/dnf-ci-fedora-modular/x86_64/nodejs-11.0.0-1.module_2311+8d497411.x86_64.rpm" exists
 
 
 Scenario: Reposync downloads packages and removes packages that are not part of repo anymore
-  Given I use the repository "setopt.ext"
+  Given I use repository "setopt.ext"
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir}"
    Then the exit code is 0
     And file "//{context.dnf.tempdir}/setopt.ext/x86_64/wget-1.0-1.fc29.x86_64.rpm" exists
@@ -126,18 +122,20 @@ Scenario: Reposync downloads packages and removes packages that are not part of 
     And file "//{context.dnf.tempdir}/setopt.ext/x86_64/flac-1.0-1.fc29.x86_64.rpm" exists
     And file "//{context.dnf.tempdir}/setopt.ext/src/flac-1.0-1.fc29.src.rpm" exists
     And file "//{context.dnf.tempdir}/setopt.ext/x86_64/flac-libs-1.0-1.fc29.x86_64.rpm" exists
-
   Given I create and substitute file "/etc/yum.repos.d/test.repo" with
   """
   [setopt.ext]
   name=setopt.ext
-  baseurl=file://$DNF0/repos/setopt
+  baseurl={context.dnf.repos_location}/setopt
   enabled=1
   gpgcheck=0
   skip_if_unavailable=0
   """
-    And I do not set reposdir
-  When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --refresh --delete"
+    And I drop repository "setopt.ext"
+    # The following two steps generate repodata for the repository without configuring it
+    And I use repository "setopt"
+    And I drop repository "setopt"
+   When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --refresh --delete"
    Then the exit code is 0
     And file "//{context.dnf.tempdir}/setopt.ext/x86_64/wget-1.0-1.fc29.x86_64.rpm" exists
     And file "//{context.dnf.tempdir}/setopt.ext/src/wget-1.0-1.fc29.src.rpm" exists
@@ -147,22 +145,22 @@ Scenario: Reposync downloads packages and removes packages that are not part of 
 
 
 Scenario: Reposync preserves remote timestamps of packages
-  Given I use the http repository based on "reposync"
+  Given I use repository "reposync" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --remote-time"
    Then the exit code is 0
     And stdout matches line by line
     """
-    http-reposync .*
-    \(1/2\): wget-1\.0-1\.fc29\.src\.rpm .*
-    \(2/2\): wget-1\.0-1\.fc29\.x86_64\.rpm .*
+    reposync .*
+    \(1/2\): wget-1\.0-1\.fc29\.x86_64\.rpm .*
+    \(2/2\): wget-1\.0-1\.fc29\.src\.rpm .*
     """
-    And the files "{context.dnf.tempdir}/http-reposync/x86_64/wget-1.0-1.fc29.x86_64.rpm" and "{context.dnf.fixturesdir}/repos/reposync/x86_64/wget-1.0-1.fc29.x86_64.rpm" do not differ
-    And timestamps of the files "{context.dnf.tempdir}/http-reposync/x86_64/wget-1.0-1.fc29.x86_64.rpm" and "{context.dnf.fixturesdir}/repos/reposync/x86_64/wget-1.0-1.fc29.x86_64.rpm" do not differ
+    And the files "{context.dnf.tempdir}/reposync/x86_64/wget-1.0-1.fc29.x86_64.rpm" and "{context.dnf.fixturesdir}/repos/reposync/x86_64/wget-1.0-1.fc29.x86_64.rpm" do not differ
+    And timestamps of the files "{context.dnf.tempdir}/reposync/x86_64/wget-1.0-1.fc29.x86_64.rpm" and "{context.dnf.fixturesdir}/repos/reposync/x86_64/wget-1.0-1.fc29.x86_64.rpm" do not differ
 
 
 Scenario: Reposync preserves remote timestamps of metadata files
-  Given I use the http repository based on "reposync"
+  Given I use repository "reposync" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --download-metadata --remote-time"
    Then the exit code is 0
-    And the files "{context.dnf.tempdir}/http-reposync/repodata/primary.xml.gz" and "{context.dnf.fixturesdir}/repos/reposync/repodata/primary.xml.gz" do not differ
-    And timestamps of the files "{context.dnf.tempdir}/http-reposync/repodata/primary.xml.gz" and "{context.dnf.fixturesdir}/repos/reposync/repodata/primary.xml.gz" do not differ
+    And the files "{context.dnf.tempdir}/reposync/repodata/primary.xml.gz" and "{context.dnf.fixturesdir}/repos/reposync/repodata/primary.xml.gz" do not differ
+    And timestamps of the files "{context.dnf.tempdir}/reposync/repodata/primary.xml.gz" and "{context.dnf.fixturesdir}/repos/reposync/repodata/primary.xml.gz" do not differ

--- a/dnf-behave-tests/features/protected_packages.feature
+++ b/dnf-behave-tests/features/protected_packages.feature
@@ -2,7 +2,7 @@ Feature: Protected packages
 
 
 Background: Use dnf-ci-fedora repository
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "install filesystem"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/provides-alternatives.feature
+++ b/dnf-behave-tests/features/provides-alternatives.feature
@@ -2,7 +2,7 @@ Feature: Alternative packages are suggested when package is not available
 
 @bz1625586
 Scenario: Alternative packages are suggested during package install
-Given I use the repository "dnf-ci-thirdparty"
+Given I use repository "dnf-ci-thirdparty"
  When I execute dnf with args "install IHaveAlternatives"
  Then the exit code is 1
   And stdout contains "No match for argument: IHaveAlternatives"

--- a/dnf-behave-tests/features/provides.feature
+++ b/dnf-behave-tests/features/provides.feature
@@ -2,13 +2,13 @@ Feature: Test for dnf provides
 
 
 Background: use dnf-ci-fedora repository
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
 
 
 Scenario: dnf provides webclient - installed package wget provides webclient
    When I execute dnf with args "install wget glibc"
    Then the exit code is 0
-  Given I disable the repository "dnf-ci-fedora"
+  Given I drop repository "dnf-ci-fedora"
    When I execute dnf with args "provides webclient"
    Then stdout contains "wget-1.19.5-5.fc29[^R]+Repo[ \t]+: @System"
     And stdout does not contain "(glibc)|(setup)"
@@ -26,7 +26,7 @@ Scenario: dnf provides webclient - installed and in repo package wget provides w
 Scenario: dnf provides webclient - installed and in repos package wget provides webclient
    When I execute dnf with args "install wget glibc"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "provides webclient"
    Then stdout contains "wget-1.19.5-5.fc29[^R]+Repo[ \t]+: @System"
    Then stdout contains "wget-1.19.5-5.fc29[^R]+Repo[ \t]+: dnf-ci-fedora"

--- a/dnf-behave-tests/features/reinstall-reason.feature
+++ b/dnf-behave-tests/features/reinstall-reason.feature
@@ -3,15 +3,15 @@ Feature: Reinstall must keep the "reason" why a package was installed
 
 
 Scenario: Reinstall a dependency, and then remove the main package
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install CQRlib-devel"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
         | install       | CQRlib-0:1.1.2-16.fc29.x86_64             |
         | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "reinstall CQRlib"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/reinstall.feature
+++ b/dnf-behave-tests/features/reinstall.feature
@@ -2,8 +2,8 @@ Feature: Reinstall
 
 
 Background: Install CQRlib-devel and CQRlib
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install CQRlib-devel"
    Then the exit code is 0
     And Transaction is following
@@ -21,7 +21,7 @@ Scenario: Reinstall an RPM from the same repository
 
 
 Scenario: Reinstall an RPM from different repository
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "reinstall CQRlib"
    Then the exit code is 0
     And Transaction is following
@@ -30,6 +30,6 @@ Scenario: Reinstall an RPM from different repository
 
 
 Scenario: Reinstall an RPM that is not available
-  Given I disable the repository "dnf-ci-fedora-updates"
+  Given I drop repository "dnf-ci-fedora-updates"
    When I execute dnf with args "reinstall CQRlib"
    Then the exit code is 1

--- a/dnf-behave-tests/features/remove-duplicates.feature
+++ b/dnf-behave-tests/features/remove-duplicates.feature
@@ -38,7 +38,7 @@ Scenario: Remove a duplicate RPM and reinstall an existing RPM when a copy is av
    Then the exit code is 0
   Given I execute rpm with args "-i {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/flac-1.3.3-3.fc29.x86_64.rpm"
    Then the exit code is 0
-    And I use the repository "dnf-ci-fedora-updates"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "remove --duplicates"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/remove-exclude.feature
+++ b/dnf-behave-tests/features/remove-exclude.feature
@@ -2,7 +2,7 @@ Feature: Remove RPMs with --exclude
 
 
 Scenario: Remove RPMs while excluding another RPM
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install basesystem"
    Then the exit code is 0
     And Transaction is following
@@ -19,7 +19,7 @@ Scenario: Remove RPMs while excluding another RPM
 
 
 Scenario: Remove RPM which is required by excluded RPM
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/remove-pkgspec.feature
+++ b/dnf-behave-tests/features/remove-pkgspec.feature
@@ -2,7 +2,7 @@ Feature: Remove RPMs by pkgspec
 
 
 Background: Install glibc
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/remove-protected.feature
+++ b/dnf-behave-tests/features/remove-protected.feature
@@ -2,7 +2,7 @@ Feature: Do not remove protected RPMs
 
 @use.with_os=rhel__ge__8
 Scenario: Cannot remove protected package yum
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install yum"
    Then the exit code is 0
    When I execute dnf with args "remove yum"

--- a/dnf-behave-tests/features/remove-provides.feature
+++ b/dnf-behave-tests/features/remove-provides.feature
@@ -2,7 +2,7 @@ Feature: Remove RPMs by provides
 
 
 Background: Install glibc
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/repo-packages-check-update.feature
+++ b/dnf-behave-tests/features/repo-packages-check-update.feature
@@ -2,7 +2,7 @@ Feature: repo-packages check-update
 
 
 Scenario: check for updates - not available
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install basesystem"
  Then the exit code is 0
   And Transaction is following
@@ -16,7 +16,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: check for updates in not enabled repo - available
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
   And Transaction is following
@@ -27,6 +27,9 @@ Given I use the repository "dnf-ci-fedora"
       | install       | glibc-0:2.28-9.fc29.x86_64                |
       | install       | glibc-common-0:2.28-9.fc29.x86_64         |
       | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+  Given I use repository "dnf-ci-fedora-updates" with configuration
+      | key     | value |
+      | enabled | 0     |
  When I execute dnf with args "repository-packages dnf-ci-fedora-updates check-update"
  Then the exit code is 100
  Then stdout contains "glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates"
@@ -35,7 +38,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: check for updates in enabled repo - available
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
   And Transaction is following
@@ -46,7 +49,7 @@ Given I use the repository "dnf-ci-fedora"
       | install       | glibc-0:2.28-9.fc29.x86_64                |
       | install       | glibc-common-0:2.28-9.fc29.x86_64         |
       | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "repository-packages dnf-ci-fedora-updates check-update"
  Then the exit code is 100
  Then stdout contains "glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates"

--- a/dnf-behave-tests/features/repo-packages-info.feature
+++ b/dnf-behave-tests/features/repo-packages-info.feature
@@ -1,7 +1,7 @@
 Feature: repository-packages info
 
 Scenario: List info of all packages from repository
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install filesystem"
  Then the exit code is 0
   And Transaction is following
@@ -26,7 +26,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: List all installed packages from repository
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "repository-packages dnf-ci-fedora info installed"
@@ -37,7 +37,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: Single repository package info
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "repository-packages dnf-ci-fedora info setup"
@@ -49,33 +49,24 @@ Given I use the repository "dnf-ci-fedora"
 
 Scenario Outline: List repo <extras alias> - installed from repo, but not available anymore
 # use temporary copy of repository dnf-ci-fedora for this test
-Given I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/temp-repo"
-  And I create and substitute file "/etc/yum.repos.d/test.repo" with
-  """
-  [testrepo]
-  name=testrepo
-  baseurl={context.dnf.installroot}/temp-repos/temp-repo
-  enabled=1
-  gpgcheck=0
-  """
-  And I do not set reposdir
-  And I use the repository "testrepo"
+Given I copy repository "dnf-ci-fedora" for modification
+  And I use repository "dnf-ci-fedora"
  When I execute dnf with args "install setup"
  Then the exit code is 0
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |
-Given I delete file "/temp-repos/temp-repo/noarch/setup-2.12.1-1.fc29.noarch.rpm"
+Given I delete file "/{context.dnf.repos[dnf-ci-fedora].path}/noarch/setup-2.12.1-1.fc29.noarch.rpm"
  Then the exit code is 0
-Given I delete file "/temp-repos/temp-repo/src/setup-2.12.1-1.fc29.src.rpm"
+Given I delete file "/{context.dnf.repos[dnf-ci-fedora].path}/src/setup-2.12.1-1.fc29.src.rpm"
  Then the exit code is 0
-  And I execute "createrepo_c --update ." in "{context.dnf.installroot}/temp-repos/temp-repo"
+  And I execute "createrepo_c --update ." in "/{context.dnf.repos[dnf-ci-fedora].path}"
  Then the exit code is 0
  When I execute dnf with args "clean expire-cache"
  Then the exit code is 0
- When I execute dnf with args "repository-packages testrepo info <extras alias>"
+ When I execute dnf with args "repository-packages dnf-ci-fedora info <extras alias>"
  Then the exit code is 0
- Then stdout contains "testrepo"
+ Then stdout contains "dnf-ci-fedora"
  Then stdout contains "Extra Packages"
  Then stdout contains "Source\s+:\s+setup-2.12.1-1.fc29.src.rpm"
  Then stdout does not contain "Source\s+:\s+glibc-2.28-9.fc29.src.rpm"

--- a/dnf-behave-tests/features/repo-packages-list.feature
+++ b/dnf-behave-tests/features/repo-packages-list.feature
@@ -2,7 +2,7 @@ Feature: repository-packages list installed packages from repository
 
 
 Scenario: List related packages to repo "dnf-ci-fedora"
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install basesystem"
  Then the exit code is 0
  When I execute dnf with args "repository-packages -q dnf-ci-fedora list"
@@ -16,7 +16,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: List installed packages from repo "dnf-ci-fedora"
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
  When I execute dnf with args "repository-packages -q dnf-ci-fedora list --installed"
@@ -27,7 +27,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: List available packages from repo "dnf-ci-fedora"
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "repository-packages -q dnf-ci-fedora list --available"
  Then the exit code is 0
  Then stdout section "Available Packages" contains "glibc-common.x86_64\s+2.28-9.fc29\s+dnf-ci-fedora"
@@ -38,10 +38,10 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: List packages from repo "dnf-ci-fedora-updates" that obsolete some installed packages
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "repository-packages -q dnf-ci-fedora-updates list --obsoletes"
  Then the exit code is 0
  Then stdout section "Obsoleting Packages" contains "glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates"
@@ -49,10 +49,10 @@ Given I use the repository "dnf-ci-fedora-updates"
 
 
 Scenario: List packages from repo "dnf-ci-fedora-updates" that upgrade some installed packages
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "repository-packages -q dnf-ci-fedora-updates list --upgrades"
  Then the exit code is 0
  Then stdout section "Available Upgrades" contains "glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates"

--- a/dnf-behave-tests/features/repo-packages-reinstall.feature
+++ b/dnf-behave-tests/features/repo-packages-reinstall.feature
@@ -23,8 +23,8 @@ Given I use repository "dnf-ci-fedora"
       | reinstall     | glibc-0:2.28-9.fc29.x86_64               |
       | reinstall     | glibc-common-0:2.28-9.fc29.x86_64        |
       | reinstall     | glibc-all-langpacks-0:2.28-9.fc29.x86_64 |
-        
-        
+
+
 Scenario: fail reinstall-old packages from non existing repository
 Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
@@ -37,6 +37,6 @@ Given I use repository "dnf-ci-fedora"
       | install       | glibc-0:2.28-9.fc29.x86_64               |
       | install       | glibc-common-0:2.28-9.fc29.x86_64        |
       | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64 |
-Given There are no repositories
+Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "repo-packages dnf-ci-fedora reinstall-old"
  Then the exit code is 1

--- a/dnf-behave-tests/features/repo-packages-reinstall.feature
+++ b/dnf-behave-tests/features/repo-packages-reinstall.feature
@@ -2,7 +2,7 @@ Feature: repository-packages reinstall-old
 
 
 Scenario: reinstall-old packages from repository
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
   And Transaction is following
@@ -26,7 +26,7 @@ Given I use the repository "dnf-ci-fedora"
         
         
 Scenario: fail reinstall-old packages from non existing repository
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
   And Transaction is following

--- a/dnf-behave-tests/features/repo-packages-remove-or-distro-sync.feature
+++ b/dnf-behave-tests/features/repo-packages-remove-or-distro-sync.feature
@@ -2,7 +2,7 @@ Feature: repo-packages remove-or-distro-sync
 
 
 Scenario: Sync package to latest version in available repositories
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -13,7 +13,7 @@ Scenario: Sync package to latest version in available repositories
         | install       | basesystem-0:11-6.fc29.noarch         |
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install       | setup-0:2.12.1-1.fc29.noarch          |
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "repo-packages dnf-ci-fedora remove-or-distro-sync glibc"
    Then the exit code is 0
     And Transaction is following
@@ -24,14 +24,14 @@ Scenario: Sync package to latest version in available repositories
 
 
 Scenario: Remove repository package because it's not available in other repositories
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                               |
         | install       | setup-0:2.12.1-1.fc29.noarch          |
   # following line is not necessary - the package isn't available in the repo anyway
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "repo-packages dnf-ci-fedora remove-or-distro-sync setup"
    Then the exit code is 0
     And Transaction is following
@@ -40,8 +40,8 @@ Scenario: Remove repository package because it's not available in other reposito
 
 
 Scenario: Remove and distro-sync packages from a repository
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc libzstd"
    Then the exit code is 0
     And Transaction is following
@@ -64,7 +64,7 @@ Scenario: Remove and distro-sync packages from a repository
 
 
 Scenario: Fail on no package installed from the repo
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
     And Transaction is following
@@ -76,6 +76,6 @@ Scenario: Fail on no package installed from the repo
 
 
 Scenario: Fail on a non-existent package
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "repo-packages dnf-ci-fedora remove-or-distro-sync pkg-does-not-exist"
    Then the exit code is 1

--- a/dnf-behave-tests/features/repo-packages-remove-or-reinstall.feature
+++ b/dnf-behave-tests/features/repo-packages-remove-or-reinstall.feature
@@ -2,8 +2,8 @@ Feature: repo-packages remove-or-reinstall
 
 
 Scenario: remove-or-reinstall all packages from repository
-Given I use the repository "dnf-ci-fedora"
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "install CQRlib-devel libzstd"
  Then the exit code is 0
   And Transaction is following
@@ -17,7 +17,7 @@ Given I use the repository "dnf-ci-fedora-updates"
       | install       | CQRlib-0:1.1.2-16.fc29.x86_64             |
       | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
       | install       | libzstd-0:1.3.6-1.fc29.x86_64             |
-Given I use the repository "dnf-ci-fedora-updates-testing"
+Given I use repository "dnf-ci-fedora-updates-testing"
  When I execute dnf with args "repo-packages dnf-ci-fedora-updates remove-or-reinstall"
  Then the exit code is 0
   And Transaction is following
@@ -33,7 +33,7 @@ Given I use the repository "dnf-ci-fedora-updates-testing"
 
 
 Scenario: Remove single package from repository
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install setup"
  Then the exit code is 0
   And Transaction is following
@@ -47,13 +47,13 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: Reinstall single package from repository
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "install CQRlib"
  Then the exit code is 0
   And Transaction is following
       | Action        | Package                                   |
       | install       | CQRlib-0:1.1.2-16.fc29.x86_64             |
-Given I use the repository "dnf-ci-fedora-updates-testing"
+Given I use repository "dnf-ci-fedora-updates-testing"
  When I execute dnf with args "repo-packages dnf-ci-fedora-updates remove-or-reinstall CQRlib"
  Then the exit code is 0
   And Transaction is following

--- a/dnf-behave-tests/features/repo-packages-remove.feature
+++ b/dnf-behave-tests/features/repo-packages-remove.feature
@@ -3,8 +3,8 @@ Feature: repo-packages remove
 
   Scenario: Remove packages from available repository, also remove their 
     dependencies and packages that depend on them (even from other repositories)
-Given I use the repository "dnf-ci-fedora"
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "install CQRlib-devel libzstd"
  Then the exit code is 0
   And Transaction is following

--- a/dnf-behave-tests/features/repo-packages-upgrade.feature
+++ b/dnf-behave-tests/features/repo-packages-upgrade.feature
@@ -2,7 +2,7 @@ Feature: repo-packages upgrade
 
 
 Scenario: upgrade packages from not enabled repo
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
   And Transaction is following
@@ -23,7 +23,7 @@ Given I use the repository "dnf-ci-fedora"
 
 
 Scenario: upgrade packages from enabled repo
-Given I use the repository "dnf-ci-fedora"
+Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "install glibc"
  Then the exit code is 0
   And Transaction is following
@@ -34,7 +34,7 @@ Given I use the repository "dnf-ci-fedora"
       | install       | glibc-0:2.28-9.fc29.x86_64                |
       | install       | glibc-common-0:2.28-9.fc29.x86_64         |
       | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-Given I use the repository "dnf-ci-fedora-updates"
+Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "repository-packages dnf-ci-fedora-updates upgrade"
  Then the exit code is 0
   And Transaction is following

--- a/dnf-behave-tests/features/repo-packages-upgrade.feature
+++ b/dnf-behave-tests/features/repo-packages-upgrade.feature
@@ -13,6 +13,9 @@ Given I use repository "dnf-ci-fedora"
       | install       | glibc-0:2.28-9.fc29.x86_64                |
       | install       | glibc-common-0:2.28-9.fc29.x86_64         |
       | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+  Given I use repository "dnf-ci-fedora-updates" with configuration
+      | key     | value |
+      | enabled | 0     |
  When I execute dnf with args "repository-packages dnf-ci-fedora-updates upgrade"
  Then the exit code is 0
   And Transaction is following

--- a/dnf-behave-tests/features/repo-priorities.feature
+++ b/dnf-behave-tests/features/repo-priorities.feature
@@ -2,9 +2,15 @@ Feature: Repositories with priorities
 
 
 Background: Use repositories with priorities 1, 2, and 3
-  Given I use the repository "dnf-ci-priority-1"
-    And I use the repository "dnf-ci-priority-2"
-    And I use the repository "dnf-ci-priority-3"
+  Given I use repository "dnf-ci-priority-1" with configuration
+        | key      | value |
+        | priority | 1     |
+    And I use repository "dnf-ci-priority-2" with configuration
+        | key      | value |
+        | priority | 2     |
+    And I use repository "dnf-ci-priority-3" with configuration
+        | key      | value |
+        | priority | 3     |
 
 
 Scenario: Install an RPM from the highest-priority repository
@@ -97,7 +103,7 @@ Scenario: Upgrade RPMs from different highest-priority repositories
         | install       | glibc-0:2.28-9.fc29.x86_64                |
         | install       | glibc-common-0:2.28-9.fc29.x86_64         |
         | install       | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-   When I disable the repository "dnf-ci-priority-1"
+   When I drop repository "dnf-ci-priority-1"
    When I execute dnf with args "upgrade setup glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/repo-sync.feature
+++ b/dnf-behave-tests/features/repo-sync.feature
@@ -4,8 +4,7 @@ Feature: Tests for the repository syncing functionality
 @bz1679509
 @bz1692452
 Scenario: The default value of skip_if_unavailable is False
-  Given I use the repository "testrepo"
-    And I create file "/etc/dnf/dnf.conf" with
+  Given I create file "/etc/dnf/dnf.conf" with
     """
     [main]
     reposdir=/testrepos
@@ -18,7 +17,6 @@ Scenario: The default value of skip_if_unavailable is False
     enabled=1
     gpgcheck=0
     """
-    And I do not set reposdir
     And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 1
@@ -30,8 +28,7 @@ Scenario: The default value of skip_if_unavailable is False
 
 @bz1689931
 Scenario: There is global skip_if_unavailable option
-  Given I use the repository "testrepo"
-    And I create file "/etc/dnf/dnf.conf" with
+  Given I create file "/etc/dnf/dnf.conf" with
     """
     [main]
     reposdir=/testrepos
@@ -45,7 +42,6 @@ Scenario: There is global skip_if_unavailable option
     enabled=1
     gpgcheck=0
     """
-    And I do not set reposdir
     And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 0
@@ -62,8 +58,7 @@ Scenario: There is global skip_if_unavailable option
 
 
 Scenario: Per repo skip_if_unavailable configuration
-  Given I use the repository "testrepo"
-    And I create file "/etc/dnf/dnf.conf" with
+  Given I create file "/etc/dnf/dnf.conf" with
     """
     [main]
     reposdir=/testrepos
@@ -77,7 +72,6 @@ Scenario: Per repo skip_if_unavailable configuration
     gpgcheck=0
     skip_if_unavailable=True
     """
-    And I do not set reposdir
     And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 0
@@ -95,8 +89,7 @@ Scenario: Per repo skip_if_unavailable configuration
 
 @bz1689931
 Scenario: The repo configuration takes precedence over the global one
-  Given I use the repository "testrepo"
-    And I create file "/etc/dnf/dnf.conf" with
+  Given I create file "/etc/dnf/dnf.conf" with
     """
     [main]
     reposdir=/testrepos
@@ -111,7 +104,6 @@ Scenario: The repo configuration takes precedence over the global one
     gpgcheck=0
     skip_if_unavailable=False
     """
-    And I do not set reposdir
     And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 1
@@ -124,23 +116,9 @@ Scenario: The repo configuration takes precedence over the global one
 @not.with_os=rhel__eq__8
 @bz1741442
 Scenario: Test repo_gpgcheck=1 error if repomd.xml.asc is not present
-Given I use the repository "testrepo"
-  And I create file "/etc/dnf/dnf.conf" with
-      """
-      [main]
-      reposdir=/testrepos
-      """
-  And I create and substitute file "/testrepos/test.repo" with
-      """
-      [testrepo]
-      name=testrepo
-      baseurl={context.dnf.repos_location}/dnf-ci-fedora
-      enabled=1
-      gpgcheck=0
-      repo_gpgcheck=1
-      """
-  And I do not set reposdir
-  And I do not set config file
+Given I use repository "dnf-ci-fedora" with configuration
+      | key           | value |
+      | repo_gpgcheck | 1     |
  When I execute dnf with args "makecache"
  Then the exit code is 1
-  And stderr contains "Error: Failed to download metadata for repo 'testrepo': GPG verification is enabled, but GPG signature is not available. This may be an error or the repository does not support GPG verification: Curl error \(37\): Couldn't read a file:// file"
+  And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': GPG verification is enabled, but GPG signature is not available. This may be an error or the repository does not support GPG verification: Curl error \(37\): Couldn't read a file:// file"

--- a/dnf-behave-tests/features/repolist-disabled.feature
+++ b/dnf-behave-tests/features/repolist-disabled.feature
@@ -1,5 +1,10 @@
 Feature: Repolist when all repositories are disabled
 
+Background:
+  Given I use repository "dnf-ci-fedora" with configuration
+        |key      | value |
+        | enabled | 0     |
+
 
 Scenario: Repolist without arguments
    When I execute dnf with args "repolist"
@@ -17,15 +22,11 @@ Scenario: Repolist with "disabled"
    When I execute dnf with args "repolist disabled"
    Then the exit code is 0
     And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora"
-    And stdout contains "dnf-ci-fedora-updates\s+dnf-ci-fedora-updates"
-    And stdout contains "dnf-ci-thirdparty\s+dnf-ci-thirdparty"
-    And stdout contains "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"
 
 
 Scenario: Repolist with "all"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "repolist all"
    Then the exit code is 0
-    And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora\s+disabled"
-    And stdout contains "dnf-ci-fedora-updates\s+dnf-ci-fedora-updates\s+disabled"
-    And stdout contains "dnf-ci-thirdparty\s+dnf-ci-thirdparty\s+disabled"
-    And stdout contains "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates\s+disabled"
+    And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora test repository\s+disabled"
+    And stdout contains "dnf-ci-fedora-updates\s+dnf-ci-fedora-updates test repository\s+enabled"

--- a/dnf-behave-tests/features/repolist-enablerepo-disablerepo.feature
+++ b/dnf-behave-tests/features/repolist-enablerepo-disablerepo.feature
@@ -8,34 +8,25 @@ Feature: Repolist with --enablerepo and --disablerepo
 #   --enablerepo   strict=false  -> warning
 
 
-Background: Do not add --disablerepo='*' to the dnf command by default
-  Given I do not disable all repos
-
-
 Scenario: List repositories with --enablerepo='*' when there are no repo files - strict
-  Given There are no repositories
    When I execute dnf with args "repolist --enablerepo='*' --setopt=strict=true"
    Then the exit code is 1
     And stderr contains "Error: Unknown repo: '*'"
 
 
 Scenario: List repositories with --enablerepo='*' when there are no repo files - not strict
-  Given There are no repositories
    When I execute dnf with args "repolist --enablerepo='*' --setopt=strict=false"
    Then the exit code is 0
     And stderr contains "No repositories available"
 
 
 Scenario: List repositories with --disablerepo='*' when there are no repo files - strict
-  Given There are no repositories
    When I execute dnf with args "repolist --disablerepo='*' --setopt=strict=true"
    Then the exit code is 0
     And stderr contains "No repositories available"
 
 
 Scenario: List repositories with --disablerepo='*' when there are no repo files - not strict
-  Given There are no repositories
    When I execute dnf with args "repolist --disablerepo='*' --setopt=strict=false"
    Then the exit code is 0
     And stderr contains "No repositories available"
-

--- a/dnf-behave-tests/features/repolist-no-repos.feature
+++ b/dnf-behave-tests/features/repolist-no-repos.feature
@@ -2,7 +2,6 @@ Feature: Repolist when there are no repositories
 
 
 Scenario: Repolist without arguments
-  Given There are no repositories
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout is empty
@@ -10,7 +9,6 @@ Scenario: Repolist without arguments
 
 
 Scenario: Repolist with "enabled"
-  Given There are no repositories
    When I execute dnf with args "repolist enabled"
    Then the exit code is 0
     And stdout is empty
@@ -18,7 +16,6 @@ Scenario: Repolist with "enabled"
 
 
 Scenario: Repolist with "disabled"
-  Given There are no repositories
    When I execute dnf with args "repolist disabled"
    Then the exit code is 0
     And stdout is empty
@@ -26,7 +23,6 @@ Scenario: Repolist with "disabled"
 
 
 Scenario: Repolist with "all"
-  Given There are no repositories
    When I execute dnf with args "repolist all"
    Then the exit code is 0
     And stdout is empty

--- a/dnf-behave-tests/features/repolist.feature
+++ b/dnf-behave-tests/features/repolist.feature
@@ -2,8 +2,14 @@ Feature: Repolist
 
 
 Background: Using repositories dnf-ci-fedora and dnf-ci-thirdparty-updates
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty-updates"
+    And I use repository "dnf-ci-fedora-updates" with configuration
+        | key     | value |
+        | enabled | 0     |
+    And I use repository "dnf-ci-thirdparty" with configuration
+        | key     | value |
+        | enabled | 0     |
 
 
 Scenario: Repolist without arguments
@@ -36,7 +42,7 @@ Scenario: Repolist with "disabled"
 Scenario: Repolist with "all"
    When I execute dnf with args "repolist all"
    Then the exit code is 0
-    And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora\s+enabled"
-    And stdout contains "dnf-ci-fedora-updates\s+dnf-ci-fedora-updates\s+disabled"
-    And stdout contains "dnf-ci-thirdparty\s+dnf-ci-thirdparty\s+disabled"
-    And stdout contains "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates\s+enabled"
+    And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora test repository\s+enabled"
+    And stdout contains "dnf-ci-fedora-updates\s+dnf-ci-fedora-updates test repository\s+disabled"
+    And stdout contains "dnf-ci-thirdparty\s+dnf-ci-thirdparty test repository\s+disabled"
+    And stdout contains "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates test repository\s+enabled"

--- a/dnf-behave-tests/features/repoquery/deps.feature
+++ b/dnf-behave-tests/features/repoquery/deps.feature
@@ -3,7 +3,7 @@ Feature: Tests for the basic repoquery dependencies functionality:
     --whatrequires, --whatprovides, --whatconflicts, --whatobsoletes
 
 Background:
- Given I use the repository "repoquery-deps"
+ Given I use repository "repoquery-deps"
 
 
 # --requires

--- a/dnf-behave-tests/features/repoquery/globs.feature
+++ b/dnf-behave-tests/features/repoquery/globs.feature
@@ -1,7 +1,7 @@
 Feature: Glob tests for expanding all the various glob patterns.
 
 Background:
- Given I use the repository "repoquery-globs"
+ Given I use repository "repoquery-globs"
 
 
 # <name> globs

--- a/dnf-behave-tests/features/repoquery/main.feature
+++ b/dnf-behave-tests/features/repoquery/main.feature
@@ -1,7 +1,7 @@
 Feature: The common repoquery tests, core functionality, odds and ends.
 
 Background:
- Given I use the repository "repoquery-main"
+ Given I use repository "repoquery-main"
 
 
 # simple nevra matching tests
@@ -249,7 +249,7 @@ Given I successfully execute dnf with args "install bottom-a1"
 
 Scenario: repoquery -C (with cache, but disabled repository)
 Given I successfully execute dnf with args "makecache"
-Given I disable the repository "repoquery-main"
+Given I drop repository "repoquery-main"
  When I execute dnf with args "repoquery --available -C"
  Then the exit code is 0
   And stdout is empty
@@ -401,7 +401,7 @@ Scenario: repoquery --location NAME
 @fixture.httpd
 Scenario: repoquery --location NAME (in an HTTP repo)
 Given I use the https repository based on "repoquery-main"
-  And I disable the repository "repoquery-main"
+  And I drop repository "repoquery-main"
  When I execute dnf with args "repoquery --location top-a-2.0"
  Then the exit code is 0
   And stdout matches line by line

--- a/dnf-behave-tests/features/repoquery/main.feature
+++ b/dnf-behave-tests/features/repoquery/main.feature
@@ -560,7 +560,7 @@ Scenario: dnf repoquery --querytags
  Then the exit code is 0
   And stdout is
       """
-      Available query-tags: use --queryformat ".. %{tag} .."
+      Available query-tags: use --queryformat ".. %{{tag}} .."
 
       name, arch, epoch, version, release, reponame (repoid), evr,
       debug_name, source_name, source_debug_name,

--- a/dnf-behave-tests/features/repoquery/main.feature
+++ b/dnf-behave-tests/features/repoquery/main.feature
@@ -400,8 +400,7 @@ Scenario: repoquery --location NAME
 
 @fixture.httpd
 Scenario: repoquery --location NAME (in an HTTP repo)
-Given I use the https repository based on "repoquery-main"
-  And I drop repository "repoquery-main"
+Given I use repository "repoquery-main" as https
  When I execute dnf with args "repoquery --location top-a-2.0"
  Then the exit code is 0
   And stdout matches line by line

--- a/dnf-behave-tests/features/repoquery/rich-deps.feature
+++ b/dnf-behave-tests/features/repoquery/rich-deps.feature
@@ -9,7 +9,7 @@ Feature: Tests for rich (boolean) dependencies:
  unless else - same as above but requires the third operand to be fulfilled if the second is
 
 Background:
-Given I use the repository "repoquery-rich-deps"
+Given I use repository "repoquery-rich-deps"
 
 
 Scenario: repoquery --recommends NAME

--- a/dnf-behave-tests/features/repoquery/weak-deps.feature
+++ b/dnf-behave-tests/features/repoquery/weak-deps.feature
@@ -20,7 +20,7 @@ Feature: Tests for repoquery weak deps related functionality:
 #   +-----------------------------------------------+
 
 Background:
-Given I use the repository "repoquery-weak-deps"
+Given I use repository "repoquery-weak-deps"
 
 
 # --recommends

--- a/dnf-behave-tests/features/repository.feature
+++ b/dnf-behave-tests/features/repository.feature
@@ -3,7 +3,7 @@ Feature: Handling local base url in repository in installroot
 
 @fixture.httpd
 Scenario: Handling remote base url in repository in installroot
-  Given I use the http repository based on "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora" as http
     And I do not set config file
    When I execute dnf with args "install filesystem"
    Then the exit code is 0

--- a/dnf-behave-tests/features/repository.feature
+++ b/dnf-behave-tests/features/repository.feature
@@ -1,24 +1,5 @@
 Feature: Handling local base url in repository in installroot
 
-Scenario: Handling local base url in repository in installroot
-  Given I use the repository "testrepo"
-    And I do not set config file
-    And I do not set reposdir
-    And I create file "/etc/yum.repos.d/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl=file://$DNF0/repos/dnf-ci-fedora
-    enabled=1
-    gpgcheck=0
-    """
-   When I execute dnf with args "install filesystem"
-   Then the exit code is 0
-    And Transaction is following
-        | Action        | Package                           |
-        | install       | setup-0:2.12.1-1.fc29.noarch      |
-        | install       | filesystem-0:3.9-2.fc29.x86_64    |
-
 
 @fixture.httpd
 Scenario: Handling remote base url in repository in installroot

--- a/dnf-behave-tests/features/rich-dependencies.feature
+++ b/dnf-behave-tests/features/rich-dependencies.feature
@@ -4,7 +4,7 @@ Feature: Rich dependencies testing
 
 
 Background: Use dnf-ci-rich repository
-    Given I use the repository "dnf-ci-rich"
+    Given I use repository "dnf-ci-rich"
 
 
 # pancake

--- a/dnf-behave-tests/features/scriptlets.feature
+++ b/dnf-behave-tests/features/scriptlets.feature
@@ -2,7 +2,7 @@ Feature: Test for successful and failing rpm scriptlets
 
 
 Background: Enable repository
-  Given I use the repository "dnf-ci-scriptlets"
+  Given I use repository "dnf-ci-scriptlets"
 
 
 Scenario Outline: Install a pkg with a successful scriptlet

--- a/dnf-behave-tests/features/security-advisory.feature
+++ b/dnf-behave-tests/features/security-advisory.feature
@@ -2,7 +2,7 @@ Feature: Test upgrade-minimal with advisory, cve, secseverity
 
 
 Background: Use repository with advisories
-  Given I use the repository "dnf-ci-security"
+  Given I use repository "dnf-ci-security"
    When I execute dnf with args "install advisory_A-1.0-1 advisory_B-1.0-1"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/security-bugfix.feature
+++ b/dnf-behave-tests/features/security-bugfix.feature
@@ -2,7 +2,7 @@ Feature: Test security options for update
 
 
 Background: Use repository with advisories
-  Given I use the repository "dnf-ci-security"
+  Given I use repository "dnf-ci-security"
    When I execute dnf with args "install bugfix_A-1.0-1 bugfix_B-1.0-1 bugfix_C-1.0-1"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/security-security.feature
+++ b/dnf-behave-tests/features/security-security.feature
@@ -2,7 +2,7 @@ Feature: Test security options for update
 
 
 Background: Use repository with advisories
-  Given I use the repository "dnf-ci-security"
+  Given I use repository "dnf-ci-security"
    When I execute dnf with args "install security_A-1.0-1 security_B-1.0-1"
    Then the exit code is 0
     And Transaction is following
@@ -12,8 +12,8 @@ Background: Use repository with advisories
 
 
 Scenario: Security check-update when there are no such updates
-  Given I disable the repository "dnf-ci-security"
-    And I use the repository "dnf-ci-fedora"
+  Given I drop repository "dnf-ci-security"
+    And I use repository "dnf-ci-fedora"
    When I execute dnf with args "check-update --security"
    Then the exit code is 0
     And stdout does not contain "security_A"

--- a/dnf-behave-tests/features/setopt.feature
+++ b/dnf-behave-tests/features/setopt.feature
@@ -2,8 +2,8 @@ Feature: --setopt option
 
 
 Background: Use repos setopt and setopt.ext
-  Given I use the repository "setopt"
-    And I use the repository "setopt.ext"
+  Given I use repository "setopt"
+    And I use repository "setopt.ext"
 
 
 # setopt repo contains: wget

--- a/dnf-behave-tests/features/shell-distro-sync.feature
+++ b/dnf-behave-tests/features/shell-distro-sync.feature
@@ -2,7 +2,7 @@ Feature: Shell distro-sync
 
 
 Background: Install glibc, flac, and CQRlib
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc flac CQRlib"
    Then the exit code is 0
     And Transaction is following
@@ -18,7 +18,7 @@ Background: Install glibc, flac, and CQRlib
 
 
 Scenario: Using dnf shell, make distro-sync for an RPM
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I open dnf shell session
     And I execute in dnf shell "distro-sync glibc"
     And I execute in dnf shell "run"
@@ -32,7 +32,7 @@ Scenario: Using dnf shell, make distro-sync for an RPM
 
 
 Scenario: Using dnf shell, make distro-sync for mutiple RPMs
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I open dnf shell session
     And I execute in dnf shell "distro-sync setup filesystem flac CQRlib"
     And I execute in dnf shell "run"
@@ -45,8 +45,8 @@ Scenario: Using dnf shell, make distro-sync for mutiple RPMs
 
 
 Scenario: Using dnf shell, fail to make distro-sync when no upgrade is available
-  Given I use the repository "dnf-ci-fedora-updates"
-    And I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates"
+    And I use repository "dnf-ci-fedora-updates-testing"
    When I open dnf shell session
     And I execute in dnf shell "distro-sync setup filesystem"
    When I execute in dnf shell "run"
@@ -57,7 +57,7 @@ Scenario: Using dnf shell, fail to make distro-sync when no upgrade is available
 
 
 Scenario: Using dnf shell, fail to make distro-sync for non-existent RPM
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I open dnf shell session
     And I execute in dnf shell "distro-sync non-existent"
    Then Transaction is empty

--- a/dnf-behave-tests/features/shell-downgrade.feature
+++ b/dnf-behave-tests/features/shell-downgrade.feature
@@ -2,8 +2,8 @@ Feature: Shell downgrade
 
 
 Background: Install glibc and flac
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/shell-from-file.feature
+++ b/dnf-behave-tests/features/shell-from-file.feature
@@ -5,7 +5,10 @@ Feature: Execute dnf shell commands from file
 #   repo enable dnf-ci-fedora
 #   install flac
 #   run
-
+Background:
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
 
 Scenario: Execute dnf shell with file as argument
   When I execute dnf with args "shell {context.dnf.fixturesdir}/scripts/shell-commands"

--- a/dnf-behave-tests/features/shell-group.feature
+++ b/dnf-behave-tests/features/shell-group.feature
@@ -16,8 +16,9 @@ Feature: Shell group
 
 
 Scenario: Using dnf shell, install a package group
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-fedora dnf-ci-thirdparty"
     And I execute in dnf shell "group install DNF-CI-Testgroup"
     And I execute in dnf shell "run"
    Then Transaction is following
@@ -32,8 +33,15 @@ Scenario: Using dnf shell, install a package group
 
 
 Scenario Outline: Using dnf shell, upgrade a package group using alias <upgrade alias>
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
+    And I use repository "dnf-ci-fedora-updates" with configuration
+        | key     | value |
+        | enabled | 0     |
+    And I use repository "dnf-ci-thirdparty-updates" with configuration
+        | key     | value |
+        | enabled | 0     |
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-fedora dnf-ci-thirdparty"
     And I execute in dnf shell "group install DNF-CI-Testgroup"
     And I execute in dnf shell "run"
    Then Transaction is following
@@ -66,8 +74,9 @@ Examples:
 
 
 Scenario: Using dnf shell, remove a package group
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-fedora dnf-ci-thirdparty"
     And I execute in dnf shell "group install DNF-CI-Testgroup"
     And I execute in dnf shell "run"
    Then Transaction is following
@@ -91,8 +100,8 @@ Scenario: Using dnf shell, remove a package group
 
 
 Scenario: Using dnf shell, fail to install a non-existent package group
+  Given I use repository "dnf-ci-fedora"
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-fedora"
     And I execute in dnf shell "group install NoSuchGroup"
    Then stdout contains "Module or Group '.*NoSuchGroup.*' is not available\."
     And I execute in dnf shell "run"
@@ -102,8 +111,8 @@ Scenario: Using dnf shell, fail to install a non-existent package group
 
 
 Scenario: Using dnf shell, fail to remove a non-existent package group
+  Given I use repository "dnf-ci-fedora"
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-fedora"
     And I execute in dnf shell "group remove NoSuchGroup"
    Then stdout contains "Group '.*NoSuchGroup.*' is not installed\."
     And I execute in dnf shell "run"

--- a/dnf-behave-tests/features/shell-install.feature
+++ b/dnf-behave-tests/features/shell-install.feature
@@ -2,8 +2,8 @@ Feature: Shell install
 
 
 Scenario: Using dnf shell, install an RPM
+  Given I use repository "dnf-ci-fedora"
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-fedora"
     And I execute in dnf shell "install filesystem wget"
     And I execute in dnf shell "run"
    Then Transaction is following
@@ -16,11 +16,10 @@ Scenario: Using dnf shell, install an RPM
 
 @bz1658579
 Scenario: Using dnf shell, fail to install an RPM when no repositories are enabled
-  Given I do not set reposdir
    When I open dnf shell session
     And I execute in dnf shell "install setup"
    Then Transaction is empty
-    And stdout contains "Error: There are no enabled repositories in "/etc/yum.repos.d", "/etc/yum/repos.d", "/etc/distro.repos.d"\."
+    And stdout contains "Error: There are no enabled repositories in ".*/etc/yum.repos.d", ".*/etc/yum/repos.d", ".*/etc/distro.repos.d"\."
    When I execute in dnf shell "run"
    Then Transaction is empty
    When I execute in dnf shell "exit"
@@ -28,8 +27,8 @@ Scenario: Using dnf shell, fail to install an RPM when no repositories are enabl
 
 
 Scenario: Using dnf shell, fail to install a non-existent RPM
+  Given I use repository "dnf-ci-fedora"
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-fedora"
     And I execute in dnf shell "install NoSuchPackage"
    Then Transaction is empty
     And stdout contains "No match for argument: .*NoSuchPackage"

--- a/dnf-behave-tests/features/shell-more-commands.feature
+++ b/dnf-behave-tests/features/shell-more-commands.feature
@@ -2,8 +2,8 @@ Feature: Execute more commands in one transaction in dnf shell
 
 
 Scenario: Using dnf shell, install and remove RPMs in one transaction
+  Given I use repository "dnf-ci-fedora"
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-fedora"
     And I execute in dnf shell "install flac"
     And I execute in dnf shell "run"
    Then Transaction is following
@@ -22,8 +22,9 @@ Scenario: Using dnf shell, install and remove RPMs in one transaction
 
 
 Scenario: Using dnf shell, switch conflicting RPMs using install and remove
+  Given I use repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-fedora-updates"
    When I open dnf shell session
-    And I execute in dnf shell "repo enable dnf-ci-thirdparty dnf-ci-fedora-updates"
     And I execute in dnf shell "install CQRlib CQRlib-extension SuperRipper"
     And I execute in dnf shell "run"
    Then Transaction is following

--- a/dnf-behave-tests/features/shell-reinstall.feature
+++ b/dnf-behave-tests/features/shell-reinstall.feature
@@ -2,7 +2,10 @@ Feature: Shell reinstall
 
 
 Background: Install flac and filesystem
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates" with configuration
+        | key     | value |
+        | enabled | 0     |
    When I execute dnf with args "install flac filesystem"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/shell-remove.feature
+++ b/dnf-behave-tests/features/shell-remove.feature
@@ -2,7 +2,7 @@ Feature: Shell remove
 
 
 Background: Install flac
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/shell-repo.feature
+++ b/dnf-behave-tests/features/shell-repo.feature
@@ -2,6 +2,15 @@ Feature: Shell repo
 
 
 Scenario: Using dnf shell, enable repositories
+  Given I use repository "dnf-ci-fedora" with configuration
+        | key     | value |
+        | enabled | 0     |
+    And I use repository "dnf-ci-fedora-updates" with configuration
+        | key     | value |
+        | enabled | 0     |
+    And I use repository "dnf-ci-fedora-updates-testing" with configuration
+        | key     | value |
+        | enabled | 0     |
    When I open dnf shell session
     And I execute in dnf shell "repo enable dnf-ci-fedora*"
     And I execute in dnf shell "repolist"

--- a/dnf-behave-tests/features/shell-repo.feature
+++ b/dnf-behave-tests/features/shell-repo.feature
@@ -14,8 +14,8 @@ Scenario: Using dnf shell, enable repositories
 
 
 Scenario: Using dnf shell, disable repositories
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
    When I open dnf shell session
     And I execute in dnf shell "repo disable dnf-ci-fedora-updates"
     And I execute in dnf shell "repolist"
@@ -27,9 +27,9 @@ Scenario: Using dnf shell, disable repositories
 
 
 Scenario: Using dnf shell, disable and enable repositories
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-fedora-updates"
-    And I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+    And I use repository "dnf-ci-fedora-updates-testing"
    When I open dnf shell session
     And I execute in dnf shell "repo disable dnf-ci-fedora-updates*"
     And I execute in dnf shell "repo enable dnf-ci-fedora-updates"

--- a/dnf-behave-tests/features/shell-swap.feature
+++ b/dnf-behave-tests/features/shell-swap.feature
@@ -1,11 +1,12 @@
 Feature: Shell swap
 
+Background:
+Given I use repository "dnf-ci-fedora"
+  And I use repository "dnf-ci-fedora-updates"
+  And I use repository "dnf-ci-thirdparty"
 
 Scenario: Switch packages and their subpackages by swap command (using wildcards)
  When I open dnf shell session
-  And I execute in dnf shell "repo enable dnf-ci-fedora"
-  And I execute in dnf shell "repo enable dnf-ci-fedora-updates"
-  And I execute in dnf shell "repo enable dnf-ci-thirdparty"
   And I execute in dnf shell "install CQRlib-devel CQRlib CQRlib-extension"
   And I execute in dnf shell "run"
  Then Transaction is following
@@ -37,9 +38,6 @@ Scenario: Switch packages and their subpackages by swap command (using wildcards
 
 Scenario: Switch groups by swap command
  When I open dnf shell session
-  And I execute in dnf shell "repo enable dnf-ci-fedora"
-  And I execute in dnf shell "repo enable dnf-ci-fedora-updates"
-  And I execute in dnf shell "repo enable dnf-ci-thirdparty"
   And I execute in dnf shell "groupinstall CQRlib-non-devel"
   And I execute in dnf shell "run"
  Then Transaction is following

--- a/dnf-behave-tests/features/shell-upgrade-minimal.feature
+++ b/dnf-behave-tests/features/shell-upgrade-minimal.feature
@@ -2,7 +2,7 @@ Feature: Shell upgrade-minimal
 
 
 Background: Install glibc, flac, and CQRlib
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc flac CQRlib"
    Then the exit code is 0
     And Transaction is following
@@ -18,7 +18,7 @@ Background: Install glibc, flac, and CQRlib
 
 
 Scenario: Using dnf shell, make upgrade-minimal --bugfix
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I open dnf shell session
     And I execute in dnf shell "upgrade-minimal --bugfix glibc"
     And I execute in dnf shell "run"
@@ -32,7 +32,7 @@ Scenario: Using dnf shell, make upgrade-minimal --bugfix
 
 
 Scenario: Using dnf shell, make upgrade-minimal --security
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I open dnf shell session
     And I execute in dnf shell "upgrade-minimal --security CQRlib"
     And I execute in dnf shell "run"
@@ -44,8 +44,8 @@ Scenario: Using dnf shell, make upgrade-minimal --security
 
 
 Scenario Outline: Using dnf shell, fail to upgrade-minimal <update> when no such upgrade is available
-  Given I use the repository "dnf-ci-fedora-updates"
-    And I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates"
+    And I use repository "dnf-ci-fedora-updates-testing"
    When I open dnf shell session
     And I execute in dnf shell "upgrade-minimal <update> flac"
    Then Transaction is empty
@@ -62,7 +62,7 @@ Examples:
 
 
 Scenario Outline: Using dnf shell, fail upgrade-minimal <update> for non-existent RPM
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I open dnf shell session
     And I execute in dnf shell "upgrade-minimal <update> non-existent"
    Then Transaction is empty

--- a/dnf-behave-tests/features/shell-upgrade.feature
+++ b/dnf-behave-tests/features/shell-upgrade.feature
@@ -2,7 +2,10 @@ Feature: Shell upgrade
 
 
 Background: Install flac
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates" with configuration
+        | key     | value |
+        | enabled | 0     |
    When I execute dnf with args "install flac"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/ssl.feature
+++ b/dnf-behave-tests/features/ssl.feature
@@ -3,10 +3,10 @@ Feature: SSL related tests
 
 @fixture.httpd
 Scenario: Installing a package from https repository
-  Given I use the https repository based on "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora" as https
    When I execute dnf with args "repolist"
    Then the exit code is 0
-    And stdout contains "https-dnf-ci-fedora\s+https-dnf-ci-fedora"
+    And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora"
    When I execute dnf with args "install filesystem -v"
    Then the exit code is 0
     And Transaction is following
@@ -18,10 +18,10 @@ Scenario: Installing a package from https repository
 @fixture.httpd
 Scenario: Installing a package from https repository with client verification
   Given I require client certificate verification with certificate "certificates/testcerts/client/cert.pem" and key "certificates/testcerts/client/key.pem"
-    And I use the https repository based on "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora" as https
    When I execute dnf with args "repolist"
    Then the exit code is 0
-    And stdout contains "https-dnf-ci-fedora\s+https-dnf-ci-fedora"
+    And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora"
    When I execute dnf with args "install filesystem -v"
    Then the exit code is 0
     And Transaction is following
@@ -33,10 +33,10 @@ Scenario: Installing a package from https repository with client verification
 @fixture.httpd
 Scenario: Instaling a package using untrusted client cert should fail
   Given I require client certificate verification with certificate "certificates/testcerts/client2/cert.pem" and key "certificates/testcerts/client2/key.pem"
-    And I use the https repository based on "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora" as https
    When I execute dnf with args "install filesystem -v"
    Then the exit code is 1
     And stderr is
     """
-    Error: Failed to download metadata for repo 'https-dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
+    Error: Failed to download metadata for repo 'dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
     """

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -97,11 +97,6 @@ def when_I_execute_command(context, command):
     run_in_context(context, command.format(context=context))
 
 
-@behave.given("I do not disable all repos")
-def given_I_do_not_disable_all_repos(context):
-    context.dnf._set("disable_repos_option", "")
-
-
 @behave.given("I do not assume yes")
 def given_I_do_not_assumeyes(context):
     context.dnf._set("assumeyes_option", "")
@@ -116,11 +111,6 @@ def step_impl(context):
 def step_impl(context, configfile):
     full_path = os.path.join(context.dnf.installroot, configfile.lstrip("/"))
     context.dnf._set("config", full_path)
-
-
-@behave.given("I do not set reposdir")
-def step_impl(context):
-    context.dnf._set("reposdir", "")
 
 
 @behave.given("I do not set releasever")

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -169,13 +169,13 @@ def then_the_exit_code_is(context, exitcode):
 
 @behave.then("stdout contains \"{text}\"")
 def then_stdout_contains(context, text):
-    if re.search(text, context.cmd_stdout):
+    if re.search(text.format(context=context), context.cmd_stdout):
         return
     raise AssertionError("Stdout doesn't contain: %s" % text)
 
 @behave.then("stdout does not contain \"{text}\"")
 def then_stdout_does_not_contain(context, text):
-    if not re.search(text, context.cmd_stdout):
+    if not re.search(text.format(context=context), context.cmd_stdout):
         return
     raise AssertionError("Stdout contains: %s" % text)
 
@@ -195,7 +195,7 @@ def then_stdout_is(context):
     synchronization lines (i.e. the "Last metadata expiration check:" line as
     well as the individual repo download lines) in the test's output.
     """
-    expected = context.text.strip().split('\n')
+    expected = context.text.format(context=context).strip().split('\n')
     found = context.cmd_stdout.strip().split('\n')
 
     if found == [""]:
@@ -257,7 +257,7 @@ def then_stdout_section_contains(context, section, regexp):
 
 @behave.then("stderr is")
 def then_stderr_is(context):
-    expected = context.text.strip().split('\n')
+    expected = context.text.format(context=context).strip().split('\n')
     found = context.cmd_stderr.strip().split('\n')
 
     if expected == found:
@@ -270,14 +270,14 @@ def then_stderr_is(context):
 
 @behave.then("stderr contains \"{text}\"")
 def then_stderr_contains(context, text):
-    if re.search(text, context.cmd_stderr):
+    if re.search(text.format(context=context), context.cmd_stderr):
         return
     raise AssertionError("Stderr doesn't contain: %s" % text)
 
 
 @behave.then("stderr does not contain \"{text}\"")
 def then_stderr_contains(context, text):
-    if not re.search(text, context.cmd_stderr):
+    if not re.search(text.format(context=context), context.cmd_stderr):
         return
     raise AssertionError("Stderr contains: %s" % text)
 

--- a/dnf-behave-tests/features/steps/common/dnf.py
+++ b/dnf-behave-tests/features/steps/common/dnf.py
@@ -242,7 +242,10 @@ def parse_module_list(lines):
         match = MODULE_LIST_HEADER_RE.match(line2)
         if match:
             # table header for a new repository found
-            repository = line1
+            # FIXME line1 contains the repository name, while what we need here
+            # is the id. This assumes the id is the first word of the name,
+            # which happens to be the case for repos generated for the tests.
+            repository = line1.split(" ")[0]
             columns=[match.start(i+1) for i in range(4)]
             result[repository] = []
             idx += 2

--- a/dnf-behave-tests/features/steps/common/repo.py
+++ b/dnf-behave-tests/features/steps/common/repo.py
@@ -3,7 +3,7 @@ import os
 from . import sha256_checksum
 
 
-def generate_metalink(destdir, server):
+def generate_metalink(destdir, url):
     metalink = """<?xml version="1.0" encoding="utf-8"?>
 <metalink version="3.0" xmlns="http://www.metalinker.org/" xmlns:mm0="http://fedorahosted.org/mirrormanager">
   <files>
@@ -14,23 +14,20 @@ def generate_metalink(destdir, server):
         <hash type="sha256">{csum}</hash>
       </verification>
       <resources>
-        <url protocol="{schema}" type="{schema}">{schema}://{host}:{port}/{repoid}/repodata/repomd.xml</url>
+        <url protocol="{schema}" type="{schema}">{url}/repodata/repomd.xml</url>
       </resources>
     </file>
   </files>
 </metalink>
 """
-    repoid = os.path.basename(destdir)
-    schema, host, port = server
+    schema = url.split(':')[0]
     with open(os.path.join(destdir, 'repodata', 'repomd.xml')) as f:
         repomd = f.read()
     with open(os.path.join(destdir, 'metalink.xml'), 'w') as f:
         data = metalink.format(
             size=len(repomd),
             csum=sha256_checksum(repomd.encode('utf-8')),
-            repoid=repoid,
             schema=schema,
-            host=host,
-            port=port,
+            url=url,
         )
         f.write(data + '\n')

--- a/dnf-behave-tests/features/steps/file.py
+++ b/dnf-behave-tests/features/steps/file.py
@@ -53,8 +53,7 @@ def step_delete_file(context, filepath):
 
 @behave.given('I delete file "{filepath}" with globs')
 def step_delete_file_with_globs(context, filepath):
-    full_path = os.path.join(context.dnf.installroot, filepath.lstrip("/"))
-    for path in glob.glob(full_path):
+    for path in glob.glob(prepend_installroot(context, filepath)):
         delete_file(path)
 
 

--- a/dnf-behave-tests/features/steps/fixtures/httpd.py
+++ b/dnf-behave-tests/features/steps/fixtures/httpd.py
@@ -92,7 +92,7 @@ class HttpServerContext(object):
         # whether to enable logging
         self._logging = logging
         # list of AccessRecord objects
-        self.logs = dict()
+        self.log = None
 
     def _start_server(self, path, target, *args):
         """
@@ -111,10 +111,9 @@ class HttpServerContext(object):
         target = self.http_server
         args = []
         if self._logging:
-            log = multiprocessing.Manager().list()
-            self.logs[path] = log
+            self.log = multiprocessing.Manager().list()
             target = self.http_logging_server
-            args = [log]
+            args = [self.log]
         return self._start_server(path, target, *args)
 
     def new_https_server(self, path, cacert, cert, key, client_verification):
@@ -129,21 +128,19 @@ class HttpServerContext(object):
             return self.servers[path][0]
         return None
 
-    def get_log(self, path):
+    def get_log(self):
         """
-        Get the log of http server bound to "path" directory
+        Get the log of the http server
 
         A "log" here is a list of AccessRecord objects.
         """
-        if path in self.logs:
-            return self.logs[path]
-        return None
+        return self.log
 
-    def clear_log(self, path):
+    def clear_log(self):
         """
-        Empty the log of http server bound to "path"
+        Empty the log of the http server
         """
-        del self.logs[path][:]
+        del self.log[:]
 
     def shutdown(self):
         """

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -146,10 +146,10 @@ def step_remote_metalink_repo(context):
 def step_check_http_log(context, quantifier, command):
     # Obtain the httpd log
     path = context.dnf.repos_location
-    log = context.httpd.get_log(path)
+    log = context.httpd.get_log()
     assert log is not None, 'Logging should be enabled on the HTTP server'
     log = [rec for rec in log if rec.command == command]
-    context.httpd.clear_log(path)
+    context.httpd.clear_log()
     assert log, 'Some HTTP requests should have been received'
 
     # A log dump, printed on failures for convenience

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -193,6 +193,9 @@ def step_repo_condition(context, repo):
     if repo not in context.dnf["repos"]:
         context.dnf["repos"].append(repo)
 
+    context.dnf.use_repo_args = True
+
+
 @behave.step('I require client certificate verification with certificate "{client_cert}" and key "{client_key}"')
 def step_impl(context, client_cert, client_key):
     if "client_ssl" not in context.dnf:

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -186,16 +186,6 @@ def step_set_up_metalink_for_repository(context, repo):
     create_repo_conf(context, repo)
 
 
-@behave.step("I use the repository \"{repo}\"")
-def step_repo_condition(context, repo):
-    if "repos" not in context.dnf:
-        context.dnf["repos"] = []
-    if repo not in context.dnf["repos"]:
-        context.dnf["repos"].append(repo)
-
-    context.dnf.use_repo_args = True
-
-
 @behave.step('I require client certificate verification with certificate "{client_cert}" and key "{client_key}"')
 def step_impl(context, client_cert, client_key):
     if "client_ssl" not in context.dnf:
@@ -204,90 +194,6 @@ def step_impl(context, client_cert, client_key):
                                                             client_cert)
     context.dnf["client_ssl"]["key"] = os.path.join(context.dnf.fixturesdir,
                                                     client_key)
-
-
-@behave.step("I use the {rtype:repo_type} repository based on \"{repo}\"")
-def step_impl(context, rtype, repo):
-    assert (hasattr(context, 'httpd') or hasattr(context, 'ftpd')), \
-        'Httpd or Ftpd fixture not set. Use @fixture.httpd or @fixture.ftpd tag.'
-
-    metalink = False
-    if rtype == "metalink":
-        rtype = "http"
-        metalink = True
-
-    if rtype == "http":
-        host, port = context.httpd.new_http_server(context.dnf.repos_location)
-    elif rtype == "ftp":
-        host, port = context.ftpd.new_ftp_server(context.dnf.repos_location)
-    else:
-        cacert = os.path.join(context.dnf.fixturesdir,
-                              'certificates/testcerts/ca/cert.pem')
-        cert = os.path.join(context.dnf.fixturesdir,
-                            'certificates/testcerts/server/cert.pem')
-        key = os.path.join(context.dnf.fixturesdir,
-                           'certificates/testcerts/server/key.pem')
-        client_ssl = context.dnf._get("client_ssl")
-        if client_ssl:
-            client_cert = client_ssl["certificate"]
-            client_key = client_ssl["key"]
-        host, port = context.httpd.new_https_server(
-            context.dnf.repos_location, cacert, cert, key,
-            client_verification=bool(client_ssl))
-    http_reposdir = "/http.repos.d"
-    repo_id = '{}-{}'.format(rtype, repo)
-    key = "baseurl"
-    url = "{}://{}:{}/{}/".format(rtype, host, port, repo)
-    if metalink:
-        key = "metalink"
-        url += "metalink.xml"
-    repocfg = ("[{repo_id}]\n"
-        "name={repo_id}\n"
-        "{key}={url}\n"
-        "enabled=1\n"
-        "gpgcheck=0\n"
-        )
-    if rtype == "https":
-        repocfg += "sslcacert={cacert}\n"
-        if client_ssl:
-            repocfg += "sslclientcert={client_cert}\n"
-            repocfg += "sslclientkey={client_key}\n"
-
-    data_path = os.path.join(context.dnf.repos_location, repo)
-    generate_metalink(data_path, (rtype, host, port))
-
-    # generate repo file based on "repo" in /http.repos.d
-    repos_path = os.path.join(context.dnf.installroot, http_reposdir.lstrip("/"))
-    ensure_directory_exists(repos_path)
-    repo_file_path = os.path.join(repos_path, '{}.repo'.format(repo_id))
-    create_file_with_contents(
-        repo_file_path,
-        repocfg.format(**locals()))
-
-    # add /http.repos.d to reposdir
-    current_reposdir = context.dnf._get("reposdir")
-    if not repos_path in current_reposdir:
-        context.dnf._set("reposdir", "{},{}".format(current_reposdir, repos_path))
-
-    if not hasattr(context.dnf, "ports"):
-        context.dnf._set("ports", {})
-
-    context.dnf.ports[rtype + "-" + repo] = port
-
-    # enable newly created http repo
-    context.execute_steps('Given I use the repository "{}"'.format(repo_id))
-
-
-@behave.step("I disable the repository \"{repo}\"")
-def step_repo_condition(context, repo):
-    if "repos" not in context.dnf:
-        context.dnf["repos"] = []
-    context.dnf["repos"].remove(repo)
-
-
-@behave.given("There are no repositories")
-def given_no_repos(context):
-    context.dnf["reposdir"] = "/dev/null"
 
 
 @behave.step("I am running a system identified as the \"{system}\"")
@@ -301,16 +207,6 @@ def given_package_version(context, package):
     rpms = [rpm for rpm in get_rpmdb_rpms() if rpm.name == package]
     assert len(rpms) == 1, 'There should be exactly one %s installed' % package
     context.versions = {package: rpms[0].version}
-
-
-@behave.step("I have enabled a remote repository")
-def step_remote_repo(context):
-    context.execute_steps('when I use the http repository based on "dnf-ci-fedora"')
-
-
-@behave.step("I have enabled a remote metalink repository")
-def step_remote_metalink_repo(context):
-    context.execute_steps('when I use the metalink repository based on "dnf-ci-fedora"')
 
 
 @behave.step("{quantifier} HTTP {command} request should match")

--- a/dnf-behave-tests/features/swap.feature
+++ b/dnf-behave-tests/features/swap.feature
@@ -2,9 +2,9 @@ Feature: Test for swap command
 
 
 Background: Enable repositories
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates"
-  Given I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-thirdparty"
 
 
 Scenario: Switch packages by swap command

--- a/dnf-behave-tests/features/updateinfo.feature
+++ b/dnf-behave-tests/features/updateinfo.feature
@@ -2,7 +2,7 @@ Feature: Listing available updates using the dnf updateinfo command
 
 
 Scenario: Listing available updates
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
     And Transaction is following
         | Action        | Package                                  |
@@ -14,7 +14,7 @@ Scenario: Listing available updates
         | install       | glibc-common-0:2.28-9.fc29.x86_64        |
         | install       | flac-0:1.3.2-8.fc29.x86_64               |
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    Then I execute dnf with args "updateinfo list"
    Then the exit code is 0
    Then stdout contains "FEDORA-2999:002-02\s+enhancement\s+flac-1.3.3-8.fc29.x86_64"
@@ -22,7 +22,7 @@ Scenario: Listing available updates
 
 
 Scenario Outline: updateinfo <summary alias> (when there's nothing to report)
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
    When I execute dnf with args "updateinfo summary"
@@ -39,10 +39,10 @@ Examples:
  
 
 Scenario Outline: updateinfo <summary alias> available (when there is an available update)
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo <summary alias> available"
    Then the exit code is 0
    Then stdout contains "Updates Information Summary: available"
@@ -56,10 +56,10 @@ Examples:
 
 
 Scenario Outline: updateinfo info
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo <info alias> available"
    Then the exit code is 0
    Then stdout contains "\s+flac enhacements"
@@ -78,20 +78,20 @@ Examples:
          
 
 Scenario: updateinfo info security (when there's nothing to report)
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo info security"
    Then the exit code is 0
    Then stdout does not contain "Update ID"
 
 
 Scenario Outline: updateinfo <list alias>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo <list alias>"
    Then the exit code is 0
    Then stdout contains "FEDORA-2999:002-02\s+enhancement\s+flac-1.3.3-8.fc29.x86_64"
@@ -104,11 +104,11 @@ Examples:
 
 
 Scenario: updateinfo list all security
-  Given I use the repository "dnf-ci-fedora"
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    Then I execute dnf with args "install glibc flac CQRlib"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo list all security"
    Then the exit code is 0
    Then stdout contains "FEDORA-2018-318f184113\s+Moderate/Sec.\s+CQRlib-1.1.2-16.fc29.x86_64"
@@ -118,13 +118,13 @@ Scenario: updateinfo list all security
                  
 
 Scenario: updateinfo list updates
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    Then I execute dnf with args "update glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "updateinfo list updates"
    Then the exit code is 0
    Then stdout contains "FEDORA-2999:002-02\s+enhancement\s+flac-1.3.3-8.fc29.x86_64"
@@ -132,24 +132,24 @@ Scenario: updateinfo list updates
 
 
 Scenario: updateinfo list installed
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    Then I execute dnf with args "update glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "updateinfo list installed"
    Then the exit code is 0
    Then stdout contains "FEDORA-2018-318f184000\sbugfix\sglibc-2.28-26.fc29.x86_64"
 
 
 Scenario: updateinfo list available enhancement
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
-  Given I use the repository "dnf-ci-fedora-updates-testing"
+  Given I use repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "updateinfo list available enhancement"
    Then the exit code is 0
    Then stdout contains "FEDORA-2999:002-02\s+enhancement\s+flac-1.3.3-8.fc29.x86_64"
@@ -157,20 +157,20 @@ Scenario: updateinfo list available enhancement
 
 
 Scenario: updateinfo list all bugfix
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo list all bugfix"
    Then the exit code is 0
    Then stdout contains "FEDORA-2018-318f184000\s+bugfix\s+glibc-2.28-26.fc29.x86_64"
 
 
 Scenario Outline: updateinfo list updates plus <option>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "<option> <value> updateinfo list updates"
    Then the exit code is 0
    Then stdout contains "FEDORA-2018-318f184000\s+bugfix\s+glibc-2.28-26.fc29.x86_64"
@@ -183,10 +183,10 @@ Examples:
 
 
 Scenario: updateinfo info <advisory>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo info FEDORA-2018-318f184000"
    Then stdout contains "Update\s+ID:\s+FEDORA-2018-318f184000"
    Then stdout contains "\s+glibc\s+bug\s+fix"
@@ -195,10 +195,10 @@ Scenario: updateinfo info <advisory>
         
 
 Scenario: updateinfo info <advisory-with-respin-suffix>
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    Then I execute dnf with args "install glibc flac"
    Then the exit code is 0
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo info FEDORA-2999:002-02"
    Then stdout contains "Update\s+ID:\s+FEDORA-2999:002-02"
    Then stdout contains "Type:\s+enhancement"

--- a/dnf-behave-tests/features/upgrade-all.feature
+++ b/dnf-behave-tests/features/upgrade-all.feature
@@ -2,7 +2,7 @@ Feature: Upgrade all RPMs
 
 
 Background: Install some RPMs from one repository
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc flac wget"
    Then the exit code is 0
     And Transaction is following
@@ -18,7 +18,7 @@ Background: Install some RPMs from one repository
 
 
 Scenario: Upgrade all RPMs from one repository
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade"
    Then the exit code is 0
     And Transaction is following
@@ -31,7 +31,7 @@ Scenario: Upgrade all RPMs from one repository
 
 
 Scenario: Upgrade all RPMs from one repository using '*'
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade '*'"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/upgrade-buildtime.feature
+++ b/dnf-behave-tests/features/upgrade-buildtime.feature
@@ -20,7 +20,7 @@ Scenario Outline: Upgrade does not reinstall package with the same NEVRA and dif
    Then the exit code is 0
     And Transaction is empty
    # try to update from remote repository
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "upgrade"
    Then the exit code is 0
     And Transaction is empty

--- a/dnf-behave-tests/features/upgrade-from-path.feature
+++ b/dnf-behave-tests/features/upgrade-from-path.feature
@@ -2,7 +2,7 @@ Feature: Upgrade RPMs from path
 
 
 Background: Install glibc, wget
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc wget"
    Then the exit code is 0
     And Transaction is following
@@ -17,7 +17,7 @@ Background: Install glibc, wget
 
 
 Scenario: Upgrade an RPM from absolute path on disk
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/glibc-2.28-26.fc29.x86_64.rpm"
    Then the exit code is 0
     And Transaction is following
@@ -39,7 +39,7 @@ Scenario: Upgrade an RPM from relative path on disk
 
 
 Scenario: Upgrade an RPM from path on disk containing wildcards
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/glibc*"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/upgrade-pkgspec.feature
+++ b/dnf-behave-tests/features/upgrade-pkgspec.feature
@@ -2,7 +2,7 @@ Feature: Upgrade RPMs by pkgspec
 
 
 Background: Install glibc
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -16,7 +16,7 @@ Background: Install glibc
 
 
 Scenario Outline: Upgrade an RPM by <pkgspec-type>
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade <pkgspec>"
    Then the exit code is 0
     And Transaction is following
@@ -40,7 +40,7 @@ Examples: Other pkgspecs
 
 
 Scenario: Upgrade an RPM by name containing dashes
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade glibc-common"
    Then the exit code is 0
     And Transaction is following
@@ -51,7 +51,7 @@ Scenario: Upgrade an RPM by name containing dashes
 
 
 Scenario: Upgrade an RPM by pkgspec contining wildcards
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade glibc-*.x86_64"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/upgrade-provides.feature
+++ b/dnf-behave-tests/features/upgrade-provides.feature
@@ -2,7 +2,7 @@ Feature: Upgrade RPMs by provides
 
 
 Background: Install glibc
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -16,7 +16,7 @@ Background: Install glibc
 
 
 Scenario Outline: Upgrade an RPM by provide <operator> e:v-r
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade 'glibc <operator> <e:v-r>'"
    Then the exit code is 0
     And Transaction is following
@@ -36,7 +36,7 @@ Examples:
 
 
 Scenario: Upgrade an RPM by provide
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade 'libm.so.6()(64bit)'"
    Then the exit code is 0
     And Transaction is following
@@ -47,7 +47,7 @@ Scenario: Upgrade an RPM by provide
 
 
 Scenario: Upgrade an RPM by file provide
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade /etc/ld.so.conf"
    Then the exit code is 0
     And Transaction is following
@@ -58,7 +58,7 @@ Scenario: Upgrade an RPM by file provide
 
 
 Scenario: Upgrade an RPM by file provide that is directory
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade /var/db"
    Then the exit code is 0
     And Transaction is following
@@ -69,7 +69,7 @@ Scenario: Upgrade an RPM by file provide that is directory
 
 
 Scenario: Upgrade an RPM by file provide containing wildcards
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade /etc/ld*.conf"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/upgrade-to.feature
+++ b/dnf-behave-tests/features/upgrade-to.feature
@@ -2,14 +2,14 @@ Feature: Upgrade-to for one package
 
 
 Scenario: Upgrade-to specific version
-  Given I use the repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
         | install       | flac-0:1.3.2-8.fc29.x86_64                |
 
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
   When I execute dnf with args "upgrade-to flac-0:1.3.3-2.fc29"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/upgrade.feature
+++ b/dnf-behave-tests/features/upgrade.feature
@@ -2,8 +2,8 @@ Feature: Upgrade single RPMs
 
 
 Background: Install RPMs
-  Given I use the repository "dnf-ci-fedora"
-    And I use the repository "dnf-ci-thirdparty"
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install glibc flac wget SuperRipper"
    Then the exit code is 0
     And Transaction is following
@@ -24,7 +24,7 @@ Background: Install RPMs
 @tier1
 @bz1649286
 Scenario: Upgrade one RPM
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade glibc"
    Then the exit code is 0
     And stdout does not contain "Upgrade *: +glibc"
@@ -36,7 +36,7 @@ Scenario: Upgrade one RPM
 
 
 Scenario: Upgrade two RPMs
-  Given I use the repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade glibc flac"
    Then the exit code is 0
     And Transaction is following
@@ -50,9 +50,9 @@ Scenario: Upgrade two RPMs
 @tier1
 @bz1670776 @bz1671683
 Scenario: Upgrade all RPMs from multiple repositories with best=False
-  Given I use the repository "dnf-ci-fedora-updates"
-  Given I use the repository "dnf-ci-fedora-updates-testing"
-    And I use the repository "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates-testing"
+    And I use repository "dnf-ci-thirdparty-updates"
     And I do not set config file
     And I create file "/etc/dnf/dnf.conf" with
     """
@@ -84,9 +84,9 @@ Scenario: Upgrade all RPMs from multiple repositories with best=False
 @tier1
 @bz1670776 @bz1671683
 Scenario: Upgrade all RPMs from multiple repositories with best=True
-  Given I use the repository "dnf-ci-fedora-updates"
-  Given I use the repository "dnf-ci-fedora-updates-testing"
-    And I use the repository "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates-testing"
+    And I use repository "dnf-ci-thirdparty-updates"
     And I do not set config file
     And I create file "/etc/dnf/dnf.conf" with
     """
@@ -120,7 +120,7 @@ Scenario: Upgrade all RPMs from multiple repositories with best=True
 
 @bz1659390
 Scenario: Print information about skipped packages
-  Given I use the repository "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "update --setopt 'best=0'"
    Then the exit code is 0
     And Transaction is following
@@ -140,7 +140,7 @@ Scenario Outline: Print correct number of available updates if update <type> is 
     And Transaction is following
         | Action        | Package                                   |
         | install       | CQRlib-extension-0:1.5-2.x86_64           |
-   Then I use the repository "dnf-ci-thirdparty-updates"
+   Then I use repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "update <type>" 
    Then the exit code is 0
     And Transaction is empty
@@ -155,8 +155,8 @@ Examples:
 
 @bz1585138
 Scenario Outline: Print correct number of available updates if update <type> is given and updateinfo is available
-  Given I use the repository "dnf-ci-fedora-updates"
-    And I use the repository "dnf-ci-thirdparty-updates"
+  Given I use repository "dnf-ci-fedora-updates"
+    And I use repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "update <type>" 
    Then the exit code is 0
     And Transaction is empty

--- a/dnf-behave-tests/features/vars-mirrorlist.feature
+++ b/dnf-behave-tests/features/vars-mirrorlist.feature
@@ -2,21 +2,15 @@ Feature: Subtitute variables in mirrorlist
 
 @bz1651092
 Scenario: Variables are substituted in mirrorlist URLs
-Given I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/base-noarch"
-  And I create and substitute file "/etc/yum.repos.d/test.repo" with
-  """
-  [testrepo]
-  name=testrepo
-  mirrorlist={context.dnf.installroot}/temp-repos/mirrorlist.txt
-  enabled=1
-  gpgcheck=0
-  """
-  And I do not set reposdir
-  And I use the repository "testrepo"
+Given I use repository "dnf-ci-fedora" with configuration
+      | key        | value                                               |
+      | mirrorlist | {context.dnf.installroot}/temp-repos/mirrorlist.txt |
+      | baseurl    |                                                     |
+  And I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/base-noarch"
   And I create and substitute file "/temp-repos/mirrorlist.txt" with
-  """
-  file:///{context.dnf.installroot}/temp-repos/base-$basearch/
-  """
+      """
+      file:///{context.dnf.installroot}/temp-repos/base-$basearch/
+      """
 Then I set config option "basearch" to "noarch"
  And I execute dnf with args "install setup"
 Then the exit code is 0

--- a/dnf-behave-tests/features/vars-releasever.feature
+++ b/dnf-behave-tests/features/vars-releasever.feature
@@ -1,19 +1,13 @@
 Feature: Subtitute releasever in baseurl
 
+Background:
+  Given I do not set releasever
+    And I use repository "dnf-ci-fedora" with configuration
+        | key     | value                                                         |
+        | baseurl | file://{context.dnf.installroot}/temp-repos/base-f$releasever |
 
 Scenario: Releasever is substituted in baseurl via a command line option
-  Given I do not set releasever
-    And I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/base-f0123"
-    And I create and substitute file "/etc/yum.repos.d/test.repo" with
-        """
-        [testrepo]
-        name=testrepo
-        baseurl=file://{context.dnf.installroot}/temp-repos/base-f$releasever
-        enabled=1
-        gpgcheck=0
-        """
-    And I do not set reposdir
-    And I use the repository "testrepo"
+  Given I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/base-f0123"
     And I execute dnf with args "install setup --releasever=0123"
    Then the exit code is 0
     And Transaction is following
@@ -22,22 +16,11 @@ Scenario: Releasever is substituted in baseurl via a command line option
 
 
 Scenario: Releasever is substituted in baseurl via a config file
-  Given I do not set releasever
-    And I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/base-f0123"
-    And I create and substitute file "/etc/yum.repos.d/test.repo" with
-        """
-        [testrepo]
-        name=testrepo
-        baseurl=file://{context.dnf.installroot}/temp-repos/base-f$releasever
-        enabled=1
-        gpgcheck=0
-        """
+  Given I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/base-f0123"
     And I create and substitute file "/etc/dnf/vars/releasever" with
         """
         0123
         """
-    And I do not set reposdir
-    And I use the repository "testrepo"
     And I execute dnf with args "install setup"
    Then the exit code is 0
     And Transaction is following
@@ -46,19 +29,8 @@ Scenario: Releasever is substituted in baseurl via a config file
 
 
 Scenario: Releasever is substituted in baseurl via a value detected from a fedora-release package
-  Given I do not set releasever
-    And I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/fedora-release-29-1.noarch.rpm"
+  Given I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/fedora-release-29-1.noarch.rpm"
     And I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/base-f29"
-    And I create and substitute file "/etc/yum.repos.d/test.repo" with
-        """
-        [testrepo]
-        name=testrepo
-        baseurl=file://{context.dnf.installroot}/temp-repos/base-f$releasever
-        enabled=1
-        gpgcheck=0
-        """
-    And I do not set reposdir
-    And I use the repository "testrepo"
     And I execute dnf with args "install setup"
    Then the exit code is 0
     And Transaction is following
@@ -68,19 +40,8 @@ Scenario: Releasever is substituted in baseurl via a value detected from a fedor
 
 @bz1710761
 Scenario: Releasever is substituted in baseurl via a value detected from 'system-release(releasever)' provide
-  Given I do not set releasever
-    And I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/dnf-ci-fedora-release/noarch/fedora-release-29-1.noarch.rpm"
+  Given I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/dnf-ci-fedora-release/noarch/fedora-release-29-1.noarch.rpm"
     And I copy directory "{context.dnf.repos_location}/dnf-ci-fedora" to "/temp-repos/base-f123"
-    And I create and substitute file "/etc/yum.repos.d/test.repo" with
-        """
-        [testrepo]
-        name=testrepo
-        baseurl=file://{context.dnf.installroot}/temp-repos/base-f$releasever
-        enabled=1
-        gpgcheck=0
-        """
-    And I do not set reposdir
-    And I use the repository "testrepo"
     And I execute dnf with args "install setup"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/fixtures/repos.d/debuginfo-install.repo
+++ b/dnf-behave-tests/fixtures/repos.d/debuginfo-install.repo
@@ -1,5 +1,0 @@
-[debuginfo-install]
-name=debuginfo-install: test repository
-baseurl=file://$DNF0/repos/debuginfo-install
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-modular-hotfix.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-modular-hotfix.repo
@@ -1,6 +1,0 @@
-[dnf-ci-fedora-modular-hotfix]
-name=dnf-ci-fedora-modular-hotfix
-baseurl=file://$DNF0/repos/dnf-ci-fedora-modular-hotfix
-enabled=1
-gpgcheck=0
-module_hotfixes=1

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-modular-updates.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-modular-updates.repo
@@ -1,5 +1,0 @@
-[dnf-ci-fedora-modular-updates]
-name=dnf-ci-fedora-modular-updates
-baseurl=file://$DNF0/repos/dnf-ci-fedora-modular-updates
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-modular.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-modular.repo
@@ -1,5 +1,0 @@
-[dnf-ci-fedora-modular]
-name=dnf-ci-fedora-modular
-baseurl=file://$DNF0/repos/dnf-ci-fedora-modular
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-updates-testing.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-updates-testing.repo
@@ -1,5 +1,0 @@
-[dnf-ci-fedora-updates-testing]
-name=dnf-ci-fedora-updates-testing
-baseurl=file://$DNF0/repos/dnf-ci-fedora-updates-testing
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-updates.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora-updates.repo
@@ -1,5 +1,0 @@
-[dnf-ci-fedora-updates]
-name=dnf-ci-fedora-updates
-baseurl=file://$DNF0/repos/dnf-ci-fedora-updates
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fedora.repo
@@ -1,6 +1,0 @@
-[dnf-ci-fedora]
-name=dnf-ci-fedora
-baseurl=file://$DNF0/repos/dnf-ci-fedora
-enabled=1
-gpgcheck=0
-skip_if_unavailable=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fifthparty-modular.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fifthparty-modular.repo
@@ -1,5 +1,0 @@
-[dnf-ci-fifthparty-modular]
-name=dnf-ci-fifthparty-modular
-baseurl=file://$DNF0/repos/dnf-ci-fifthparty-modular
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fifthparty.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fifthparty.repo
@@ -1,5 +1,0 @@
-[dnf-ci-fifthparty]
-name=dnf-ci-fifthparty
-baseurl=file://$DNF0/repos/dnf-ci-fifthparty
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fileconflicts.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fileconflicts.repo
@@ -1,5 +1,0 @@
-[dnf-ci-fileconflicts]
-name=dnf-ci-fileconflicts
-baseurl=file://$DNF0/repos/dnf-ci-fileconflicts
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-fourthparty-modular.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-fourthparty-modular.repo
@@ -1,6 +1,0 @@
-[dnf-ci-fourthparty-modular]
-name=dnf-ci-fourthparty-modular
-baseurl=file://$DNF0/repos/dnf-ci-fourthparty-modular
-enabled=1
-gpgcheck=0
-skip_if_unavailable=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-gpg-nocheck.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-gpg-nocheck.repo
@@ -1,6 +1,0 @@
-[dnf-ci-gpg-nocheck]
-name=dnf-ci-gpg-nocheck
-baseurl=file://$DNF0/repos/dnf-ci-gpg
-enabled=1
-gpgcheck=0
-gpgkey=file:///$DNF0/gpgkeys/keys/dnf-ci-gpg/dnf-ci-gpg-public

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-gpg-updates.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-gpg-updates.repo
@@ -1,6 +1,0 @@
-[dnf-ci-gpg-updates]
-name=dnf-ci-gpg-updates
-baseurl=file://$DNF0/repos/dnf-ci-gpg-updates
-enabled=1
-gpgcheck=1
-gpgkey=file://$DNF0/gpgkeys/keys/dnf-ci-gpg-updates/dnf-ci-gpg-updates-public

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-gpg.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-gpg.repo
@@ -1,6 +1,0 @@
-[dnf-ci-gpg]
-name=dnf-ci-gpg
-baseurl=file://$DNF0/repos/dnf-ci-gpg
-enabled=1
-gpgcheck=1
-gpgkey=file:///$DNF0/gpgkeys/keys/dnf-ci-gpg/dnf-ci-gpg-public,file:///$DNF0/gpgkeys/keys/dnf-ci-gpg-subkey/dnf-ci-gpg-subkey-public

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-gpgcheck-undefined.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-gpgcheck-undefined.repo
@@ -1,4 +1,0 @@
-[dnf-ci-gpgcheck-undefined]
-name=dnf-ci-gpgcheck-undefined
-baseurl=file://$DNF0/repos/dnf-ci-gpg
-enabled=1

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-install-remove.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-install-remove.repo
@@ -1,5 +1,0 @@
-[dnf-ci-install-remove]
-name=dnf-ci-install-remove
-baseurl=file://$DNF0/repos/dnf-ci-install-remove
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-obsoletes.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-obsoletes.repo
@@ -1,5 +1,0 @@
-[dnf-ci-obsoletes]
-name=dnf-ci-obsoletes
-baseurl=file://$DNF0/repos/dnf-ci-obsoletes
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-priority-1.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-priority-1.repo
@@ -1,7 +1,0 @@
-[dnf-ci-priority-1]
-name=dnf-ci-priority-1
-baseurl=file://$DNF0/repos/dnf-ci-priority-1
-enabled=1
-gpgcheck=0
-priority=1
-

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-priority-2.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-priority-2.repo
@@ -1,7 +1,0 @@
-[dnf-ci-priority-2]
-name=dnf-ci-priority-2
-baseurl=file://$DNF0/repos/dnf-ci-priority-2
-enabled=1
-gpgcheck=0
-priority=2
-

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-priority-3.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-priority-3.repo
@@ -1,7 +1,0 @@
-[dnf-ci-priority-3]
-name=dnf-ci-priority-3
-baseurl=file://$DNF0/repos/dnf-ci-priority-3
-enabled=1
-gpgcheck=0
-priority=3
-

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-pseudo-platform-modular.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-pseudo-platform-modular.repo
@@ -1,5 +1,0 @@
-[dnf-ci-pseudo-platform-modular]
-name=dnf-ci-pseudo-platform-modular
-baseurl=file://$DNF0/repos/dnf-ci-pseudo-platform-modular
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-pseudo-platform.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-pseudo-platform.repo
@@ -1,5 +1,0 @@
-[dnf-ci-pseudo-platform]
-name=dnf-ci-pseudo-platform
-baseurl=file://$DNF0/repos/dnf-ci-pseudo-platform
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-rich.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-rich.repo
@@ -1,6 +1,0 @@
-[dnf-ci-rich]
-name=dnf-ci-rich
-baseurl=file://$DNF0/repos/dnf-ci-rich
-enabled=1
-gpgcheck=0
-skip_if_unavailable=1

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-scriptlets.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-scriptlets.repo
@@ -1,5 +1,0 @@
-[dnf-ci-scriptlets]
-name=dnf-ci-scriptlets
-baseurl=file://$DNF0/repos/dnf-ci-scriptlets
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-security.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-security.repo
@@ -1,5 +1,0 @@
-[dnf-ci-security]
-name=dnf-ci-security
-baseurl=file://$DNF0/repos/dnf-ci-security
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty-modular-updates.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty-modular-updates.repo
@@ -1,5 +1,0 @@
-[dnf-ci-thirdparty-modular-updates]
-name=dnf-ci-thirdparty-modular-updates
-baseurl=file://$DNF0/repos/dnf-ci-thirdparty-modular-updates
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty-modular.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty-modular.repo
@@ -1,5 +1,0 @@
-[dnf-ci-thirdparty-modular]
-name=dnf-ci-thirdparty-modular
-baseurl=file://$DNF0/repos/dnf-ci-thirdparty-modular
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty-updates.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty-updates.repo
@@ -1,5 +1,0 @@
-[dnf-ci-thirdparty-updates]
-name=dnf-ci-thirdparty-updates
-baseurl=file://$DNF0/repos/dnf-ci-thirdparty-updates
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty.repo
+++ b/dnf-behave-tests/fixtures/repos.d/dnf-ci-thirdparty.repo
@@ -1,5 +1,0 @@
-[dnf-ci-thirdparty]
-name=dnf-ci-thirdparty
-baseurl=file://$DNF0/repos/dnf-ci-thirdparty
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/fail-safe-hotfix.repo
+++ b/dnf-behave-tests/fixtures/repos.d/fail-safe-hotfix.repo
@@ -1,7 +1,0 @@
-[fail-safe-hotfix]
-name=fail-safe-hotfix
-baseurl=file://$DNF0/repos/fail-safe-hotfix
-enabled=1
-gpgcheck=0
-skip_if_unavailable=0
-module_hotfixes=1

--- a/dnf-behave-tests/fixtures/repos.d/miscellaneous.repo
+++ b/dnf-behave-tests/fixtures/repos.d/miscellaneous.repo
@@ -1,7 +1,0 @@
-[miscellaneous]
-# use this when you need an additional repository with arbitrary packages you
-# don't care much about
-name=Miscellaneous Packages
-baseurl=file://$DNF0/repos/miscellaneous
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/repoquery-deps.repo
+++ b/dnf-behave-tests/fixtures/repos.d/repoquery-deps.repo
@@ -1,5 +1,0 @@
-[repoquery-deps]
-name=repoquery: deps test suite
-baseurl=file://$DNF0/repos/repoquery-deps
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/repoquery-globs.repo
+++ b/dnf-behave-tests/fixtures/repos.d/repoquery-globs.repo
@@ -1,5 +1,0 @@
-[repoquery-globs]
-name=repoquery: globs test suite
-baseurl=file://$DNF0/repos/repoquery-globs
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/repoquery-main.repo
+++ b/dnf-behave-tests/fixtures/repos.d/repoquery-main.repo
@@ -1,5 +1,0 @@
-[repoquery-main]
-name=repoquery: main test suite
-baseurl=file://$DNF0/repos/repoquery-main
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/repoquery-rich-deps.repo
+++ b/dnf-behave-tests/fixtures/repos.d/repoquery-rich-deps.repo
@@ -1,5 +1,0 @@
-[repoquery-rich-deps]
-name=repoquery: rich-deps test suite
-baseurl=file://$DNF0/repos/repoquery-rich-deps
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/repoquery-weak-deps.repo
+++ b/dnf-behave-tests/fixtures/repos.d/repoquery-weak-deps.repo
@@ -1,5 +1,0 @@
-[repoquery-weak-deps]
-name=repoquery: weak-deps test suite
-baseurl=file://$DNF0/repos/repoquery-weak-deps
-enabled=1
-gpgcheck=0

--- a/dnf-behave-tests/fixtures/repos.d/reposync.repo
+++ b/dnf-behave-tests/fixtures/repos.d/reposync.repo
@@ -1,6 +1,0 @@
-[reposync]
-name=reposync
-baseurl=file://$DNF0/repos/reposync
-enabled=1
-gpgcheck=0
-skip_if_unavailable=0

--- a/dnf-behave-tests/fixtures/repos.d/setopt.ext.repo
+++ b/dnf-behave-tests/fixtures/repos.d/setopt.ext.repo
@@ -1,6 +1,0 @@
-[setopt.ext]
-name=setopt.ext
-baseurl=file://$DNF0/repos/setopt.ext
-enabled=1
-gpgcheck=0
-skip_if_unavailable=0

--- a/dnf-behave-tests/fixtures/repos.d/setopt.repo
+++ b/dnf-behave-tests/fixtures/repos.d/setopt.repo
@@ -1,6 +1,0 @@
-[setopt]
-name=setopt
-baseurl=file://$DNF0/repos/setopt
-enabled=1
-gpgcheck=0
-skip_if_unavailable=0

--- a/dnf-behave-tests/fixtures/specs/build.sh
+++ b/dnf-behave-tests/fixtures/specs/build.sh
@@ -73,25 +73,6 @@ done
 
 ${GPGDIR}/sign.sh
 ${DIR}/break-packages.sh
-
-for path in $REPODIR/*; do
-    REPO=$(basename $path)
-    echo "Creating repo $path..."
-    pushd $path
-    ARGS="--no-database --simple-md-filenames --revision=1550000000"
-    if [ -f ../../specs/$REPO/$GROUPS_FILENAME ]; then
-        ARGS="$ARGS --groupfile ../../specs/$REPO/$GROUPS_FILENAME"
-    fi
-    createrepo_c $ARGS .
-    if [ -f ../../specs/$REPO/$UPDATEINFO_FILENAME ]; then
-        modifyrepo_c ../../specs/$REPO/$UPDATEINFO_FILENAME ./repodata
-    fi
-    if [ -f ../../specs/$REPO/$MODULES_FILENAME ]; then
-        modifyrepo_c --mdtype=modules ../../specs/$REPO/$MODULES_FILENAME ./repodata
-    fi
-    popd
-done
-
 ${CERTSDIR}/generate_certificates.sh
 
 echo "DONE: Test data created"


### PR DESCRIPTION
This series introduces new steps for working with repositories in the scenarios.

In a brief summary, the static repository configs in `fixtures/repos.d/` are no longer used, instead repository configs are created dynamically in the default location inside installroot (`/etc/yum.repos.d/`). The default repository configuration is now stored in the steps and the steps allow to override it.

The repository metadata are still "static" from the behave point of view, generated once and never changing. For tests that need to change the repository metadata, a step is introduced to copy the whole repository to a temporary location (this was done somewhat manually for some steps, now it's standardized).

This cleans up a lot of the more complex test setups. For tests with non-default repo configuration, it makes it easy to do and puts the configuration next to the scenarios (as opposed to static config files elsewhere). It also reduces the number of the dnf command arguments that were needed for each call to set up the out of place repositories, which is a good thing in general and makes the tests easier to work with.

There are a lot of changes to test scenarios, loosely grouped by the kind of changes that needed to be done. I believe a lot of the changes don't need thorough review, the tests passing is enough. Some tests do though.

A couple notes:
* The last commit moves generation of repodata to behave steps. It is not necessary per se, I just wrote it while figuring out how to do this and it ended up not being required. But personally I'd like to see the whole test data setup moved to behave gradually, so I though it would be a pity to drop it when I already wrote it...

* The new way to set up a metalink for a repository now requires three steps used in the right order. I'm not opposed to and thinking about creating a single step to wrap those three...