### PR TITLE
Use libcopms spec from upstream, this should fix nightly builds

### DIFF
--- a/overlays/dnf-master/overlay.yml
+++ b/overlays/dnf-master/overlay.yml
@@ -32,9 +32,6 @@ components:
   - name: libcomps
     git:
       src: github:rpm-software-management/libcomps.git
-    distgit:
-      src: fedorapkgs:libcomps.git
-      patches: drop
 
   - name: libdnf
     git:


### PR DESCRIPTION
Downstream spec has not caught up with the changes yet.