### PR TITLE
Add steps for configuring new repositories

### DIFF
--- a/dnf-behave-tests/features/config.feature
+++ b/dnf-behave-tests/features/config.feature
@@ -71,14 +71,9 @@ Scenario: Reposdir option in dnf.conf file in installroot
     [main]
     reposdir=/testrepos
     """
-    And I create and substitute file "/testrepos/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl={context.dnf.repos_location}/dnf-ci-fedora
-    enabled=1
-    gpgcheck=0
-    """
+    And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
+        | key     | value                                      |
+        | baseurl | {context.dnf.repos_location}/dnf-ci-fedora |
     And I do not set config file
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
@@ -94,14 +89,9 @@ Scenario: Reposdir option in dnf.conf file with --config option in installroot
     [main]
     reposdir=/testrepos
     """
-    And I create and substitute file "/testrepos/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl={context.dnf.repos_location}/dnf-ci-fedora
-    enabled=1
-    gpgcheck=0
-    """
+    And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
+        | key     | value                                      |
+        | baseurl | {context.dnf.repos_location}/dnf-ci-fedora |
     And I set config file to "/testdnf.conf"
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
@@ -117,14 +107,9 @@ Scenario: Reposdir option in dnf.conf file with --config option in installroot i
     [main]
     reposdir={context.dnf.installroot}/testrepos,/othertestrepos
     """
-    And I create and substitute file "/testrepos/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl={context.dnf.repos_location}/dnf-ci-fedora
-    enabled=1
-    gpgcheck=0
-    """
+    And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
+        | key     | value                                      |
+        | baseurl | {context.dnf.repos_location}/dnf-ci-fedora |
     And I set config file to "/testdnf.conf"
     And I create directory "/othertestrepos"
    When I execute dnf with args "install filesystem"
@@ -140,14 +125,9 @@ Scenario: Reposdir option in dnf.conf file with --config option in installroot i
 
 
 Scenario: Reposdir option set by --setopt
-  Given I create and substitute file "/testrepos/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl={context.dnf.repos_location}/dnf-ci-fedora
-    enabled=1
-    gpgcheck=0
-    """
+  Given I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
+        | key     | value                                      |
+        | baseurl | {context.dnf.repos_location}/dnf-ci-fedora |
    # fail due to unavailable repository
    When I execute dnf with args "install filesystem"
    Then the exit code is 1

--- a/dnf-behave-tests/features/fail-safe.feature
+++ b/dnf-behave-tests/features/fail-safe.feature
@@ -497,15 +497,9 @@ Scenario Outline: When modulemd is not available, RPM from the enabled stream ca
   Given I execute step "<step>"
     And I execute dnf with args "clean all"
       # Workaround for a bug - when the repo id is too log and nodejs is installed later on, the output from transaction is formatted incorrectly (no space between "Arch" and "Version")
-    And I create and substitute file "/etc/yum.repos.d/short-modular-updates.repo" with
-        """
-        [short-modular-updates]
-        name=short-modular-updates
-        baseurl={context.dnf.repos_location}/dnf-ci-fedora-modular-updates
-        enabled=1
-        gpgcheck=0
-        skip_if_unavailable=0
-        """
+    And I configure a new repository "short-modular-updates" with
+        | key     | value                                                      |
+        | baseurl | {context.dnf.repos_location}/dnf-ci-fedora-modular-updates |
       # since we're configuring the repo ourselves, force generation of repodata by using and unusing it
     And I use repository "dnf-ci-fedora-modular-updates"
     And I drop repository "dnf-ci-fedora-modular-updates"

--- a/dnf-behave-tests/features/installroot.feature
+++ b/dnf-behave-tests/features/installroot.feature
@@ -6,14 +6,9 @@ Scenario: Install package from host repository into empty installroot
   # The following two steps generate repodata for the repository without configuring it
   Given I use repository "dnf-ci-install-remove"
   Given I drop repository "dnf-ci-install-remove"
-    And I create and substitute file "//{context.dnf.tempdir}/repos.d/insideinstallroot.repo" with
-    """
-    [dnf-ci-install-remove]
-    name=dnf-ci-install-remove
-    baseurl={context.dnf.repos_location}/dnf-ci-install-remove
-    enabled=1
-    gpgcheck=0
-    """
+    And I configure a new repository "outside-installroot" in "{context.dnf.tempdir}/repos.d" with
+        | key     | value                                              |
+        | baseurl | {context.dnf.repos_location}/dnf-ci-install-remove |
     When I execute dnf with args "--setopt=reposdir={context.dnf.tempdir}/repos.d install water_carbonated"
    Then the exit code is 0
     And Transaction is following
@@ -77,20 +72,15 @@ Scenario: Repolist command in installroot and with a reposdir specified
         repo id                      repo name                                    status
         dnf-ci-install-remove        dnf-ci-install-remove test repository        20
         """
-  Given I create and substitute file "/{context.dnf.tempdir}/repos.d/testrepo.repo" with
-        """
-        [testrepo]
-        name=test repo
-        baseurl={context.dnf.repos_location}/dnf-ci-install-remove
-        enabled=1
-        gpgcheck=0
-        """
+  Given I configure a new repository "testrepo" in "{context.dnf.tempdir}/repos.d" with
+        | key     | value                                              |
+        | baseurl | {context.dnf.repos_location}/dnf-ci-install-remove |
    When I execute dnf with args "--setopt=reposdir={context.dnf.tempdir}/repos.d repolist"
    Then the exit code is 0
     And stdout is
         """
-        repo id                             repo name                             status
-        testrepo                            test repo                             20
+        repo id                      repo name                                    status
+        testrepo                     testrepo test repository                     20
         """
 
 

--- a/dnf-behave-tests/features/metadata.feature
+++ b/dnf-behave-tests/features/metadata.feature
@@ -3,15 +3,10 @@ Feature: Testing DNF metadata handling
 @bz1644283
 Scenario: update expired metadata on first dnf update
 Given I create directory "/temp-repos/temp-repo"
-  And I create and substitute file "/etc/yum.repos.d/test.repo" with
-  """
-  [testrepo]
-  name=testrepo
-  baseurl={context.dnf.installroot}/temp-repos/temp-repo
-  enabled=1
-  gpgcheck=0
-  metadata_expire=1s
-  """
+  And I configure a new repository "testrepo" with
+      | key             | value                                          |
+      | baseurl         | {context.dnf.installroot}/temp-repos/temp-repo |
+      | metadata_expire | 1s                                             |
   And I execute "createrepo_c --update ." in "{context.dnf.installroot}/temp-repos/temp-repo"
  Then the exit code is 0
  When I execute dnf with args "list all"

--- a/dnf-behave-tests/features/plugins-core/reposync.feature
+++ b/dnf-behave-tests/features/plugins-core/reposync.feature
@@ -32,14 +32,9 @@ Scenario: Reposync with --downloadcomps option
     And the files "{context.dnf.tempdir}/dnf-ci-thirdparty-updates/comps.xml" and "{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/comps.xml" do not differ
    When I execute "createrepo_c --no-database --simple-md-filenames --groupfile comps.xml ." in "{context.dnf.tempdir}/dnf-ci-thirdparty-updates"
    Then the exit code is 0
-  Given I create and substitute file "/etc/yum.repos.d/test.repo" with
-  """
-  [testrepo]
-  name=testrepo
-  baseurl={context.dnf.tempdir}/dnf-ci-thirdparty-updates
-  enabled=1
-  gpgcheck=0
-  """
+  Given I configure a new repository "testrepo" with
+        | key             | value                                           |
+        | baseurl         | {context.dnf.tempdir}/dnf-ci-thirdparty-updates |
     And I drop repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "group list"
    Then the exit code is 0
@@ -73,14 +68,9 @@ Scenario: Reposync with --download-metadata option
   Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --download-metadata"
    Then the exit code is 0
-  Given I create and substitute file "/etc/yum.repos.d/test.repo" with
-  """
-  [testrepo]
-  name=testrepo
-  baseurl={context.dnf.tempdir}/dnf-ci-thirdparty-updates
-  enabled=1
-  gpgcheck=0
-  """
+  Given I configure a new repository "testrepo" with
+        | key             | value                                           |
+        | baseurl         | {context.dnf.tempdir}/dnf-ci-thirdparty-updates |
     And I drop repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "group list"
    Then the exit code is 0
@@ -122,16 +112,9 @@ Scenario: Reposync downloads packages and removes packages that are not part of 
     And file "//{context.dnf.tempdir}/setopt.ext/x86_64/flac-1.0-1.fc29.x86_64.rpm" exists
     And file "//{context.dnf.tempdir}/setopt.ext/src/flac-1.0-1.fc29.src.rpm" exists
     And file "//{context.dnf.tempdir}/setopt.ext/x86_64/flac-libs-1.0-1.fc29.x86_64.rpm" exists
-  Given I create and substitute file "/etc/yum.repos.d/test.repo" with
-  """
-  [setopt.ext]
-  name=setopt.ext
-  baseurl={context.dnf.repos_location}/setopt
-  enabled=1
-  gpgcheck=0
-  skip_if_unavailable=0
-  """
-    And I drop repository "setopt.ext"
+  Given I configure repository "setopt.ext" with
+        | key             | value                               |
+        | baseurl         | {context.dnf.repos_location}/setopt |
     # The following two steps generate repodata for the repository without configuring it
     And I use repository "setopt"
     And I drop repository "setopt"

--- a/dnf-behave-tests/features/repo-sync.feature
+++ b/dnf-behave-tests/features/repo-sync.feature
@@ -9,14 +9,9 @@ Scenario: The default value of skip_if_unavailable is False
     [main]
     reposdir=/testrepos
     """
-    And I create file "/testrepos/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl=/non/existent/repo
-    enabled=1
-    gpgcheck=0
-    """
+    And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
+        | key             | value              |
+        | baseurl         | /non/existent/repo |
     And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 1
@@ -34,14 +29,9 @@ Scenario: There is global skip_if_unavailable option
     reposdir=/testrepos
     skip_if_unavailable=True
     """
-    And I create file "/testrepos/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl=/non/existent/repo
-    enabled=1
-    gpgcheck=0
-    """
+    And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
+        | key             | value              |
+        | baseurl         | /non/existent/repo |
     And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 0
@@ -63,15 +53,10 @@ Scenario: Per repo skip_if_unavailable configuration
     [main]
     reposdir=/testrepos
     """
-    And I create file "/testrepos/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl=/non/existent/repo
-    enabled=1
-    gpgcheck=0
-    skip_if_unavailable=True
-    """
+    And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
+        | key                 | value              |
+        | baseurl             | /non/existent/repo |
+        | skip_if_unavailable | True               |
     And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 0
@@ -95,15 +80,10 @@ Scenario: The repo configuration takes precedence over the global one
     reposdir=/testrepos
     skip_if_unavailable=True
     """
-    And I create file "/testrepos/test.repo" with
-    """
-    [testrepo]
-    name=testrepo
-    baseurl=/non/existent/repo
-    enabled=1
-    gpgcheck=0
-    skip_if_unavailable=False
-    """
+    And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
+        | key                 | value              |
+        | baseurl             | /non/existent/repo |
+        | skip_if_unavailable | False              |
     And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 1


### PR DESCRIPTION
For one reason or another it is sometimes needed to create configs for
custom repositories that don't have data in fixtures/repos, occasionaly
also at non-default locations.

This adds steps for creating such configs (while using the shared config
defaults) and uses the steps where applicable.