### PR TITLE
Fix unsolvable requires in repoquery test packages

### DIFF
--- a/dnf-behave-tests/features/repoquery/deps.feature
+++ b/dnf-behave-tests/features/repoquery/deps.feature
@@ -85,7 +85,7 @@ Scenario: repoquery --requires --resolve --recursive --tree NAME-VERSION
       """
       top1-1:2.0-1.src
       top1-1:2.0-1.x86_64
-       \_ middle1-1:2.0-1.x86_64 [4: bottom1-prov1, /a/bottom4-file, bottom2 = 1:1.0-1, bottom1-prov2 >= 2.0]
+       \_ middle1-1:2.0-1.x86_64 [3: /a/bottom4-file, bottom2 = 1:1.0-1, bottom1-prov2 >= 2.0]
        |   \_ bottom1-1:2.0-1.x86_64 [0: ]
        |   \_ bottom2-1:1.0-1.x86_64 [0: ]
        |   \_ bottom4-1:1.0-1.x86_64 [0: ]
@@ -264,7 +264,7 @@ Scenario: repoquery --whatrequires NAME (file provide)
       """
 
 Scenario: repoquery --whatrequires PROVIDE_NAME
- When I execute dnf with args "repoquery --whatrequires bottom1-prov1"
+ When I execute dnf with args "repoquery --whatrequires bottom1-prov2"
  Then the exit code is 0
   And stdout is
       """
@@ -281,7 +281,7 @@ Scenario: repoquery --whatrequires PROVIDE_NAME = VERSION
       """
 
 Scenario: repoquery --whatrequires --recursive PROVIDE_NAME
- When I execute dnf with args "repoquery --recursive --whatrequires bottom1-prov1"
+ When I execute dnf with args "repoquery --recursive --whatrequires bottom1-prov2"
  Then the exit code is 0
   And stdout is
       """

--- a/dnf-behave-tests/fixtures/specs/repoquery-deps/middle1-1:2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-deps/middle1-1:2.0-1.spec
@@ -8,7 +8,6 @@ URL:            None
 
 Provides:       middle1-prov1 = 2.0
 
-Requires:       bottom1-prov1
 Requires:       bottom1-prov2 >= 2.0
 Requires:       bottom2 = 1:1.0-1
 Requires:       /a/bottom4-file


### PR DESCRIPTION
Fixes a dependency conflict in the test packages and updates the tests.

Dependencies in the middle1-2.0 package couldn't be satisfied at the
same time:
Requires: bottom1-prov1         - provided only by bottom1-1.0
Requires: bottom1-prov2 >= 2.0  - provided only by bottom1-2.0

Libsolv still resolves this (erroneously, it would seem), but the
bottom1 package version it chooses actually changed in libsolv-0:0.7.7.