### PR TITLE
Adjust output according to DNF new code

### DIFF
--- a/dnf-behave-tests/features/config.feature
+++ b/dnf-behave-tests/features/config.feature
@@ -38,7 +38,7 @@ Scenario: Test with dnf.conf in installroot (dnf.conf is taken from installroot)
     """
    When I execute dnf with args "install filesystem"
    Then the exit code is 1
-    And stdout contains "No match for argument: filesystem"
+    And stdout contains "All matches were excluded by regular filtering for argument: filesystem"
     And stderr contains "Error: Unable to find a match"
 
 
@@ -59,7 +59,7 @@ Scenario: Test with dnf.conf in installroot and --config (dnf.conf is taken from
    Then the exit code is 0
    When I execute dnf with args "install dwm"
    Then the exit code is 1
-    And stdout contains "No match for argument: dwm"
+    And stdout contains "All matches were excluded by regular filtering for argument: dwm"
   Given I do not set config file
    When I execute dnf with args "install dwm"
    Then the exit code is 0

--- a/dnf-behave-tests/features/module-install-errors.feature
+++ b/dnf-behave-tests/features/module-install-errors.feature
@@ -44,7 +44,7 @@ Scenario: I cannot install an RPM with same name as an RPM that belongs to enabl
     """
     And stdout contains lines
     """
-    No match for argument: ninja-build-0:1.8.2-5.fc29.x86_64
+    All matches were excluded by modular filtering for argument: ninja-build-0:1.8.2-5.fc29.x86_64
     """
 
 Scenario: A proper error message is displayed when I try to install a non-existent stream

--- a/dnf-behave-tests/features/module-install-package.feature
+++ b/dnf-behave-tests/features/module-install-package.feature
@@ -39,7 +39,7 @@ Scenario: module content masks ursine content - module not enabled, default stre
    When I execute dnf with args "install ninja-build-0:1.8.2-5.fc29.x86_64"
    Then the exit code is 1
     And stderr contains "Error: Unable to find a match"
-    And stdout contains "No match for argument: ninja-build-0:1.8.2-5.fc29.x86_64"
+    And stdout contains "All matches were excluded by modular filtering for argument: ninja-build-0:1.8.2-5.fc29.x86_64"
 
 
 Scenario: module content masks ursine content - non-default stream enabled
@@ -50,7 +50,7 @@ Scenario: module content masks ursine content - non-default stream enabled
    When I execute dnf with args "install ninja-build-0:1.8.2-5.fc29.x86_64"
    Then the exit code is 1
     And stderr contains "Error: Unable to find a match"
-    And stdout contains "No match for argument: ninja-build-0:1.8.2-5.fc29.x86_64"
+    And stdout contains "All matches were excluded by modular filtering for argument: ninja-build-0:1.8.2-5.fc29.x86_64"
 
 
 Scenario: a package from a non-enabled module is preferred when default stream is defined

--- a/dnf-behave-tests/features/plugins-core/versionlock-lock.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-lock.feature
@@ -104,7 +104,7 @@ Scenario: Locking does not require that the package exists in a repository
     And stdout is
     """
     <REPOSYNC>
-    No match for argument: wget
+    All matches were excluded by regular filtering for argument: wget
     """
     And stderr is
     """


### PR DESCRIPTION
The message "No match for argument:" was changed to "All matches were
excluded by modular filtering for argument:" to be more informative