### PR TITLE
Stop parsing of docker/podman output

### DIFF
--- a/dnf-testing.sh
+++ b/dnf-testing.sh
@@ -148,24 +148,10 @@ list()
 
 build()
 {
-    local output=($($DOCKER_BIN build --build-arg TYPE="$type" \
-                    ${BUILD_CACHE} --force-rm -t "$IMAGE" -f "$DOCKER_FILE" "$PROG_PATH" | \
-        tee >(cat - >&2) | tail -1))
+    $DOCKER_BIN build --build-arg TYPE="$type" \
+        ${BUILD_CACHE} --force-rm -t "$IMAGE" -f "$DOCKER_FILE" "$PROG_PATH"
     RET=$?
-    if [ "$DOCKER_BIN" == "sudo docker" ]; then
-        if [ ${#output[@]} -eq 3 ] && \
-       	   [ "${output[0]}" = "Successfully" ] && 
-           [ "${output[1]}" = "built" ]; then
-            printf "%s\n" "${output[2]}"
-        else
-            fatal "Failed to parse output."
-        fi
-    else
-        if [ $RET -ne 0 ]; then
-            fatal "Image build failed."
-        fi
-    fi
-    exit 0
+    exit $RET
 }
 [ "$action" = "build" ] && build
 

--- a/jobs/github-testers-macros.yaml
+++ b/jobs/github-testers-macros.yaml
@@ -220,8 +220,9 @@
             pushd rpms
               join , "{{${{RPMS[@]}}}}" | xargs curl -O
             popd
-            CONTAINER=$(./dnf-testing.sh build jjb)
-            TESTS=($(./dnf-testing.sh list))
+            CONTAINER=$(uuidgen)
+            ./dnf-testing.sh -c $CONTAINER build jjb
+            TESTS=($(./dnf-testing.sh -c $CONTAINER list))
           popd
 
           echo "TESTS=${{TESTS[@]}}" > props


### PR DESCRIPTION
The output differs in different versions of docker and podman and this
caused problems with parsing of the output.
The only user of the parsed image id was CI jenkins job. But this job
can happily use unique tag generated by uuidgen.