### PR TITLE
Tests for builddep with unavailable dependency

### DIFF
--- a/dnf-behave-tests/fixtures/specs/dnf-ci-builddep/unavailable-requirement-1:1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-builddep/unavailable-requirement-1:1.0-1.spec
@@ -1,0 +1,19 @@
+Name:           unavailable-requirement
+Epoch:          1
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        A dummy package.
+
+BuildRequires:  this-lib-is-not-available
+BuildRequires:  lame-libs
+
+%description
+Dummy.
+
+%files
+
+%changelog


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf-plugins-core/pull/371