### PR TITLE
Strip only trailing whitespaces when comparing output

### DIFF
--- a/dnf-behave-tests/features/repoquery/main.feature
+++ b/dnf-behave-tests/features/repoquery/main.feature
@@ -497,7 +497,8 @@ Given I successfully execute rpm with args "-i --nodeps {context.dnf.fixturesdir
  Then the exit code is 0
   And stdout is
       """
-      Problem: problem with installed package broken-deps-1:1.0-1.x86_64
+
+       Problem: problem with installed package broken-deps-1:1.0-1.x86_64
         - nothing provides broken-dep-1 needed by broken-deps-1:1.0-1.x86_64
         - nothing provides broken-dep-2 >= 2.0 needed by broken-deps-1:1.0-1.x86_64
       """

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -185,8 +185,8 @@ def then_stdout_is(context):
     synchronization lines (i.e. the "Last metadata expiration check:" line as
     well as the individual repo download lines) in the test's output.
     """
-    expected = context.text.format(context=context).strip().split('\n')
-    found = context.cmd_stdout.strip().split('\n')
+    expected = context.text.format(context=context).rstrip().split('\n')
+    found = context.cmd_stdout.rstrip().split('\n')
 
     if found == [""]:
         found = []

--- a/dnf-behave-tests/features/updateinfo.feature
+++ b/dnf-behave-tests/features/updateinfo.feature
@@ -111,7 +111,7 @@ Scenario: updateinfo info security (when there's nothing to report)
    Then the exit code is 0
    And stdout is
    """
-    <REPOSYNC>
+   <REPOSYNC>
    """
 
 


### PR DESCRIPTION
Stripping leading whitespaces results in unability to test commands
that prepend whitespace characters to their output. For example
this:

Expected:
"""
<REPOSYNC>

the output
"""

Found:
"""

the output
"""

When the <REPOSYNC> line is not present and leading empty line is
stripped from the found output, the strings do not match.