### PR TITLE
Add RHEL and CentOS to User-Agent tests

### DIFF
--- a/dnf-behave-tests/features/countme.feature
+++ b/dnf-behave-tests/features/countme.feature
@@ -16,6 +16,8 @@ Feature: Better user counting
         | Fedora 30; server             | libdnf (Fedora 30; server; Linux.x86_64)                      |
         | Fedora 31                     | libdnf (Fedora 31; generic; Linux.x86_64)                     |
         | Fedora 31; myspin             | libdnf (Fedora 31; generic; Linux.x86_64)                     |
+        | Red Hat Enterprise Linux 8.1  | libdnf (Red Hat Enterprise Linux 8.1; generic; Linux.x86_64)  |
+        | CentOS Linux 8.1              | libdnf (CentOS Linux 8.1; generic; Linux.x86_64)              |
         | OpenSUSE 15.1; desktop        | libdnf                                                        |
 
     @destructive

--- a/dnf-behave-tests/features/countme.feature
+++ b/dnf-behave-tests/features/countme.feature
@@ -12,11 +12,11 @@ Feature: Better user counting
             | User-Agent | <agent> |
 
     Examples:
-        | system                | agent                                     |
-        | Fedora 30 server      | libdnf (Fedora 30; server; Linux.x86_64)  |
-        | Fedora 31             | libdnf (Fedora 31; generic; Linux.x86_64) |
-        | Fedora 31 myspin      | libdnf (Fedora 31; generic; Linux.x86_64) |
-        | OpenSUSE 15.1 desktop | libdnf                                    |
+        | system                        | agent                                                         |
+        | Fedora 30; server             | libdnf (Fedora 30; server; Linux.x86_64)                      |
+        | Fedora 31                     | libdnf (Fedora 31; generic; Linux.x86_64)                     |
+        | Fedora 31; myspin             | libdnf (Fedora 31; generic; Linux.x86_64)                     |
+        | OpenSUSE 15.1; desktop        | libdnf                                                        |
 
     @destructive
     @fixture.httpd

--- a/dnf-behave-tests/features/countme.feature
+++ b/dnf-behave-tests/features/countme.feature
@@ -2,47 +2,21 @@ Feature: Better user counting
 
     @destructive
     @fixture.httpd
-    Scenario: User-Agent header is sent
-        Given I am running a system identified as the "Fedora 30 server"
+    Scenario Outline: User-Agent header is sent
+        Given I am running a system identified as the "<system>"
           And I use repository "dnf-ci-fedora" as http
           And I start capturing outbound HTTP requests
          When I execute dnf with args "makecache"
          Then every HTTP GET request should match:
-            | header     | value                                    |
-            | User-Agent | libdnf (Fedora 30; server; Linux.x86_64) |
+            | header     | value   |
+            | User-Agent | <agent> |
 
-    @destructive
-    @fixture.httpd
-    Scenario: User-Agent header is sent (missing variant)
-        Given I am running a system identified as the "Fedora 31"
-          And I use repository "dnf-ci-fedora" as http
-          And I start capturing outbound HTTP requests
-         When I execute dnf with args "makecache"
-         Then every HTTP GET request should match:
-            | header     | value                                     |
-            | User-Agent | libdnf (Fedora 31; generic; Linux.x86_64) |
-
-    @destructive
-    @fixture.httpd
-    Scenario: User-Agent header is sent (unknown variant)
-        Given I am running a system identified as the "Fedora 31 myspin"
-          And I use repository "dnf-ci-fedora" as http
-          And I start capturing outbound HTTP requests
-         When I execute dnf with args "makecache"
-         Then every HTTP GET request should match:
-            | header     | value                                     |
-            | User-Agent | libdnf (Fedora 31; generic; Linux.x86_64) |
-
-    @destructive
-    @fixture.httpd
-    Scenario: Shortened User-Agent value on a non-Fedora system
-        Given I am running a system identified as the "OpenSUSE 15.1 desktop"
-          And I use repository "dnf-ci-fedora" as http
-          And I start capturing outbound HTTP requests
-         When I execute dnf with args "makecache"
-         Then every HTTP GET request should match:
-            | header     | value  |
-            | User-Agent | libdnf |
+    Examples:
+        | system                | agent                                     |
+        | Fedora 30 server      | libdnf (Fedora 30; server; Linux.x86_64)  |
+        | Fedora 31             | libdnf (Fedora 31; generic; Linux.x86_64) |
+        | Fedora 31 myspin      | libdnf (Fedora 31; generic; Linux.x86_64) |
+        | OpenSUSE 15.1 desktop | libdnf                                    |
 
     @destructive
     @fixture.httpd

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -213,7 +213,7 @@ class OSRelease(object):
 
     def set(self, data):
         """Store the given data in this file."""
-        content = ('%s=%s' % (k, v) for k, v in data.items())
+        content = ('%s=%s' % (k, v) for k, v in data.items() if v is not None)
         with open(self._path, 'w') as f:
             f.write('\n'.join(content))
 

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -283,7 +283,14 @@ def step_clear_http_logs(context):
 @behave.step("I am running a system identified as the \"{system}\"")
 def given_system(context, system):
     behave.use_fixture(osrelease, context)
-    data = dict(zip(('NAME', 'VERSION_ID', 'VARIANT_ID'), system.split(' ')))
+    system = system.split(';')
+    distro = system[0]
+    variant = None
+    if len(system) > 1:
+        variant = system[1]
+    name, version = distro.rsplit(' ', 1)
+    data = dict(zip(('NAME', 'VERSION_ID', 'VARIANT_ID'),
+                    (name, version, variant)))
     context.osrelease.set(data)
 
 


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/libdnf/pull/851