### PR TITLE
rhel-8.2.0 fixes

### DIFF
--- a/dnf-behave-tests/features/help.feature
+++ b/dnf-behave-tests/features/help.feature
@@ -1,6 +1,7 @@
 Feature: Help command
 
-Scenario: General help
+Scenario: General help (dnf)
+  Given I set dnf command to "dnf"
    When I execute dnf with args "--help"
    Then the exit code is 0
     And stdout contains "List of Main Commands"
@@ -12,9 +13,30 @@ Scenario: General help
     And stdout contains "List of Main Commands"
    When I execute dnf with args "unknown-command"
    Then the exit code is 1
-    And stderr contains "No such command"
-    And stderr contains "It could be a DNF plugin command"
+    And stderr is
+   """
+   No such command: unknown-command. Please use /usr/bin/dnf --help
+   It could be a DNF plugin command, try: "dnf install 'dnf-command(unknown-command)'"
+   """
 
+Scenario: General help (yum)
+  Given I set dnf command to "yum"
+   When I execute dnf with args "--help"
+   Then the exit code is 0
+    And stdout contains "List of Main Commands"
+   When I execute dnf with args "--unknown-option"
+   Then the exit code is 0
+    And stdout contains "List of Main Commands"
+   When I execute dnf with args "help"
+   Then the exit code is 0
+    And stdout contains "List of Main Commands"
+   When I execute dnf with args "unknown-command"
+   Then the exit code is 1
+    And stderr is
+   """
+   No such command: unknown-command. Please use /usr/bin/yum --help
+   It could be a YUM plugin command, try: "yum install 'dnf-command(unknown-command)'"
+   """
 
 Scenario: Command help
    When I execute dnf with args "help install"

--- a/dnf-behave-tests/features/module-enable-errors.feature
+++ b/dnf-behave-tests/features/module-enable-errors.feature
@@ -5,7 +5,8 @@ Background:
   Given I use repository "dnf-ci-fedora-modular-updates"
 
 
-Scenario: Fail to enable a different stream of an already enabled module
+Scenario: Fail to enable a different stream of an already enabled module (dnf)
+  Given I set dnf command to "dnf"
    When I execute dnf with args "module enable nodejs:8"
    Then the exit code is 0
     And Transaction is following
@@ -26,8 +27,30 @@ Scenario: Fail to enable a different stream of an already enabled module
         It is recommended to remove all installed content from the module, and reset the module using 'dnf module reset <module_name>' command. After you reset the module, you can install the other stream.
         """
 
+Scenario: Fail to enable a different stream of an already enabled module (yum)
+  Given I set dnf command to "yum"
+   When I execute dnf with args "module enable nodejs:8"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                   | Package            |
+        | module-stream-enable     | nodejs:8           |
+    And modules state is following
+        | Module    | State     | Stream    | Profiles  |
+        | nodejs    | enabled   | 8         |           |
+   When I execute dnf with args "module enable nodejs:10"
+   Then the exit code is 1
+    And modules state is following
+        | Module    | State     | Stream    | Profiles  |
+        | nodejs    | enabled   | 8         |           |
+    And stderr is
+        """
+        The operation would result in switching of module 'nodejs' stream '8' to stream '10'
+        Error: It is not possible to switch enabled streams of a module.
+        It is recommended to remove all installed content from the module, and reset the module using 'yum module reset <module_name>' command. After you reset the module, you can install the other stream.
+        """
 
 Scenario: Fail to install a different stream of an already enabled module
+  Given I set dnf command to "dnf"
    When I execute dnf with args "module enable nodejs:8"
    Then the exit code is 0
     And Transaction is following
@@ -51,6 +74,7 @@ Scenario: Fail to install a different stream of an already enabled module
 
 @bz1706215
 Scenario: Fail to install a different stream of an already enabled module using @module:stream syntax
+  Given I set dnf command to "dnf"
    When I execute dnf with args "module enable nodejs:8"
    Then the exit code is 0
     And Transaction is following
@@ -107,6 +131,7 @@ Scenario: Fail to enable a non-existent module stream
 
 
 Scenario: Fail to enable a module stream when not specifying anything
+  Given I set dnf command to "dnf"
    When I execute dnf with args "module enable"
    Then the exit code is 1
     And Transaction is empty

--- a/dnf-behave-tests/features/module-info.feature
+++ b/dnf-behave-tests/features/module-info.feature
@@ -619,11 +619,17 @@ Scenario: Get info for an enabled stream, module name and stream specified
         """
 
 
-  Scenario: Run 'dnf module info' without further argument
+ Scenario: Run 'dnf module info' without further argument (dnf)
+  Given I set dnf command to "dnf"
    When I execute dnf with args "module info"
    Then the exit code is 1
     And stderr contains "Error: dnf module info: too few arguments"
 
+ Scenario: Run 'dnf module info' without further argument (yum)
+  Given I set dnf command to "yum"
+   When I execute dnf with args "module info"
+   Then the exit code is 1
+    And stderr contains "Error: yum module info: too few arguments"
 
   @bz1571214
   Scenario Outline: I can get the info about content of existing module streams with <command>
@@ -729,6 +735,7 @@ Examples:
 
 
   Scenario: "dnf module profile" without any additional arguments should raise an error
+  Given I set dnf command to "dnf"
    When I execute dnf with args "module info --profile"
    Then the exit code is 1
     And stderr is

--- a/dnf-behave-tests/features/module-install-multicontext.feature
+++ b/dnf-behave-tests/features/module-install-multicontext.feature
@@ -21,8 +21,6 @@ Scenario: Install module, with specified profile and enabled dependencies
         | module-stream-enable      | nodejs:5                                        |
         | module-profile-install    | nodejs/minimal                                  |
 
-# until rhel has PR https://github.com/rpm-software-management/dnf/pull/1532
-@not.with_os=rhel__eq__8
 @bz1696204
 Scenario: Install module, with specified context that is not active (unsatisfied require)
    When I execute dnf with args "module enable postgresql:9.6"

--- a/dnf-behave-tests/features/module-provides.feature
+++ b/dnf-behave-tests/features/module-provides.feature
@@ -152,10 +152,20 @@ Given I successfully execute dnf with args "makecache"
       """
 
 
-Scenario: An error is printed when no arguments are provided
+Scenario: An error is printed when no arguments are provided (dnf)
+Given I set dnf command to "dnf"
  When I execute dnf with args "module provides"
  Then the exit code is 1
   And stderr is
       """
       Error: dnf module provides: too few arguments
+      """
+
+Scenario: An error is printed when no arguments are provided (yum)
+Given I set dnf command to "yum"
+ When I execute dnf with args "module provides"
+ Then the exit code is 1
+  And stderr is
+      """
+      Error: yum module provides: too few arguments
       """

--- a/dnf-behave-tests/features/plugins-core/post-transaction-actions.feature
+++ b/dnf-behave-tests/features/plugins-core/post-transaction-actions.feature
@@ -21,8 +21,6 @@ Background:
     And I use repository "dnf-ci-fedora"
 
 
-# until rhel has PR https://github.com/rpm-software-management/dnf-plugins-core/pull/366
-@not.with_os=rhel__eq__8
 Scenario: Variables in action files are substituted
   Given I create and substitute file "/etc/dnf/plugins/post-transaction-actions.d/test.action" with
     """
@@ -39,7 +37,6 @@ Scenario: Variables in action files are substituted
     """
 
 
-@not.with_os=rhel__eq__8    
 Scenario Outline: I can filter on package or file: "<filter>"
   Given I create and substitute file "/etc/dnf/plugins/post-transaction-actions.d/test.action" with
     """
@@ -68,7 +65,6 @@ Examples:
     | g*c               |
 
 
-@not.with_os=rhel__eq__8
 Scenario Outline: I can filter on transaction state
   Given I create and substitute file "/etc/dnf/plugins/post-transaction-actions.d/test.action" with
     """

--- a/dnf-behave-tests/features/plugins-core/reposync-local.feature
+++ b/dnf-behave-tests/features/plugins-core/reposync-local.feature
@@ -4,8 +4,7 @@ Feature: Tests for reposync command with local repository
 Background:
   Given I enable plugin "reposync"
 
-# until rhel has PR https://github.com/rpm-software-management/dnf-plugins-core/pull/346
-@not.with_os=rhel__eq__8
+
 Scenario: Base functionality of reposync on local repository
   Given I use repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir}"

--- a/dnf-behave-tests/features/plugins-core/reposync.feature
+++ b/dnf-behave-tests/features/plugins-core/reposync.feature
@@ -101,7 +101,6 @@ Scenario: Reposync downloads packages from all streams of modular repository eve
     And file "//{context.dnf.tempdir}/dnf-ci-fedora-modular/x86_64/nodejs-11.0.0-1.module_2311+8d497411.x86_64.rpm" exists
 
 
-@not.with_os=rhel__eq__8
 @bz1686602
 Scenario: Reposync respects excludes
   Given I use repository "dnf-ci-thirdparty-updates" as http
@@ -122,7 +121,6 @@ Scenario: Reposync respects excludes
         """
 
 
-@not.with_os=rhel__eq__8
 Scenario: Reposync respects excludes, but not modular excludes
   Given I use repository "dnf-ci-fedora-modular" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --setopt=includepkgs=postgresql"
@@ -187,7 +185,6 @@ Scenario: Reposync preserves remote timestamps of metadata files
     And timestamps of the files "{context.dnf.tempdir}/reposync/repodata/primary.xml.gz" and "{context.dnf.fixturesdir}/repos/reposync/repodata/primary.xml.gz" do not differ
 
 
-@not.with_os=rhel__eq__8
 @bz1686602
 Scenario: Reposync --urls switch
   Given I use repository "dnf-ci-thirdparty-updates" as http
@@ -205,7 +202,6 @@ Scenario: Reposync --urls switch
     """
 
 
-@not.with_os=rhel__eq__8
 @bz1686602
 Scenario: Reposync --urls and --download-metadata switches
   Given I use repository "dnf-ci-thirdparty-updates" as http

--- a/dnf-behave-tests/features/plugins-core/versionlock-list-manipulation.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-list-manipulation.feature
@@ -122,8 +122,6 @@ Scenario: Basic commands add/exclude/list/delete/clear for manipulation with ver
     """
 
 
-# until rhel has PR https://github.com/rpm-software-management/dnf-plugins-core/pull/363
-@not.with_os=rhel__eq__8
 Scenario: Versionlock accepts --raw switch
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac"

--- a/dnf-behave-tests/features/plugins-core/versionlock-lock.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-lock.feature
@@ -174,8 +174,6 @@ Scenario: Versionlock can lock only parts of the package version
         | install       | flac-0:1.3.3-3.fc29.x86_64            |
 
 
-# until rhel has PR https://github.com/rpm-software-management/dnf-plugins-core/pull/370
-@not.with_os=rhel__eq__8
 @bz1750620
 Scenario: Check-update command does not report updates filtered out by the versionlock
   Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/features/shell-help.feature
+++ b/dnf-behave-tests/features/shell-help.feature
@@ -2,13 +2,30 @@ Feature: Shell help
 
 
 @bz1659328
-Scenario: Using dnf shell, list available commands
+Scenario: Using dnf shell, list available commands (dnf)
+  Given I set dnf command to "dnf"
    When I open dnf shell session
     And I execute in dnf shell "help"
    Then stdout contains "usage: .+ \[options\] COMMAND"
     And stdout contains "List of Main Commands:"
     And stdout contains "alias\s+List or create command aliases"
     And stdout contains "General DNF options:"
+    And stdout contains "-q, --quiet\s+quiet operation"
+    And stdout contains "Shell specific arguments:"
+    And stdout contains "repository \(or repo\)\s+enable, disable or list repositories"
+      # "List of Plugin Commands:" depends on enabled plugins
+   When I execute in dnf shell "exit"
+   Then stdout contains "Leaving Shell"
+
+@bz1659328
+Scenario: Using dnf shell, list available commands (yum)
+  Given I set dnf command to "yum"
+   When I open dnf shell session
+    And I execute in dnf shell "help"
+   Then stdout contains "usage: .+ \[options\] COMMAND"
+    And stdout contains "List of Main Commands:"
+    And stdout contains "alias\s+List or create command aliases"
+    And stdout contains "General YUM options:"
     And stdout contains "-q, --quiet\s+quiet operation"
     And stdout contains "Shell specific arguments:"
     And stdout contains "repository \(or repo\)\s+enable, disable or list repositories"

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -125,6 +125,11 @@ def step_impl(context):
     context.dnf._set("disable_plugins", False)
 
 
+@behave.given("I set dnf command to \"{command}\"")
+def step_set_dnf_command(context, command):
+    context.dnf.dnf_command = command
+
+
 @behave.given("I enable plugin \"{plugin}\"")
 def given_enable_plugin(context, plugin):
     if "plugins" not in context.dnf:


### PR DESCRIPTION
I removed unnecessary @not.with_os=rhel__eq__8 and included rebased change from https://github.com/rpm-software-management/ci-dnf-stack/pull/703.

Our gating should pass with these changes.