### PR TITLE
Add test for shell command with local package

### DIFF
--- a/dnf-behave-tests/features/shell-install.feature
+++ b/dnf-behave-tests/features/shell-install.feature
@@ -36,3 +36,17 @@ Scenario: Using dnf shell, fail to install a non-existent RPM
    Then Transaction is empty
    When I execute in dnf shell "exit"
    Then stdout contains "Leaving Shell"
+
+@bz1773483
+Scenario: Using dnf shell, fail to install local file when goal is not empty
+  Given I use repository "dnf-ci-fedora"
+   When I open dnf shell session
+    And I execute in dnf shell "install setup-0:2.12.1-1.fc29.noarch"
+   When I execute in dnf shell "install {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/filesystem-0:3.9-2.fc29.x86_64.rpm"
+   Then stdout contains "Error: Cannot add local packages, because transaction job already exists"
+   When I execute in dnf shell "run"
+   Then Transaction is following
+        | Action        | Package                                   |
+        | install       | setup-0:2.12.1-1.fc29.noarch              |
+   When I execute in dnf shell "exit"
+   Then stdout contains "Leaving Shell"


### PR DESCRIPTION
When shell command is used, all local packages must be placed in
the first transaction subcommand, otherwise Error message will appear.