### PR TITLE
Add mock server ready check

### DIFF
--- a/dnf-behave-tests/features/steps/fixtures/ftpd.py
+++ b/dnf-behave-tests/features/steps/fixtures/ftpd.py
@@ -37,7 +37,9 @@ class FtpServerContext(ServerContext):
         handler = NoLogFtpHandler
         handler.authorizer = authorizer
 
-        ftpd = FTPServer(address, handler)
+        # with 'localhost' in the address, the FTPServer defaults to IPv6; the
+        # ready check would then need to be opening an AF_INET6 socket...
+        ftpd = FTPServer(('127.0.0.1', address[1]), handler)
         ftpd.serve_forever()
 
     def new_ftp_server(self, path):

--- a/dnf-behave-tests/features/steps/fixtures/ftpd.py
+++ b/dnf-behave-tests/features/steps/fixtures/ftpd.py
@@ -1,21 +1,20 @@
 # -*- coding: utf-8 -*-
 
 from behave import fixture
-import contextlib
-import multiprocessing
 import os
-import socket
 
 from pyftpdlib.authorizers import DummyAuthorizer
 from pyftpdlib.handlers import FTPHandler
 from pyftpdlib.servers import FTPServer
+
+from steps.fixtures.server import ServerContext
 
 
 class NoLogFtpHandler(FTPHandler):
     def log_request(self, *args, **kwargs):
         pass
 
-class FtpServerContext(object):
+class FtpServerContext(ServerContext):
     """
     This object manages group of simple ftp servers. Each of them is run in
     separate process and serves configured directory.
@@ -41,47 +40,8 @@ class FtpServerContext(object):
         ftpd = FTPServer(address, handler)
         ftpd.serve_forever()
 
-    @staticmethod
-    def _get_free_socket(host='localhost'):
-        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind((host, 0))
-            return (host, s.getsockname()[1])
-
-    def __init__(self):
-        # mapping path -> (address, server process)
-        self.servers = dict()
-
-    def _start_server(self, path, target, *args):
-        """
-        Start a new ftp server for serving files from "path" directory.
-        Returns (host, port) tupple of new running server.
-        """
-        if path in self.servers:
-            return self.get_address(path)
-        address = self._get_free_socket()
-        process = multiprocessing.Process(target=target, args=(address, path) + args)
-        process.start()
-        self.servers[path] = (address, process)
-        return address
-
     def new_ftp_server(self, path):
         return self._start_server(path, self.ftp_server)
-
-    def get_address(self, path):
-        """
-        Get address of ftp server bound to "path" directory
-        """
-        if path in self.servers:
-            return self.servers[path][0]
-        return None
-
-    def shutdown(self):
-        """
-        Terminate all running servers
-        """
-        for _, process in self.servers.values():
-            process.terminate()
 
 
 @fixture

--- a/dnf-behave-tests/features/steps/fixtures/server.py
+++ b/dnf-behave-tests/features/steps/fixtures/server.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import contextlib
+import multiprocessing
+import socket
+
+
+class ServerContext(object):
+    """
+    This object manages a group of simple servers. Each of them is run in a
+    separate process. This is the shared base for http and ftp servers and it
+    has a 'path' argument on the interface, which is passed to the server and
+    from which the server will serve files.
+
+    It also provides a dict with keys being the path and value being the
+    (address, process) pair for the server serving from the path.
+    """
+
+    @staticmethod
+    def _get_free_socket(host='localhost'):
+        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind((host, 0))
+            return (host, s.getsockname()[1])
+
+    def __init__(self):
+        # mapping path -> (address, server process)
+        self.servers = dict()
+
+    def _start_server(self, path, target, *args):
+        """
+        Start a new server. Returns (host, port) tupple of the new running server.
+        """
+        if path in self.servers:
+            return self.get_address(path)
+        address = self._get_free_socket()
+        process = multiprocessing.Process(target=target, args=(address, path) + args)
+        process.start()
+        self.servers[path] = (address, process)
+        return address
+
+    def get_address(self, path):
+        """
+        Get address of the server bound to the "path" directory.
+        """
+        if path in self.servers:
+            return self.servers[path][0]
+        return None
+
+    def shutdown(self):
+        """
+        Terminate all running servers.
+        """
+        for _, process in self.servers.values():
+            process.terminate()


### PR DESCRIPTION
Launching an HTTP/FTP server for the tests can race between the server being ready and sending requests. This PR adds a ready check loop to wait for the server to be ready to accept connections.