### PR TITLE
[microdnf] Add reinstall tests

### DIFF
--- a/dnf-behave-tests/features/microdnf/reinstall-reason.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall-reason.feature
@@ -1,0 +1,31 @@
+@no_installroot
+Feature: Reinstall must keep the "reason" why a package was installed
+  E.g. if package with dependency is installed, and the dependency is reinstalled, and the main package is then removed, the dependency is removed as well.
+
+
+Background:
+  Given I delete file "/etc/dnf/dnf.conf"
+    And I delete file "/etc/yum.repos.d/*.repo" with globs
+
+
+Scenario: Reinstall a dependency, and then remove the main package
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "install CQRlib-devel"
+   Then the exit code is 0
+    And RPMDB Transaction is following
+        | Action        | Package                                   |
+        | install       | CQRlib-0:1.1.2-16.fc29.x86_64             |
+        | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
+  Given I use repository "dnf-ci-fedora-updates-testing"
+   When I execute microdnf with args "reinstall CQRlib"
+   Then the exit code is 0
+    And RPMDB Transaction is following
+        | Action        | Package                                   |
+        | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |
+   When I execute dnf with args "remove CQRlib-devel"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                                   |
+        | remove        | CQRlib-0:1.1.2-16.fc29.x86_64             |
+        | remove        | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |

--- a/dnf-behave-tests/features/microdnf/reinstall1.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall1.feature
@@ -1,0 +1,23 @@
+@no_installroot
+Feature: Reinstall
+
+
+Background: Install CQRlib-devel and CQRlib
+  Given I delete file "/etc/dnf/dnf.conf"
+    And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "install CQRlib-devel"
+   Then the exit code is 0
+    And RPMDB Transaction is following
+        | Action        | Package                                   |
+        | install       | CQRlib-0:1.1.2-16.fc29.x86_64             |
+        | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
+
+
+Scenario: Reinstall an RPM from the same repository
+   When I execute microdnf with args "reinstall CQRlib"
+   Then the exit code is 0
+    And RPMDB Transaction is following
+        | Action        | Package                                   |
+        | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |

--- a/dnf-behave-tests/features/microdnf/reinstall2.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall2.feature
@@ -1,0 +1,24 @@
+@no_installroot
+Feature: Reinstall
+
+
+Background: Install CQRlib-devel and CQRlib
+  Given I delete file "/etc/dnf/dnf.conf"
+    And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "install CQRlib-devel"
+   Then the exit code is 0
+    And RPMDB Transaction is following
+        | Action        | Package                                   |
+        | install       | CQRlib-0:1.1.2-16.fc29.x86_64             |
+        | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
+
+
+Scenario: Reinstall an RPM from different repository
+  Given I use repository "dnf-ci-fedora-updates-testing"
+   When I execute microdnf with args "reinstall CQRlib"
+   Then the exit code is 0
+    And RPMDB Transaction is following
+        | Action        | Package                                   |
+        | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |

--- a/dnf-behave-tests/features/microdnf/reinstall3.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall3.feature
@@ -1,0 +1,22 @@
+@no_installroot
+Feature: Reinstall
+
+
+Background: Install CQRlib-devel and CQRlib
+  Given I delete file "/etc/dnf/dnf.conf"
+    And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "install CQRlib-devel"
+   Then the exit code is 0
+    And RPMDB Transaction is following
+        | Action        | Package                                   |
+        | install       | CQRlib-0:1.1.2-16.fc29.x86_64             |
+        | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
+
+
+Scenario: Reinstall an RPM that is not available
+  Given I drop repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "reinstall CQRlib"
+   Then the exit code is 1
+    And RPMDB Transaction is empty


### PR DESCRIPTION
Tests are in more feature files because `@no_installroot` is used and the result of one test will affect other tests if all is in one feature file.

Depends on: https://github.com/rpm-software-management/microdnf/pull/61