### PR TITLE
rhel-8.2: Add a step for checking microdnf transaction

### DIFF
--- a/dnf-behave-tests/common/lib/diff.py
+++ b/dnf-behave-tests/common/lib/diff.py
@@ -22,6 +22,10 @@ def print_lines_diff(expected, found, num_lines_equal=0):
             treat as equal even if they differ; a hack for correctly diffing
             outputs with repository syncing
     """
+    # make this function work for lists and tuples in addition to strings
+    expected = [" ".join(l) if type(l) in (list, tuple) else l for l in expected]
+    found = [" ".join(l) if type(l) in (list, tuple) else l for l in found]
+
     left_width = len("expected")
 
     # calculate the width of the left column

--- a/dnf-behave-tests/features/steps/lib/rpm.py
+++ b/dnf-behave-tests/features/steps/lib/rpm.py
@@ -8,7 +8,7 @@ import re
 import rpm
 
 
-NEVRA_RE = re.compile(r"^(.+)-([0-9]+):(.+)-(.+)\.(.+)$")
+NEVRA_RE = re.compile(r"^(.+)-(?:([0-9]+):)?(.+)-(.+)\.(.+)$")
 INSTALLONLY_PROVIDES = {b'kernel', b'kernel-PAE', b'installonlypkg(kernel)',
                         b'installonlypkg(kernel-module)', b'installonlypkg(vm)',
                         b'multiversion(kernel)'}
@@ -23,7 +23,7 @@ class RPM(object):
         if not match:
             raise ValueError("Cannot parse NEVRA: %s" % nevra)
         result = list(match.groups())
-        result[1] = int(result[1])
+        result[1] = int(result[1]) if result[1] is not None else 0
         return result
 
     def __init__(self, nevra, rpmheader=None):

--- a/dnf-behave-tests/features/steps/transaction.py
+++ b/dnf-behave-tests/features/steps/transaction.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import behave
+import re
+
 from common.lib.behave_ext import check_context_table
+from common.lib.diff import print_lines_diff
 from lib.dnf import ACTIONS, parse_transaction_table
 from lib.rpm import RPM, diff_rpm_lists
 from lib.rpmdb import get_rpmdb_rpms
@@ -177,3 +180,59 @@ def then_DNF_transaction_is_empty(context):
 def then_transaction_is_empty(context):
     context.execute_steps(u"Then RPMDB Transaction is empty")
     context.execute_steps(u"Then DNF Transaction is empty")
+
+
+def parse_microdnf_transaction_table(lines):
+    """
+    Find and parse transaction table.
+    Return {action: set([rpms])}
+    """
+    trans_start_re = re.compile(r"Package +Repository +Size")
+    transaction_start = None
+    for i in range(0, len(lines) - 1):
+        if trans_start_re.match(lines[i]):
+            transaction_start = i + 1
+            break
+    assert transaction_start is not None, "Transaction table start not found"
+    lines = lines[transaction_start:]
+
+    transaction_end = None
+    for i in range(0, len(lines)):
+        if lines[i].startswith("Transaction Summary:"):
+            transaction_end = i
+    assert transaction_end is not None, "Transaction table end not found"
+    lines = lines[:transaction_end]
+
+    label_re = re.compile(r"^([^ ].+):$")
+    action = None
+    result = []
+    for line in lines:
+        line = line.strip()
+
+        label_match = label_re.match(line)
+        if label_match:
+            action = ACTIONS[label_match.group(1)]
+            continue
+
+        package = line.split(" ")[0]
+        # use RPM to parse and format the NEVRA to add epoch if missing
+        result.append((action, str(RPM(package))))
+
+    return sorted(result)
+
+
+def check_microdnf_transaction(context, mode):
+    check_context_table(context, ["Action", "Package"])
+
+    transaction = parse_microdnf_transaction_table(context.cmd_stdout.splitlines())
+    table = sorted([(a, p) for a, p in context.table])
+
+    if transaction != table:
+        print_lines_diff(table, transaction)
+        raise AssertionError("Transaction table mismatch")
+
+
+@behave.then("microdnf transaction is")
+def then_microdnf_transaction_is_following(context):
+    check_microdnf_transaction(context, 'exact_match')
+    check_rpmdb_transaction(context, 'exact_match')


### PR DESCRIPTION
Backporting the microdnf transaction check step to the 8.2 branch.

Original PR: https://github.com/rpm-software-management/ci-dnf-stack/pull/731

@lucab85 I haven't tested this on the rhel-8.2.0 branch (although I think it should work), please test it and then feel free to merge :+1: