### PR TITLE
microdnf is able to downgrade packages

### DIFF
--- a/dnf-behave-tests/features/microdnf/install8.feature
+++ b/dnf-behave-tests/features/microdnf/install8.feature
@@ -1,0 +1,19 @@
+@no_installroot
+Feature: microdnf is able to downgrade packages
+
+
+Background:
+Given I delete file "/etc/dnf/dnf.conf"
+  And I delete file "/etc/yum.repos.d/*.repo" with globs
+
+
+@bz1725863
+Scenario: Install a package specifying a lower version than currently installed
+Given I use repository "dnf-ci-fedora"
+  And I use repository "dnf-ci-fedora-updates"
+  And I successfully execute microdnf with args "install flac"
+ When I execute microdnf with args "install flac-1.3.2-8.fc29"
+ Then the exit code is 0
+  And microdnf transaction is
+      | Action        | Package                                   |
+      | downgrade     | flac-0:1.3.2-8.fc29.x86_64                |


### PR DESCRIPTION
Backporting the microdnf downgrade test to the 8.2 branch.

Original PR: #740 

https://bugzilla.redhat.com/show_bug.cgi?id=1725863