### PR TITLE
updateinfo show <advisory> of the running kernel after a kernel update

### DIFF
--- a/dnf-behave-tests/features/updateinfo.feature
+++ b/dnf-behave-tests/features/updateinfo.feature
@@ -312,3 +312,33 @@ Examples:
     # yum compatibility
     | list bugzillas      |
     | list bzs            |
+
+
+@bz1728004
+Scenario: updateinfo show <advisory> of the running kernel after a kernel update
+   When I execute dnf with args "install kernel"
+   Then Transaction is following
+        | Action        | Package                                  |
+        | install       | kernel-core-0:4.18.16-300.fc29.x86_64    |
+        | install       | kernel-modules-0:4.18.16-300.fc29.x86_64 |
+        | install       | kernel-0:4.18.16-300.fc29.x86_64         |
+  Given I use repository "dnf-ci-fedora-updates"
+    And I execute dnf with args "updateinfo list kernel"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    FEDORA-2019-348e185000 bugfix kernel-4.19.15-300.fc29.x86_64
+    """
+   When I execute dnf with args "update kernel"
+   Then Transaction is following
+        | Action        | Package                                  |
+        | install       | kernel-core-0:4.19.15-300.fc29.x86_64    |
+        | install       | kernel-modules-0:4.19.15-300.fc29.x86_64 |
+        | install       | kernel-0:4.19.15-300.fc29.x86_64         |
+   When I execute dnf with args "updateinfo list kernel"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    """

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-updates/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-updates/updateinfo.xml
@@ -44,4 +44,26 @@
       </collection>
     </pkglist>
   </update>
+  <update from="secresponseteam@foo.bar" status="final" type="bugfix" version="3">
+    <id>FEDORA-2019-348e185000</id>
+    <title>kernel bug fix</title>
+    <issued date="2019-01-17 00:00:00"/>
+    <updated date="2019-01-17 00:00:00"/>
+    <severity>Moderate</severity>
+    <summary>summary_1</summary>
+    <description>Fix some stuff</description>
+    <references>
+        <reference href="https://foobar/foobarupdate_1" id="1234" type="bugzilla" title="1234"/>
+        <reference href="https://foobar/foobarupdate_1" id="4321" type="cve" title="CVE-4321"/>
+    </references>
+    <pkglist>
+      <collection short="named collection">
+        <name>Bar component</name>
+        <package name="kernel" version="4.19.15" release="300.fc29" epoch="0" arch="x86_64" src="kernel-0:4.19.15-300.fc29.x86_64.rpm">
+          <filename>kernel-0:4.19.15-300.fc29.x86_64.rpm</filename>
+          <reboot_suggested/>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
 </updates>


### PR DESCRIPTION
Backporting the updateinfo check to the 8.2 branch.

Original PR: #717

https://bugzilla.redhat.com/show_bug.cgi?id=1728004