### PR TITLE
Remove test data in separate image layer

### DIFF
--- a/Dockerfile.f29
+++ b/Dockerfile.f29
@@ -112,6 +112,11 @@ RUN echo -e "\
 destructive=yes\n\
 os=$OSVERSION" > /opt/behave/behave.ini
 
+RUN set -x && \
+    rm -rf "/opt/behave/fixtures/certificates/testcerts/" && \
+    rm -rf "/opt/behave/fixtures/gpgkeys/keys/" && \
+    rm -rf "/opt/behave/fixtures/repos/"
+
 # build test repos from sources
 RUN set -x && \
     cd /opt/behave/fixtures/specs/ && \

--- a/Dockerfile.f30
+++ b/Dockerfile.f30
@@ -109,6 +109,11 @@ RUN echo -e "\
 destructive=yes\n\
 os=$OSVERSION" > /opt/behave/behave.ini
 
+RUN set -x && \
+    rm -rf "/opt/behave/fixtures/certificates/testcerts/" && \
+    rm -rf "/opt/behave/fixtures/gpgkeys/keys/" && \
+    rm -rf "/opt/behave/fixtures/repos/"
+
 # build test repos from sources
 RUN set -x && \
     cd /opt/behave/fixtures/specs/ && \

--- a/Dockerfile.f31
+++ b/Dockerfile.f31
@@ -109,6 +109,11 @@ RUN echo -e "\
 destructive=yes\n\
 os=$OSVERSION" > /opt/behave/behave.ini
 
+RUN set -x && \
+    rm -rf "/opt/behave/fixtures/certificates/testcerts/" && \
+    rm -rf "/opt/behave/fixtures/gpgkeys/keys/" && \
+    rm -rf "/opt/behave/fixtures/repos/"
+
 # build test repos from sources
 RUN set -x && \
     cd /opt/behave/fixtures/specs/ && \


### PR DESCRIPTION
The ssl certificates are sometimes incorrectly generated when old
fixtures/certificates/testcerts is present. This is probably caused by
a bug in podman that cache is sometimes reused even when files have
changed (with --no-cache option, the ssl certificates are generated
correctly).

Deleting the directory in a separate RUN command (therefore, in a
separate layer) works around the issue.