### PR TITLE
[fixtures] osrelease: use real path [RHEL-8.2]

### DIFF
--- a/dnf-behave-tests/features/steps/fixtures/osrelease.py
+++ b/dnf-behave-tests/features/steps/fixtures/osrelease.py
@@ -40,7 +40,8 @@ class OSRelease(object):
 def osrelease_fixture(context):
     try:
         if not hasattr(context, "osrelease"):
-            context.scenario.osrelease = OSRelease('/usr/lib/os-release')
+            path = os.path.realpath('/etc/os-release')
+            context.scenario.osrelease = OSRelease(path)
 
         yield context.scenario.osrelease
     finally:


### PR DESCRIPTION
On some systems, /etc/os-release is a symlink (Fedora), while on others,
it's a regular file (RHEL).  To make sure we restore the original file
(and don't overwrite a symlink instead), let's mock the real path.