### PR TITLE
Add @xfail tag to failing tests

### DIFF
--- a/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
+++ b/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
@@ -84,7 +84,8 @@ Given I create directory "/modular_repo1/"
   And I execute modifyrepo_c with args "--mdtype=modules ../../modules2.yaml ." in "/modular_repo2/repodata"
 
 
-
+# createrepo_c is compiled without support for modular metadata and refuses to use them on rhel 8
+@xfail
 Scenario: merged repository contains streams from both source repositories
  When I execute mergerepo_c with args "--repo {context.scenario.default_tmp_dir}/modular_repo1 --repo {context.scenario.default_tmp_dir}/modular_repo2" in "/"
  Then the exit code is 0

--- a/dnf-behave-tests/createrepo_c/update-keepallmetadata.feature
+++ b/dnf-behave-tests/createrepo_c/update-keepallmetadata.feature
@@ -71,6 +71,8 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
       | other_db     | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
 
 
+# createrepo_c is compiled without support for modular metadata and refuses to use them on rhel 8
+@xfail
 Scenario: --update --keep-all-metadata keeps all additional metadata
 Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/temp-repo"
   And I execute modifyrepo_c with args "../../updateinfo.xml ." in "/temp-repo/repodata"
@@ -113,6 +115,8 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
       | custom_metadata | ${checksum}-custom_metadata.txt.gz | sha256        | gz               |
 
 
+# createrepo_c is compiled without support for zchunk on rhel 8
+@xfail
 Scenario: --update --keep-all-metadata --groupfile overrides old groupfile and --zck generates zck versions
 Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/temp-repo"
   And I execute modifyrepo_c with args "../../custom_metadata.txt ." in "/temp-repo/repodata"
@@ -137,6 +141,8 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
       | custom_metadata_zck | ${checksum}-custom_metadata.txt.zck | sha256        | zck              |
 
 
+# createrepo_c is compiled without support for zchunk on rhel 8
+@xfail
 Scenario: --update --keep-all-metadata keeps additional metadata including zck variants
 Given I execute createrepo_c with args "--groupfile ../groupfile.xml --zck ." in "/temp-repo"
   And I execute modifyrepo_c with args "../../custom_metadata.txt --zck ." in "/temp-repo/repodata"


### PR DESCRIPTION
On RHEL 8 createrepo_c is compiled without support for zchunk and
modules therefore we have to disable tests that use them.