### PR TITLE
Add another part of createrepo_c tests

### DIFF
--- a/Dockerfile.f29
+++ b/Dockerfile.f29
@@ -92,7 +92,8 @@ RUN set -x && \
         # all plugins with the same version as dnf-utils
         $(dnf repoquery dnf-utils --latest-limit=1 -q --qf="python*-dnf-plugin-*-%{version}-%{release}") \
         libdnf \
-        microdnf
+        microdnf \
+        zchunk
 
 
 # install local RPMs if available

--- a/Dockerfile.f30
+++ b/Dockerfile.f30
@@ -91,7 +91,8 @@ RUN set -x && \
         libdnf \
         microdnf \
         # install third party plugins
-        dnf-plugin-swidtags
+        dnf-plugin-swidtags \
+        zchunk
 
 
 # install local RPMs if available

--- a/Dockerfile.f31
+++ b/Dockerfile.f31
@@ -91,7 +91,8 @@ RUN set -x && \
         libdnf \
         microdnf \
         # install third party plugins
-        dnf-plugin-swidtags
+        dnf-plugin-swidtags \
+        zchunk
 
 
 # install local RPMs if available

--- a/dnf-behave-tests/common/lib/file.py
+++ b/dnf-behave-tests/common/lib/file.py
@@ -7,6 +7,7 @@ import codecs
 import os
 import shutil
 import glob
+import subprocess
 
 import bz2
 import gzip
@@ -90,5 +91,7 @@ def decompress_file_by_extension(src):
         return gzip.open(src, "rb").read()
     elif src.endswith(".xz"):
         return lzma.open(src, "rb").read()
+    elif src.endswith(".zck"):
+        return subprocess.run(["unzck", "--stdout", src], capture_output=True).stdout
 
     return None

--- a/dnf-behave-tests/common/lib/tag_matcher.py
+++ b/dnf-behave-tests/common/lib/tag_matcher.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import operator
+
+from behave.tag_matcher import ActiveTagMatcher
+
+class VersionedActiveTagMatcher(ActiveTagMatcher):
+    @staticmethod
+    def version_compare_operator(tag_value_str, current_value_str, is_negated=False):
+        tag_key, tag_oper, tag_value = tag_value_str.split("__", 2)
+        try:
+            current_key, current_value = current_value_str.split("__", 1)
+        except ValueError:
+            return is_negated
+
+        # convert versions into list of integers for correct comparing
+        tag_value = [int(i) for i in tag_value.split(".")]
+        try:
+            current_value = [int(i) for i in current_value.split(".")]
+        except:
+            return is_negated
+
+        if tag_oper not in ["lt", "le", "eq", "ne", "ge", "gt"]:
+            raise ValueError("Invalid operator in tag: %s" % tag_value_str)
+
+        if tag_key != current_key:
+            # always return false if keys do not match
+            return is_negated
+
+        op = getattr(operator, tag_oper)
+        result = op(current_value, tag_value)
+        if is_negated:
+            result = not(result)
+        return result
+
+    def is_tag_group_enabled(self, group_category, group_tag_pairs):
+        """Modified ActiveTagMatcher.is_tag_group_enabled()"""
+        if not group_tag_pairs:
+            # -- CASE: Empty group is always enabled (CORNER-CASE).
+            return True
+
+        current_value = self.value_provider.get(group_category, None)
+        if current_value is None and self.ignore_unknown_categories:
+            # -- CASE: Unknown category, ignore it.
+            return True
+
+        tags_enabled = []
+        for category_tag, tag_match in group_tag_pairs:
+            tag_prefix = tag_match.group("prefix")
+            category = tag_match.group("category")
+            tag_value = tag_match.group("value")
+            assert category == group_category
+            tag_enabled = self.version_compare_operator(tag_value, current_value, self.is_tag_negated(tag_prefix))
+            tags_enabled.append(tag_enabled)
+        return any(tags_enabled)    # -- PROVIDES: LOGICAL-OR expression

--- a/dnf-behave-tests/createrepo_c/delta-rpms.feature
+++ b/dnf-behave-tests/createrepo_c/delta-rpms.feature
@@ -1,0 +1,68 @@
+Feature: Tests createrepo_c generating delta rpms
+
+
+Scenario: --deltas on empty repo
+ When I execute createrepo_c with args "--deltas ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type          | File                                | Checksum Type | Compression Type |
+      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
+      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
+      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary_db    | ${checksum}-primary.sqlite.bz2      | sha256        | bz2              |
+      | filelists_db  | ${checksum}-filelists.sqlite.bz2    | sha256        | bz2              |
+      | other_db      | ${checksum}-other.sqlite.bz2        | sha256        | bz2              |
+      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+
+
+Scenario: --deltas on repo
+Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x86_64/package-0.2.1-1.fc29.x86_64.rpm" to "/"
+ When I execute createrepo_c with args "--deltas ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type          | File                                | Checksum Type | Compression Type |
+      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
+      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
+      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary_db    | ${checksum}-primary.sqlite.bz2      | sha256        | bz2              |
+      | filelists_db  | ${checksum}-filelists.sqlite.bz2    | sha256        | bz2              |
+      | other_db      | ${checksum}-other.sqlite.bz2        | sha256        | bz2              |
+      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+
+
+Scenario: --deltas with empty --oldpackagedirs on repo
+Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x86_64/package-0.2.1-1.fc29.x86_64.rpm" to "/"
+  And I create directory "/old_packages"
+ When I execute createrepo_c with args "--deltas --oldpackagedirs ./old_packages ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type          | File                                | Checksum Type | Compression Type |
+      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
+      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
+      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary_db    | ${checksum}-primary.sqlite.bz2      | sha256        | bz2              |
+      | filelists_db  | ${checksum}-filelists.sqlite.bz2    | sha256        | bz2              |
+      | other_db      | ${checksum}-other.sqlite.bz2        | sha256        | bz2              |
+      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+
+
+Scenario: --deltas with --oldpackagedirs on repo generates drpm
+Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages-2/x86_64/package-0.3.1-1.fc29.x86_64.rpm" to "/"
+  And I create directory "/old_packages"
+  And I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x86_64/package-0.2.1-1.fc29.x86_64.rpm" to "/old_packages"
+ When I execute createrepo_c with args "--deltas --oldpackagedirs ./old_packages ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type          | File                                | Checksum Type | Compression Type |
+      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
+      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
+      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary_db    | ${checksum}-primary.sqlite.bz2      | sha256        | bz2              |
+      | filelists_db  | ${checksum}-filelists.sqlite.bz2    | sha256        | bz2              |
+      | other_db      | ${checksum}-other.sqlite.bz2        | sha256        | bz2              |
+      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+  And file "/drpms/package-0.2.1-1.fc29_0.3.1-1.fc29.x86_64.drpm" exists

--- a/dnf-behave-tests/createrepo_c/environment.py
+++ b/dnf-behave-tests/createrepo_c/environment.py
@@ -17,6 +17,7 @@ from behave import model
 from behave.formatter.ansi_escapes import escapes
 
 from common.lib.cmd import print_last_command
+from common.lib.tag_matcher import VersionedActiveTagMatcher
 
 FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fixtures"))
 
@@ -58,6 +59,8 @@ def after_step(context, step):
 
 
 def before_scenario(context, scenario):
+    if context.tag_matcher.should_exclude_with(scenario.effective_tags):
+        scenario.skip(reason="DISABLED ACTIVE-TAG")
     context.tempdir_manager = TempDirManager(context.config.userdata)
 
     context.scenario.default_tmp_dir = context.tempdir_manager.tempdir
@@ -85,7 +88,7 @@ def after_tag(context, tag):
 
 
 def before_all(context):
-    pass
+    context.tag_matcher = VersionedActiveTagMatcher({"os": context.config.userdata.get("os", None)})
 
 
 def after_all(context):

--- a/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
+++ b/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
@@ -85,6 +85,8 @@ Given I create directory "/modular_repo1/"
 
 
 
+# createrepo_c is compiled without support for modular metadata and refuses to use them on rhel 8
+@not.with_os=rhel__eq__8
 Scenario: merged repository contains streams from both source repositories
  When I execute mergerepo_c with args "--repo {context.scenario.default_tmp_dir}/modular_repo1 --repo {context.scenario.default_tmp_dir}/modular_repo2" in "/"
  Then the exit code is 0

--- a/dnf-behave-tests/createrepo_c/modifyrepo_c.feature
+++ b/dnf-behave-tests/createrepo_c/modifyrepo_c.feature
@@ -35,3 +35,108 @@ Given I create directory "/temp-repo/"
       | filelists_db        | ${checksum}-filelists.sqlite.bz2    | sha256        | bz2              |
       | other_db            | ${checksum}-other.sqlite.bz2        | sha256        | bz2              |
       | modules             | ${checksum}-modules.yaml.gz         | sha256        | gz               |
+
+
+Scenario: Modifying repo with compressed metadata of the same compression type
+Given I create directory "/temp-repo/"
+  And I execute createrepo_c with args "." in "/temp-repo"
+  And I create "gz" compressed file "/modules.yaml" with
+      """
+      ---
+      document: modulemd
+      version: 2
+      data:
+      name: ingredience
+      stream: chicken
+      version: 1
+      arch: x86_64
+      description: Made up module
+      license:
+      module:
+      - MIT
+      ...
+      """
+ When I execute modifyrepo_c with args "../modules.yaml.gz ./repodata" in "/temp-repo"
+ Then the exit code is 0
+  And repodata "/temp-repo/repodata/" are consistent
+  And repodata in "/temp-repo/repodata/" is
+      | Type                | File                                | Checksum Type | Compression Type |
+      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
+      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
+      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary_db          | ${checksum}-primary.sqlite.bz2      | sha256        | bz2              |
+      | filelists_db        | ${checksum}-filelists.sqlite.bz2    | sha256        | bz2              |
+      | other_db            | ${checksum}-other.sqlite.bz2        | sha256        | bz2              |
+      | modules             | ${checksum}-modules.yaml.gz         | sha256        | gz               |
+
+
+Scenario: Modifying repo with compressed metadata of different compression type
+Given I create directory "/temp-repo/"
+  And I execute createrepo_c with args "." in "/temp-repo"
+  And I create "xz" compressed file "/modules.yaml" with
+      """
+      ---
+      document: modulemd
+      version: 2
+      data:
+      name: ingredience
+      stream: chicken
+      version: 1
+      arch: x86_64
+      description: Made up module
+      license:
+      module:
+      - MIT
+      ...
+      """
+ When I execute modifyrepo_c with args "../modules.yaml.xz ./repodata" in "/temp-repo"
+ Then the exit code is 0
+  And repodata "/temp-repo/repodata/" are consistent
+  And repodata in "/temp-repo/repodata/" is
+      | Type                | File                                | Checksum Type | Compression Type |
+      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
+      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
+      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary_db          | ${checksum}-primary.sqlite.bz2      | sha256        | bz2              |
+      | filelists_db        | ${checksum}-filelists.sqlite.bz2    | sha256        | bz2              |
+      | other_db            | ${checksum}-other.sqlite.bz2        | sha256        | bz2              |
+      | modules             | ${checksum}-modules.yaml.gz         | sha256        | gz               |
+
+
+# createrepo_c is compiled without support for zchunk on rhel 8
+@not.with_os=rhel__eq__8
+Scenario: Modifying repo with zck compressed metadata
+Given I create directory "/temp-repo/"
+  And I execute createrepo_c with args "--zck ." in "/temp-repo"
+  And I create "xz" compressed file "/modules.yaml" with
+      """
+      ---
+      document: modulemd
+      version: 2
+      data:
+      name: ingredience
+      stream: chicken
+      version: 1
+      arch: x86_64
+      description: Made up module
+      license:
+      module:
+      - MIT
+      ...
+      """
+ When I execute modifyrepo_c with args "--compress-type zck ../modules.yaml.xz ./repodata" in "/temp-repo"
+ Then the exit code is 0
+  And repodata "/temp-repo/repodata/" are consistent
+  And repodata in "/temp-repo/repodata/" is
+      | Type                | File                             | Checksum Type | Compression Type |
+      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
+      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
+      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zck      | sha256        | zck              |
+      | filelists           | ${checksum}-filelists.xml.zck    | sha256        | zck              |
+      | other               | ${checksum}-other.xml.zck        | sha256        | zck              |
+      | primary_db          | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
+      | filelists_db        | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
+      | other_db            | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
+      | modules             | ${checksum}-modules.yaml.zck     | sha256        | zck              |
+

--- a/dnf-behave-tests/createrepo_c/steps/cmd.py
+++ b/dnf-behave-tests/createrepo_c/steps/cmd.py
@@ -7,6 +7,7 @@ import glob
 from common.lib.cmd import run_in_context
 from common.lib.file import prepend_installroot
 
+from lib.file import create_compressed_file_with_contents
 
 @behave.step("I execute createrepo_c with args \"{arguments}\" in \"{directory}\"")
 def when_I_execute_createrepo_c_in_directory(context, arguments, directory):
@@ -48,3 +49,9 @@ def file_has_mode(context, filepath, octal_mode_str):
     octal_file_mode = os.stat(matched_files[0]).st_mode & 0o777
     assert oct(octal_mode) == oct(octal_file_mode), \
         "File \"{}\" has mode \"{}\"".format(matched_files[0], oct(octal_file_mode))
+
+
+@behave.step("I create \"{compression}\" compressed file \"{filepath}\" with")
+def create_compressed_file_with(context, compression, filepath):
+    target_path = prepend_installroot(context, filepath)
+    create_compressed_file_with_contents(target_path, compression, context.text)

--- a/dnf-behave-tests/createrepo_c/steps/lib/file.py
+++ b/dnf-behave-tests/createrepo_c/steps/lib/file.py
@@ -27,14 +27,8 @@ def get_checksum_regex(type_str):
 
 
 def get_compression_suffix(type_str):
-    if type_str == "gz":
-        return ".gz"
-    if type_str == "zck":
-        return ".zck"
-    if type_str == "xz":
-        return ".xz"
-    if type_str == "bz2":
-        return ".bz2"
+    if type_str in ("gz", "zck", "xz", "bz2"):
+        return "." + type_str
     if type_str == "-":
         return ""
     raise ValueError("Unknown compression type: " + type_str)
@@ -47,6 +41,9 @@ def decompression_iter(filepath, compression_type, blocksize=65536):
         return file_as_blockiter(lzma.open(filepath, 'rb'), blocksize)
     if compression_type == "bz2":
         return file_as_blockiter(bz2.open(filepath, 'rb'), blocksize)
+    if compression_type == "zck":
+        decompress_file_by_extension_to_dir(filepath, os.path.dirname(filepath))
+        return file_as_blockiter(open(filepath[:-4], 'rb'), blocksize)
 
     return file_as_blockiter(open(filepath, 'rb'), blocksize)
 
@@ -83,10 +80,7 @@ def decompress_file_by_extension_to_dir(compressed_filepath, dest_dir):
 
     basename = os.path.basename(compressed_filepath)
     dst = os.path.join(dest_dir, basename)
-    if compressed_filepath.endswith(".bz2"):
-        dst = dst[:-4]
-    else: # .gz and .xz are both 3 chars long
-        dst = dst[:-3]
+    dst = os.path.splitext(dst)[0] #remove compression extension
 
     open(dst, "wb").write(content)
     return dst

--- a/dnf-behave-tests/createrepo_c/steps/lib/file.py
+++ b/dnf-behave-tests/createrepo_c/steps/lib/file.py
@@ -84,3 +84,21 @@ def decompress_file_by_extension_to_dir(compressed_filepath, dest_dir):
 
     open(dst, "wb").write(content)
     return dst
+
+
+def create_compressed_file_with_contents(filename, compression, contents, encoding="utf-8"):
+    fullname = filename + get_compression_suffix(compression)
+    if os.path.exists(fullname):
+        raise ValueError("File: " + fullname + " already exists")
+
+    if compression == "gz":
+        with gzip.open(fullname, 'wt') as f:
+            f.write(contents)
+    elif compression == "xz":
+        with lzma.open(fullname, 'wt') as f:
+            f.write(contents)
+    elif compression == "bz2":
+        with bz2.open(fullname, 'wt') as f:
+            f.write(contents)
+    else:
+        raise ValueError("Unknown compression type: " + compression)

--- a/dnf-behave-tests/createrepo_c/steps/lib/repodata_representation.py
+++ b/dnf-behave-tests/createrepo_c/steps/lib/repodata_representation.py
@@ -29,8 +29,9 @@ class MetadataItem(object):
 
 
 class Metadata(object):
-    def __init__(self):
+    def __init__(self, location):
         self.items = {}
+        self.path = location
 
     def append(self, key, item):
         if key in self.items:

--- a/dnf-behave-tests/createrepo_c/steps/lib/sqlite_repodata.py
+++ b/dnf-behave-tests/createrepo_c/steps/lib/sqlite_repodata.py
@@ -38,7 +38,7 @@ COL_PACKAGES_MAPPING = {"checksum": "pkgId",
 
 
 def load_sqlite(sqlite_path, repodata_type):
-    metadata_obj = Metadata()
+    metadata_obj = Metadata(sqlite_path)
     con = sqlite3.Connection(sqlite_path)
     con.row_factory = sqlite3.Row
 

--- a/dnf-behave-tests/createrepo_c/steps/lib/xml_repodata.py
+++ b/dnf-behave-tests/createrepo_c/steps/lib/xml_repodata.py
@@ -44,7 +44,7 @@ def xml_parse_repodata(repodata_path, element_tag, repodata_type):
         parse_pkg_elem = parse_repomd_item_elem
 
     parser = ET.XMLPullParser(['end'])
-    metadata_obj = Metadata()
+    metadata_obj = Metadata(repodata_path)
     for xml_data in iterator:
         parser.feed(xml_data)
         for event, element in parser.read_events():

--- a/dnf-behave-tests/createrepo_c/steps/repodata.py
+++ b/dnf-behave-tests/createrepo_c/steps/repodata.py
@@ -179,9 +179,7 @@ def repodata_in_path_is(context, path):
             if compression_suffix and filepath.endswith(compression_suffix):
                 filepath = filepath[:-(len(compression_suffix))]
             if tmp:
-                if filepath.endswith(".zck"):
-                    assert("ZCK" in str(tmp))
-                elif filepath.endswith(".sqlite"):
+                if filepath.endswith(".sqlite"):
                     assert("SQLite" in str(tmp))
                 elif filepath.endswith(".xml"):
                     assert("xml" in str(tmp))
@@ -194,7 +192,7 @@ def repodata_in_path_is(context, path):
                     raise
         except (AssertionError, IOError):
             raise AssertionError("Cannot decompress File: " + repodata_file + " using"
-                                 " copression type: " + compression_type)
+                                 " compression type: " + compression_type)
 
     if len(files) > 0:
         raise AssertionError("repodata directory contains additional metadata files:\n{0}".format('\n'.join(files)))

--- a/dnf-behave-tests/createrepo_c/steps/repodata.py
+++ b/dnf-behave-tests/createrepo_c/steps/repodata.py
@@ -176,16 +176,22 @@ def repodata_in_path_is(context, path):
                                  " not match suffix of File: " + repodata_file)
         try:
             tmp = next(decompression_iter(filepath, compression_type, blocksize=100))
+            if compression_suffix and filepath.endswith(compression_suffix):
+                filepath = filepath[:-(len(compression_suffix))]
             if tmp:
                 if filepath.endswith(".zck"):
                     assert("ZCK" in str(tmp))
                 elif filepath.endswith(".sqlite"):
-                    assert("SQLITE" in str(tmp))
+                    assert("SQLite" in str(tmp))
                 elif filepath.endswith(".xml"):
                     assert("xml" in str(tmp))
-                else:
+                elif filepath.endswith(".yaml"):
+                    # Assume all yaml files are modulemd documents
+                    assert("modulemd" in str(tmp))
+                elif filepath.endswith(".txt"):
                     pass
-                    # We don't know the filetype, assume it's correct
+                else:
+                    raise
         except (AssertionError, IOError):
             raise AssertionError("Cannot decompress File: " + repodata_file + " using"
                                  " copression type: " + compression_type)

--- a/dnf-behave-tests/createrepo_c/update-keep-all-metadata.feature
+++ b/dnf-behave-tests/createrepo_c/update-keep-all-metadata.feature
@@ -71,6 +71,8 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
       | other_db     | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
 
 
+# createrepo_c is compiled without support for modular metadata and refuses to use them on rhel 8
+@not.with_os=rhel__eq__8
 Scenario: --update --keep-all-metadata keeps all additional metadata
 Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/temp-repo"
   And I execute modifyrepo_c with args "../../updateinfo.xml ." in "/temp-repo/repodata"
@@ -113,6 +115,8 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
       | custom_metadata | ${checksum}-custom_metadata.txt.gz | sha256        | gz               |
 
 
+# createrepo_c is compiled without support for zchunk on rhel 8
+@not.with_os=rhel__eq__8
 Scenario: --update --keep-all-metadata --groupfile overrides old groupfile and --zck generates zck versions
 Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/temp-repo"
   And I execute modifyrepo_c with args "../../custom_metadata.txt ." in "/temp-repo/repodata"
@@ -137,6 +141,8 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
       | custom_metadata_zck | ${checksum}-custom_metadata.txt.zck | sha256        | zck              |
 
 
+# createrepo_c is compiled without support for zchunk on rhel 8
+@not.with_os=rhel__eq__8
 Scenario: --update --keep-all-metadata keeps additional metadata including zck variants
 Given I execute createrepo_c with args "--groupfile ../groupfile.xml --zck ." in "/temp-repo"
   And I execute modifyrepo_c with args "../../custom_metadata.txt --zck ." in "/temp-repo/repodata"

--- a/dnf-behave-tests/createrepo_c/zchunk.feature
+++ b/dnf-behave-tests/createrepo_c/zchunk.feature
@@ -1,0 +1,172 @@
+Feature: Tests createrepo_c --zck
+
+
+# createrepo_c is compiled without support for zchunk on rhel 8
+@not.with_os=rhel__eq__8
+Scenario: create empty repository with zck metadata
+ When I execute createrepo_c with args "--zck ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type                | File                             | Checksum Type | Compression Type |
+      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
+      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
+      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary_db          | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
+      | filelists_db        | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
+      | other_db            | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
+      | primary_zck         | ${checksum}-primary.xml.zck      | sha256        | zck              |
+      | filelists_zck       | ${checksum}-filelists.xml.zck    | sha256        | zck              |
+      | other_zck           | ${checksum}-other.xml.zck        | sha256        | zck              |
+  And primary in "/repodata/" doesn't have any packages
+
+
+# createrepo_c is compiled without support for zchunk on rhel 8
+@not.with_os=rhel__eq__8
+Scenario: create repository with zck metadata
+Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x86_64/package-0.2.1-1.fc29.x86_64.rpm" to "/"
+ When I execute createrepo_c with args "--zck ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type                | File                             | Checksum Type | Compression Type |
+      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
+      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
+      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary_db          | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
+      | filelists_db        | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
+      | other_db            | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
+      | primary_zck         | ${checksum}-primary.xml.zck      | sha256        | zck              |
+      | filelists_zck       | ${checksum}-filelists.xml.zck    | sha256        | zck              |
+      | other_zck           | ${checksum}-other.xml.zck        | sha256        | zck              |
+  And primary in "/repodata" has only packages
+      | Name          | Epoch | Version | Release | Architecture |
+      | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
+
+
+# createrepo_c is compiled without support for zchunk on rhel 8
+@not.with_os=rhel__eq__8
+Scenario: create repository with zck metadata with bad package
+Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x86_64/package-0.2.1-1.fc29.x86_64.rpm" to "/"
+  And I create file "/afilethatlookslike.rpm" with
+      """
+      gibberish
+      """
+ When I execute createrepo_c with args "--zck ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type                | File                             | Checksum Type | Compression Type |
+      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
+      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
+      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary_db          | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
+      | filelists_db        | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
+      | other_db            | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
+      | primary_zck         | ${checksum}-primary.xml.zck      | sha256        | zck              |
+      | filelists_zck       | ${checksum}-filelists.xml.zck    | sha256        | zck              |
+      | other_zck           | ${checksum}-other.xml.zck        | sha256        | zck              |
+  And primary in "/repodata" has only packages
+      | Name          | Epoch | Version | Release | Architecture |
+      | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
+
+
+# createrepo_c is compiled without support for zchunk on rhel 8
+@not.with_os=rhel__eq__8
+Scenario: create repository with zck metadata usign dictionaries
+Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x86_64/package-0.2.1-1.fc29.x86_64.rpm" to "/"
+Given I create directory "/dictionaries"
+  And I create file "/dictionaries/primary.xml.zdict" with
+      """
+      primary foobar
+      """
+  And I create file "/dictionaries/filelists.xml.zdict" with
+      """
+      filelists foobar
+      """
+  And I create file "/dictionaries/other.xml.zdict" with
+      """
+      other foobar
+      """
+ When I execute createrepo_c with args "--zck --zck-dict-dir {context.scenario.default_tmp_dir}/dictionaries --simple-md-filenames ." in "/"
+ Then the exit code is 0
+  And stderr is empty
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type                | File                 | Checksum Type | Compression Type |
+      | primary             | primary.xml.gz       | sha256        | gz               |
+      | filelists           | filelists.xml.gz     | sha256        | gz               |
+      | other               | other.xml.gz         | sha256        | gz               |
+      | primary_db          | primary.sqlite.bz2   | sha256        | bz2              |
+      | filelists_db        | filelists.sqlite.bz2 | sha256        | bz2              |
+      | other_db            | other.sqlite.bz2     | sha256        | bz2              |
+      | primary_zck         | primary.xml.zck      | sha256        | zck              |
+      | filelists_zck       | filelists.xml.zck    | sha256        | zck              |
+      | other_zck           | other.xml.zck        | sha256        | zck              |
+  And I execute "unzck --dict {context.scenario.default_tmp_dir}/repodata/primary.xml.zck" in "{context.scenario.default_tmp_dir}/"
+  And I execute "unzck --dict {context.scenario.default_tmp_dir}/repodata/filelists.xml.zck" in "{context.scenario.default_tmp_dir}/"
+  And I execute "unzck --dict {context.scenario.default_tmp_dir}/repodata/other.xml.zck" in "{context.scenario.default_tmp_dir}/"
+  And file "/primary.xml.zdict" contents is
+      """
+      primary foobar
+      """
+  And file "/filelists.xml.zdict" contents is
+      """
+      filelists foobar
+      """
+  And file "/other.xml.zdict" contents is
+      """
+      other foobar
+      """
+
+
+# createrepo_c is compiled without support for zchunk on rhel 8
+@not.with_os=rhel__eq__8
+Scenario: create repository with zck and dictionary metadata with bad package
+Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x86_64/package-0.2.1-1.fc29.x86_64.rpm" to "/"
+  And I create file "/afilethatlookslike.rpm" with
+      """
+      gibberish
+      """
+Given I create directory "/dictionaries"
+  And I create file "/dictionaries/primary.xml.zdict" with
+      """
+      primary foobar
+      """
+  And I create file "/dictionaries/filelists.xml.zdict" with
+      """
+      filelists foobar
+      """
+  And I create file "/dictionaries/other.xml.zdict" with
+      """
+      other foobar
+      """
+ When I execute createrepo_c with args "--zck --zck-dict-dir {context.scenario.default_tmp_dir}/dictionaries --simple-md-filenames ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata/" are consistent
+  And repodata in "/repodata/" is
+      | Type                | File                 | Checksum Type | Compression Type |
+      | primary             | primary.xml.gz       | sha256        | gz               |
+      | filelists           | filelists.xml.gz     | sha256        | gz               |
+      | other               | other.xml.gz         | sha256        | gz               |
+      | primary_db          | primary.sqlite.bz2   | sha256        | bz2              |
+      | filelists_db        | filelists.sqlite.bz2 | sha256        | bz2              |
+      | other_db            | other.sqlite.bz2     | sha256        | bz2              |
+      | primary_zck         | primary.xml.zck      | sha256        | zck              |
+      | filelists_zck       | filelists.xml.zck    | sha256        | zck              |
+      | other_zck           | other.xml.zck        | sha256        | zck              |
+  And I execute "unzck --dict {context.scenario.default_tmp_dir}/repodata/primary.xml.zck" in "{context.scenario.default_tmp_dir}/"
+  And I execute "unzck --dict {context.scenario.default_tmp_dir}/repodata/filelists.xml.zck" in "{context.scenario.default_tmp_dir}/"
+  And I execute "unzck --dict {context.scenario.default_tmp_dir}/repodata/other.xml.zck" in "{context.scenario.default_tmp_dir}/"
+  And file "/primary.xml.zdict" contents is
+      """
+      primary foobar
+      """
+  And file "/filelists.xml.zdict" contents is
+      """
+      filelists foobar
+      """
+  And file "/other.xml.zdict" contents is
+      """
+      other foobar
+      """

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import operator
 import os
 import shutil
 import sys
@@ -15,11 +14,11 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import common
 
 from behave import model
-from behave.tag_matcher import ActiveTagMatcher
 from behave.formatter.ansi_escapes import escapes
 
 from common.lib.cmd import print_last_command
 from common.lib.file import ensure_directory_exists
+from common.lib.tag_matcher import VersionedActiveTagMatcher
 
 
 FIXTURES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "fixtures"))
@@ -36,61 +35,6 @@ DESTRUCTIVE_TAGS = [
     "destructive",
     "no_installroot",
 ]
-
-
-class VersionedActiveTagMatcher(ActiveTagMatcher):
-    @staticmethod
-    def version_compare_operator(tag_value_str, current_value_str, is_negated=False):
-        tag_key, tag_oper, tag_value = tag_value_str.split("__", 2)
-        try:
-            current_key, current_value = current_value_str.split("__", 1)
-        except ValueError:
-            return is_negated
-
-        # convert versions into list of integers for correct comparing
-        tag_value = [int(i) for i in tag_value.split(".")]
-        try:
-            current_value = [int(i) for i in current_value.split(".")]
-        except:
-            return is_negated
-
-        if tag_oper not in ["lt", "le", "eq", "ne", "ge", "gt"]:
-            raise ValueError("Invalid operator in tag: %s" % tag_value_str)
-
-        if tag_key != current_key:
-            # always return false if keys do not match
-            return is_negated
-
-        op = getattr(operator, tag_oper)
-        result = op(current_value, tag_value)
-        if is_negated:
-            result = not(result)
-        return result
-
-    def is_tag_group_enabled(self, group_category, group_tag_pairs):
-        """Modified ActiveTagMatcher.is_tag_group_enabled()"""
-        if not group_tag_pairs:
-            # -- CASE: Empty group is always enabled (CORNER-CASE).
-            return True
-
-        current_value = self.value_provider.get(group_category, None)
-        if current_value is None and self.ignore_unknown_categories:
-            # -- CASE: Unknown category, ignore it.
-            return True
-
-        tags_enabled = []
-        for category_tag, tag_match in group_tag_pairs:
-            tag_prefix = tag_match.group("prefix")
-            category = tag_match.group("category")
-            tag_value = tag_match.group("value")
-            assert category == group_category
-            tag_enabled = self.version_compare_operator(tag_value, current_value, self.is_tag_negated(tag_prefix))
-            tags_enabled.append(tag_enabled)
-        return any(tags_enabled)    # -- PROVIDES: LOGICAL-OR expression
-
-
-active_tag_value_provider = {}
-active_tag_matcher = VersionedActiveTagMatcher(active_tag_value_provider)
 
 
 class DNFContext(object):
@@ -218,7 +162,7 @@ def after_step(context, step):
 
 
 def before_scenario(context, scenario):
-    if active_tag_matcher.should_exclude_with(scenario.effective_tags):
+    if context.tag_matcher.should_exclude_with(scenario.effective_tags):
         scenario.skip(reason="DISABLED ACTIVE-TAG")
 
     # Skip if destructive and not explicitly allowed by the user
@@ -255,10 +199,7 @@ def after_tag(context, tag):
 
 
 def before_all(context):
-    os = context.config.userdata.get("os", None)
-    if os:
-        active_tag_value_provider["os"] = os
-
+    context.tag_matcher = VersionedActiveTagMatcher({"os": context.config.userdata.get("os", None)})
     context.repos = {}
 
 

--- a/dnf-behave-tests/fixtures/specs/createrepo_c-ci-packages-2/package-0.3.1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/createrepo_c-ci-packages-2/package-0.3.1-1.spec
@@ -5,12 +5,11 @@ Release:        1%{?dist}
 License:        GPLv2+
 URL:            https://github.com/rpm-software-management/package
 
-Requires:       gcc
 Obsoletes:      package < 0.1.0
 Provides:       package = %{version}-%{release}
 
 %description
-Test un-installable package for createrepo_c tests.
+Test installable package for createrepo_c tests.
 It is an updated version of ../createrepo_c-ci-packages/package-0.2.1-1.spec
 
 %install


### PR DESCRIPTION
Adding tests for modifyrepo_c with compressed input, zchunk and drpms.

I have also extracted the VersionedActiveTagMatcher class into common, so that createrepo_c can use it (its useful mainly for zchunk and modules, because those are turned off on rhel)