### PR TITLE
[config-parser] Exit status for no options is now 1 (RhBug:1782822)

### DIFF
--- a/dnf-behave-tests/features/plugins-core/config-manager.feature
+++ b/dnf-behave-tests/features/plugins-core/config-manager.feature
@@ -11,6 +11,11 @@ Background:
         | enabled     | 0        |
 
 
+Scenario: when run without arguments
+   When I execute dnf with args "config-manager"
+   Then the exit code is 1
+
+
 Scenario Outline: <option> enables given repository
    When I execute dnf with args "config-manager <option> repo2"
    Then the exit code is 0
@@ -112,7 +117,7 @@ Scenario: --setopt modifies repo when used with --save
 
 Scenario: --setopt does not modify repo when used without --save
    When I execute dnf with args "config-manager --setopt=repo1.gpgcheck=1"
-   Then the exit code is 0
+   Then the exit code is 1
     And file "/etc/yum.repos.d/repo1.repo" contents is
         """
         [repo1]

--- a/dnf-behave-tests/features/plugins-core/config-manager.feature
+++ b/dnf-behave-tests/features/plugins-core/config-manager.feature
@@ -11,18 +11,23 @@ Background:
         | enabled     | 0        |
 
 
+@bz1782822
 Scenario: when run without arguments
    When I execute dnf with args "config-manager"
    Then the exit code is 1
-    And stdout contains "usage: dnf config-manager"
-    And stderr contains "Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable"
+    And stderr is
+    """
+    Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable
+    """
 
 
 Scenario: when run with single argument
    When I execute dnf with args "config-manager repo1"
    Then the exit code is 1
-    And stdout contains "usage: dnf config-manager"
-    And stderr contains "Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable"
+    And stderr is
+    """
+    Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable
+    """
 
 
 Scenario Outline: <option> enables given repository
@@ -134,8 +139,10 @@ Scenario: --setopt does not modify repo when used without --save
         enabled=1
         gpgcheck=0
         """
-    And stdout contains "usage: dnf config-manager"
-    And stderr contains "Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable"
+    And stderr is
+    """
+    Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable
+    """
 
 
 
@@ -149,5 +156,7 @@ Scenario: --setopt does not modify repo when used without --save and one argumen
         enabled=1
         gpgcheck=0
         """
-    And stdout contains "usage: dnf config-manager"
-    And stderr contains "Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable"
+    And stderr is
+    """
+    Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable
+    """

--- a/dnf-behave-tests/features/plugins-core/config-manager.feature
+++ b/dnf-behave-tests/features/plugins-core/config-manager.feature
@@ -14,6 +14,15 @@ Background:
 Scenario: when run without arguments
    When I execute dnf with args "config-manager"
    Then the exit code is 1
+    And stdout contains "usage: dnf config-manager"
+    And stderr contains "Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable"
+
+
+Scenario: when run with single argument
+   When I execute dnf with args "config-manager repo1"
+   Then the exit code is 1
+    And stdout contains "usage: dnf config-manager"
+    And stderr contains "Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable"
 
 
 Scenario Outline: <option> enables given repository
@@ -125,3 +134,20 @@ Scenario: --setopt does not modify repo when used without --save
         enabled=1
         gpgcheck=0
         """
+    And stdout contains "usage: dnf config-manager"
+    And stderr contains "Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable"
+
+
+
+Scenario: --setopt does not modify repo when used without --save and one argument
+   When I execute dnf with args "config-manager --setopt=repo1.gpgcheck=1 repo1"
+   Then the exit code is 1
+    And file "/etc/yum.repos.d/repo1.repo" contents is
+        """
+        [repo1]
+        name=repo1 test repository
+        enabled=1
+        gpgcheck=0
+        """
+    And stdout contains "usage: dnf config-manager"
+    And stderr contains "Command line error: one of the following arguments is required: --save --add-repo --dump --dump-variables --enable --disable"


### PR DESCRIPTION
Added test for dnf config-manager without any option provoded
Edited exit status for "without --save" option which now exits with 1
PR#381:   https://github.com/rpm-software-management/dnf-plugins-core/pull/381
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1782822