### PR TITLE
 Install an RPM without null lines 

### DIFF
--- a/dnf-behave-tests/features/microdnf/install7.feature
+++ b/dnf-behave-tests/features/microdnf/install7.feature
@@ -1,0 +1,20 @@
+@no_installroot
+Feature: Install package
+
+
+Background:
+Given I delete file "/etc/dnf/dnf.conf"
+  And I delete file "/etc/yum.repos.d/*.repo" with globs
+
+
+@bz1691353
+Scenario: Install an RPM without null lines
+  Given I use repository "dnf-ci-fedora"
+   When I execute microdnf with args "install lame"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | install       | lame-0:3.100-4.fc29.x86_64                |
+        | install       | lame-libs-0:3.100-4.fc29.x86_64           |
+  And stdout does not contain "Installing: (null)"
+


### PR DESCRIPTION
Backporting the install an RPM without null lines test to the 8.2 branch.

Original PR: #726

https://bugzilla.redhat.com/show_bug.cgi?id=1691353