### PR TITLE
Add tests: versionlock.list missing or misconfigured (RhBug:1785563)

### DIFF
--- a/dnf-behave-tests/features/plugins-core/versionlock-list-manipulation.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-list-manipulation.feature
@@ -136,3 +136,15 @@ Scenario: Versionlock accepts --raw switch
     <REPOSYNC>
     Adding versionlock on: flac-1.3.*
     """
+
+@bz1785563
+@not.with_os=rhel__eq__8
+Scenario: versionlock will print just necessary information with -q option
+  Given I use repository "dnf-ci-fedora"
+  Given I execute dnf with args "versionlock add wget"
+  When I execute dnf with args "-q versionlock"
+  Then the exit code is 0
+  And stdout is
+    """
+    wget-0:1.19.5-5.fc29.*
+    """

--- a/dnf-behave-tests/features/plugins-core/versionlock-list.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-list.feature
@@ -1,0 +1,89 @@
+Feature: Tests missing or misconfigured versionlock.list file in versionlock plugin
+
+
+Background: Set up versionlock infrastructure in the installroot
+  Given I enable plugin "versionlock"
+  # plugins do not honor installroot when searching their configuration
+  # all the next steps are merely to set up versionlock plugin inside installroot
+  And I create and substitute file "/etc/dnf/dnf.conf" with
+    """
+    [main]
+    gpgcheck=1
+    installonly_limit=3
+    clean_requirements_on_remove=True
+    pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
+    """
+  And I create and substitute file "/etc/dnf/plugins/versionlock.conf" with
+    """
+    [main]
+    enabled = 1
+    locklist = {context.dnf.installroot}/etc/dnf/plugins/versionlock.list
+    """
+  And I create file "/etc/dnf/plugins/versionlock.list" with
+    """
+    """
+  And I do not set config file
+  # check that both locked and newer versions of the package are available
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+
+
+@not.with_os=rhel__eq__8
+Scenario: dnf will fail if versionlock.list file is missing
+  Given I delete file "/etc/dnf/plugins/versionlock.list"
+  When I execute dnf with args "check-update"
+  Then the exit code is 1
+
+
+@not.with_os=rhel__eq__8
+Scenario: dnf will fail if versionlock.list path is missing from conf
+  Given I create file "/etc/dnf/plugins/versionlock.conf" with
+    """
+    [main]
+    enabled=1
+    """
+  When I execute dnf with args "check-update"
+  Then the exit code is 1
+
+
+@not.with_os=rhel__eq__8
+Scenario Outline: dnf versionlock <option> <package> will fail if versionlock.list file is missing
+  Given I delete file "/etc/dnf/plugins/versionlock.list"
+  When I execute dnf with args "versionlock <option> <package>"
+  Then the exit code is 1
+
+Examples:
+        | option  | package |
+        | list    |         |
+        | delete  | abcde   |
+        | add     | abcde   |
+        | exclude | abcde   |
+
+
+@not.with_os=rhel__eq__8
+Scenario: dnf versionlock clear will create empty file if versionlock.list is missing
+  Given I delete file "/etc/dnf/plugins/versionlock.list"
+  When I execute dnf with args "versionlock clear"
+  Then the exit code is 0
+  And file "/etc/dnf/plugins/versionlock.list" exists
+  And file "/etc/dnf/plugins/versionlock.list" contents is
+    """
+    """
+
+@not.with_os=rhel__eq__8
+Scenario Outline: dnf versionlock <option> <package> will fail if versionlock.list path is missing from conf
+  Given I create file "/etc/dnf/plugins/versionlock.conf" with
+    """
+    [main]
+    enabled=1
+    """
+  When I execute dnf with args "versionlock <option> <package>"
+  Then the exit code is 1
+
+Examples:
+        | option    | package |
+        | list      |         |
+        | clear     |         |
+        | add       | abcde   |
+        | delete    | abcde   |
+        | exclude   | abcde   |


### PR DESCRIPTION
Add tests for versionlock.list misconfigured to prevent open None files which results in python opening a stdin
Add tests for versionlock.list missing

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1785563
PR: https://github.com/rpm-software-management/dnf-plugins-core/pull/378