### PR TITLE
Delete module failsafe cache for all @no_installroot tests

### DIFF
--- a/dnf-behave-tests/features/alias-command.feature
+++ b/dnf-behave-tests/features/alias-command.feature
@@ -5,6 +5,7 @@ Feature: Test for alias command
 Background:
   Given I delete directory "/etc/dnf/aliases.d/"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
     And I use repository "alias-command"
 
 

--- a/dnf-behave-tests/features/installonly.feature
+++ b/dnf-behave-tests/features/installonly.feature
@@ -83,7 +83,10 @@ Scenario: Remove all installonly packages but keep the latest
 @no_installroot
 @destructive
 Scenario: Remove all installonly packages but keep the latest and running kernel-core-0:4.18.16-300.fc29.x86_64
-  Given I fake kernel release to "4.18.16-300.fc29.x86_64"
+  Given I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
+    And I use repository "dnf-ci-fedora"
+    And I fake kernel release to "4.18.16-300.fc29.x86_64"
    When I execute dnf with args "install kernel-core --repofrompath=r,{context.dnf.repos[dnf-ci-fedora].path} --repo=r --nogpgcheck"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/microdnf/config-with-repos.feature
+++ b/dnf-behave-tests/features/microdnf/config-with-repos.feature
@@ -5,6 +5,7 @@ Feature: Repositories configured in main configuration file
 Background: Configure repositories in the main configuration file
   Given I delete file "/etc/dnf/dnf.conf"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
     And I create file "/etc/dnf/dnf.conf" with
      """
      [main]

--- a/dnf-behave-tests/features/microdnf/install-nodocs-1.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-1.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 Scenario: Install a documentation package from local repodata

--- a/dnf-behave-tests/features/microdnf/install-nodocs-2.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-2.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1769831

--- a/dnf-behave-tests/features/microdnf/install-nodocs-3.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-3.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1771012

--- a/dnf-behave-tests/features/microdnf/install1.feature
+++ b/dnf-behave-tests/features/microdnf/install1.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1734350

--- a/dnf-behave-tests/features/microdnf/install2.feature
+++ b/dnf-behave-tests/features/microdnf/install2.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1734350

--- a/dnf-behave-tests/features/microdnf/install3.feature
+++ b/dnf-behave-tests/features/microdnf/install3.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1734350

--- a/dnf-behave-tests/features/microdnf/install4.feature
+++ b/dnf-behave-tests/features/microdnf/install4.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1734350

--- a/dnf-behave-tests/features/microdnf/install5.feature
+++ b/dnf-behave-tests/features/microdnf/install5.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1734350

--- a/dnf-behave-tests/features/microdnf/install6.feature
+++ b/dnf-behave-tests/features/microdnf/install6.feature
@@ -5,6 +5,7 @@ Feature: microdnf install command on packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1734350

--- a/dnf-behave-tests/features/microdnf/install7.feature
+++ b/dnf-behave-tests/features/microdnf/install7.feature
@@ -5,6 +5,7 @@ Feature: Install package
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1691353

--- a/dnf-behave-tests/features/microdnf/install8.feature
+++ b/dnf-behave-tests/features/microdnf/install8.feature
@@ -5,6 +5,7 @@ Feature: microdnf is able to downgrade packages
 Background:
 Given I delete file "/etc/dnf/dnf.conf"
   And I delete file "/etc/yum.repos.d/*.repo" with globs
+  And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 @bz1725863

--- a/dnf-behave-tests/features/microdnf/install_weak_deps.feature
+++ b/dnf-behave-tests/features/microdnf/install_weak_deps.feature
@@ -8,6 +8,7 @@ Feature: Tests --setopt=install_weak_deps=
 Background: Prepare environment
   Given I delete file "/etc/dnf/dnf.conf"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
     And I execute microdnf with args "remove abcde flac"
     And I use repository "dnf-ci-fedora"
 

--- a/dnf-behave-tests/features/microdnf/reinstall-reason.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall-reason.feature
@@ -6,6 +6,7 @@ Feature: Reinstall must keep the "reason" why a package was installed
 Background:
   Given I delete file "/etc/dnf/dnf.conf"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
 
 
 Scenario: Reinstall a dependency, and then remove the main package

--- a/dnf-behave-tests/features/microdnf/reinstall1.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall1.feature
@@ -5,6 +5,7 @@ Feature: Reinstall
 Background: Install CQRlib-devel and CQRlib
   Given I delete file "/etc/dnf/dnf.conf"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
     And I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "install CQRlib-devel"

--- a/dnf-behave-tests/features/microdnf/reinstall2.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall2.feature
@@ -5,6 +5,7 @@ Feature: Reinstall
 Background: Install CQRlib-devel and CQRlib
   Given I delete file "/etc/dnf/dnf.conf"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
     And I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "install CQRlib-devel"

--- a/dnf-behave-tests/features/microdnf/reinstall3.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall3.feature
@@ -5,6 +5,7 @@ Feature: Reinstall
 Background: Install CQRlib-devel and CQRlib
   Given I delete file "/etc/dnf/dnf.conf"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
     And I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "install CQRlib-devel"

--- a/dnf-behave-tests/features/microdnf/repolist-disabled.feature
+++ b/dnf-behave-tests/features/microdnf/repolist-disabled.feature
@@ -6,6 +6,7 @@ Feature: Repolist when all repositories are disabled
 Background:
   Given I delete file "/etc/dnf/dnf.conf"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
     And I use repository "dnf-ci-fedora" with configuration
         |key      | value |
         | enabled | 0     |

--- a/dnf-behave-tests/features/microdnf/repolist.feature
+++ b/dnf-behave-tests/features/microdnf/repolist.feature
@@ -6,6 +6,7 @@ Feature: Repolist
 Background: Using repositories dnf-ci-fedora and dnf-ci-thirdparty-updates
   Given I delete file "/etc/dnf/dnf.conf"
     And I delete file "/etc/yum.repos.d/*.repo" with globs
+    And I delete directory "/var/lib/dnf/modulefailsafe/"
     And I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-thirdparty-updates"
     And I use repository "dnf-ci-fedora-updates" with configuration

--- a/dnf-behave-tests/features/microdnf/repoquery-globs.feature
+++ b/dnf-behave-tests/features/microdnf/repoquery-globs.feature
@@ -5,6 +5,7 @@ Feature: Glob tests for expanding all the various glob patterns.
 Background:
  Given I delete file "/etc/dnf/dnf.conf"
    And I delete file "/etc/yum.repos.d/*.repo" with globs
+   And I delete directory "/var/lib/dnf/modulefailsafe/"
    And I use repository "repoquery-globs"
 
 

--- a/dnf-behave-tests/features/microdnf/repoquery.feature
+++ b/dnf-behave-tests/features/microdnf/repoquery.feature
@@ -5,6 +5,7 @@ Feature: The common repoquery tests, core functionality, odds and ends.
 Background:
  Given I delete file "/etc/dnf/dnf.conf"
    And I delete file "/etc/yum.repos.d/*.repo" with globs
+   And I delete directory "/var/lib/dnf/modulefailsafe/"
    And I use repository "repoquery-main"
 
 


### PR DESCRIPTION
Module failsafe on the host can contain some modules that may affect
tests (e.g. modular dependency problems are reported and stderr differs).