### PR TITLE
Disable colors inside pexpect child applications

### DIFF
--- a/dnf-behave-tests/features/steps/shell.py
+++ b/dnf-behave-tests/features/steps/shell.py
@@ -23,7 +23,7 @@ def when_I_open_dnf_shell(context):
     context.cmd = cmd
     context.dnf["rpmdb_pre"] = get_rpmdb_rpms(context.dnf.installroot)
 
-    context.shell_session = pexpect.spawn(cmd)
+    context.shell_session = pexpect.spawn(cmd, env = {"COLORTERM": "FALSE"})
     # pexpect adds a short delay before sending data, so that SSH has time
     # to turn off TTY echo; the echo is still there though, so removing the delay
     context.shell_session.delaybeforesend = None


### PR DESCRIPTION
https://github.com/rpm-software-management/libdnf/commit/b685e2bded5939964e11248f99e6967b326bd440
commit set default colors, since then DNF output inside pexpect child
applications contains specified colors. These have to be disabled in
order not to break parsing of transaction table in shell tests.

DNF is not able to tell whether it's being run by pexpect or by a standart
user or at least I didn't find any way how to.