### PR TITLE
Duplicate NSVCAs are dropped, defaults remain unaffected 

### DIFF
--- a/dnf-behave-tests/features/module/defaults-conflict.feature
+++ b/dnf-behave-tests/features/module/defaults-conflict.feature
@@ -1,4 +1,4 @@
-Feature: Not fail if conflicting defaults. Only remove defaults
+Feature: Not fail if conflicts in module metadata.
 
   @bz1656019
   Scenario: Enabling two repository with conflicting defaults - only remove defaults
@@ -34,3 +34,18 @@ Feature: Not fail if conflicting defaults. Only remove defaults
       | dnf-ci-thirdparty-modular-updates-conflict | ingredience | chicken [d] | default |
       | dnf-ci-thirdparty-modular-updates-conflict | ingredience | egg         | default |
       | dnf-ci-thirdparty-modular-updates-conflict | ingredience | orange      | default |
+
+
+Scenario: Two streams that have matching NSVCA but different content (conflict) are dropped by libmodulemd, but defaults are unaffected
+Given I use repository "dnf-ci-thirdparty-modular-updates"
+  And I use repository "dnf-ci-thirdparty-modular-updates-duplicate"
+ When I execute dnf with args "module list"
+ Then the exit code is 0
+  And module list is
+      | Repository                                  | Name        | Stream     | Profiles                             |
+      | dnf-ci-thirdparty-modular-updates           | cookbook    | 1          | ham-and-eggs, orange-juice, axe-soup |
+      | dnf-ci-thirdparty-modular-updates           | ingredience | chicken    | default                              |
+      | dnf-ci-thirdparty-modular-updates           | ingredience | egg        | default                              |
+      | dnf-ci-thirdparty-modular-updates           | ingredience | orange [d] | default                              |
+      | dnf-ci-thirdparty-modular-updates           | ingredience | strawberry | default                              |
+      | dnf-ci-thirdparty-modular-updates-duplicate | ingredience | egg        | default                              |

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates-duplicate/egg-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates-duplicate/egg-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           egg
+Epoch:          0
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for rich dependencies testing.
+
+%description
+Modular dependencies testing package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates-duplicate/modules.yaml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty-modular-updates-duplicate/modules.yaml
@@ -1,0 +1,21 @@
+---
+document: modulemd
+version: 2
+data:
+  name: ingredience
+  stream: egg
+  version: 2
+  arch: x86_64
+  summary: Dependency testing module
+  description: Made up module for dependency testing, with different content
+  license:
+    module:
+    - MIT
+  profiles:
+    default:
+      rpms: ["egg"]
+  components:
+    rpms:
+      egg: {rationale: 'There is never a rationale for an egg'}
+  artifacts:
+    rpms: ["egg-0:2.0-1.x86_64"]


### PR DESCRIPTION
Tests for: https://github.com/rpm-software-management/libdnf/pull/900