### PR TITLE
Add dependency on glibc-all-langpacks to test encoding

### DIFF
--- a/Dockerfile.f29
+++ b/Dockerfile.f29
@@ -61,6 +61,8 @@ RUN set -x && \
     dnf -y install \
         # behave and test requirements
         findutils \
+        glibc-all-langpacks \
+        langpacks-en \
         libfaketime \
         openssl \
         python3-behave \

--- a/Dockerfile.f30
+++ b/Dockerfile.f30
@@ -59,6 +59,8 @@ RUN set -x && \
     dnf -y install \
         # behave and test requirements
         findutils \
+        glibc-all-langpacks \
+        langpacks-en \
         libfaketime \
         python3-behave \
         python3-pexpect \

--- a/Dockerfile.f31
+++ b/Dockerfile.f31
@@ -59,6 +59,8 @@ RUN set -x && \
     dnf -y install \
         # behave and test requirements
         findutils \
+        glibc-all-langpacks \
+        langpacks-en \
         libfaketime \
         python3-behave \
         python3-pexpect \


### PR DESCRIPTION
Without this, encoding.feature was failing due to:
"Failed to set locale, defaulting to C"