### PR TITLE
History length longer than 80 char (RhBug:1786335,1786316)

### DIFF
--- a/dnf-behave-tests/features/history-list.feature
+++ b/dnf-behave-tests/features/history-list.feature
@@ -191,3 +191,23 @@ Scenario: history lame (no transaction with such package)
       """
       No transaction which manipulates package 'lame' was found.
       """
+
+@bz1786335
+@bz1786316
+Scenario: history longer than 80 characters
+ When I execute dnf with args "history | head -1 | wc -c"
+ Then the exit code is 0
+  And stdout is
+  """
+  244
+  """
+
+@bz1786335
+@bz1786316
+Scenario: history length is 80 chars when missing rows are queried
+ When I execute dnf with args "history 10 | head -1 | wc -c"
+ Then the exit code is 0
+  And stdout is
+  """
+  80
+  """


### PR DESCRIPTION
History length longer than 80 char when run in non interactive terminal
History length 80 char when run in non interactive terminal and row does not exist

PR in dnf: https://github.com/rpm-software-management/dnf/pull/1587

Related bugs:
RHEL8: https://bugzilla.redhat.com/show_bug.cgi?id=1786335
Fedora: https://bugzilla.redhat.com/show_bug.cgi?id=1786316

Partial fix to: https://bugzilla.redhat.com/show_bug.cgi?id=1653607