### PR TITLE
Move invalid_utf8_char from context.dnf to context

### DIFF
--- a/dnf-behave-tests/common/lib/cmd.py
+++ b/dnf-behave-tests/common/lib/cmd.py
@@ -6,6 +6,8 @@ from __future__ import print_function
 from behave.formatter.ansi_escapes import escapes
 import subprocess
 
+import consts
+
 
 def run(cmd, shell=True, cwd=None):
     """
@@ -48,13 +50,13 @@ def run_in_context(context, cmd, can_fail=False, **run_args):
 
 
 def assert_exitcode(context, exitcode):
-    cmd = context.cmd.replace(context.dnf.invalid_utf8_char, "\\udcfd")
+    cmd = context.cmd.replace(consts.INVALID_UTF8_CHAR, "\\udcfd")
     assert context.cmd_exitcode == int(exitcode), \
         "Command has returned exit code {0}: {1}".format(context.cmd_exitcode, cmd)
 
 
 def print_last_command(context):
-    cmd = context.cmd.replace(context.dnf.invalid_utf8_char, "\\udcfd")
+    cmd = context.cmd.replace(consts.INVALID_UTF8_CHAR, "\\udcfd")
     if getattr(context, "cmd", ""):
         print(
             "%sLast Command: %s%s" %

--- a/dnf-behave-tests/consts.py
+++ b/dnf-behave-tests/consts.py
@@ -10,3 +10,5 @@ DESTRUCTIVE_TAGS = [
     "destructive",
     "no_installroot",
 ]
+
+INVALID_UTF8_CHAR = '\udcfd'

--- a/dnf-behave-tests/features/encoding.feature
+++ b/dnf-behave-tests/features/encoding.feature
@@ -31,7 +31,7 @@ Scenario: non-UTF-8 characters in .repo filename
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key     | value                                            |
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora  |
-    And I copy file "{context.dnf.installroot}/testrepos/testrepo.repo" to "testrepos/{context.dnf.invalid_utf8_char}.repo"
+    And I copy file "{context.dnf.installroot}/testrepos/testrepo.repo" to "testrepos/{context.invalid_utf8_char}.repo"
     And I delete file "/testrepos/testrepo.repo"
    When I execute dnf with args "repolist"
    Then the exit code is 0
@@ -46,7 +46,7 @@ Scenario: non-UTF-8 characters in .repo filename
 @not.with_os=rhel__eq__8
 Scenario: non-UTF-8 character in pkgspec
   Given I use repository "miscellaneous"
-   When I execute dnf with args "install {context.dnf.invalid_utf8_char}ummy"
+   When I execute dnf with args "install {context.invalid_utf8_char}ummy"
    Then the exit code is 1
     And stdout is empty
     And stderr is 
@@ -58,7 +58,7 @@ Scenario: non-UTF-8 character in pkgspec
 @not.with_os=rhel__eq__8
 Scenario: non-UTF-8 character in baseurl
   Given I use repository "miscellaneous"
-   When I execute dnf with args "install dummy --repofrompath=testrepo,{context.dnf.invalid_utf8_char}"
+   When I execute dnf with args "install dummy --repofrompath=testrepo,{context.invalid_utf8_char}"
    Then the exit code is 1
     And stdout is empty
     And stderr is 
@@ -70,7 +70,7 @@ Scenario: non-UTF-8 character in baseurl
 @not.with_os=rhel__eq__8
 Scenario: non-UTF-8 character in an option
   Given I use repository "miscellaneous"
-   When I execute dnf with args "install dummy --config={context.dnf.invalid_utf8_char}"
+   When I execute dnf with args "install dummy --config={context.invalid_utf8_char}"
    Then the exit code is 1
     And stdout is empty
     And stderr is 
@@ -82,11 +82,11 @@ Scenario: non-UTF-8 character in an option
 @not.with_os=rhel__eq__8
 Scenario: non-UTF-8 character in an option when using corresponding locale
   Given I use repository "miscellaneous"
-    And I create file "/{context.dnf.invalid_utf8_char}" with
+    And I create file "/{context.invalid_utf8_char}" with
         """
         """
     And I set LC_ALL to "en_US.ISO-8859-1"
-   When I execute dnf with args "install dummy --config={context.dnf.installroot}/{context.dnf.invalid_utf8_char}"
+   When I execute dnf with args "install dummy --config={context.dnf.installroot}/{context.invalid_utf8_char}"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                    |

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -36,8 +36,6 @@ class DNFContext(object):
         self.repos = {}
         self.ports = {}
 
-        self.invalid_utf8_char = '\udcfd'
-
         self.tempdir = tempfile.mkdtemp(prefix="dnf_ci_tempdir_")
         # some tests need to be run inside the installroot, it can be forced
         # per scenario by using @force_installroot decorator
@@ -195,6 +193,7 @@ def after_tag(context, tag):
 def before_all(context):
     context.tag_matcher = VersionedActiveTagMatcher({"os": context.config.userdata.get("os", None)})
     context.repos = {}
+    context.invalid_utf8_char = consts.INVALID_UTF8_CHAR
 
 
 def after_all(context):


### PR DESCRIPTION
Although this is used only in dnf tests, the character must be also
replaced when checking context.cmd in case that the dnf command
contained it. Moreover, it is not a dnf-specific thing, so it makes
more sense in the context rather than context.dnf.