### PR TITLE
Swdb error tests, unprivileged user test steps and improvements

### DIFF
--- a/dnf-behave-tests/common/cmd.py
+++ b/dnf-behave-tests/common/cmd.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import behave
 
-from common.lib.cmd import run_in_context
+from common.lib.cmd import assert_exitcode, run_in_context
 
 
 @behave.step("I set working directory to \"{working_dir}\"")
@@ -18,9 +18,21 @@ def when_I_execute_command_in_directory(context, command, directory):
     run_in_context(context, command.format(context=context), cwd=directory.format(context=context))
 
 
+@behave.step("I successfully execute \"{command}\" in \"{directory}\"")
+def when_I_successfully_execute_command_in_directory(context, command, directory):
+    when_I_execute_command_in_directory(context, command, directory)
+    assert_exitcode(context, 0)
+
+
 @behave.step("I execute \"{command}\"")
 def when_I_execute_command(context, command):
     run_in_context(context, command.format(context=context))
+
+
+@behave.step("I successfully execute \"{command}\"")
+def when_I_successfully_execute_command(context, command):
+    when_I_execute_command(context, command)
+    assert_exitcode(context, 0)
 
 
 @behave.step("I set LC_ALL to \"{value}\"")

--- a/dnf-behave-tests/features/alias-command.feature
+++ b/dnf-behave-tests/features/alias-command.feature
@@ -3,10 +3,7 @@
 Feature: Test for alias command
 
 Background:
-  Given I delete directory "/etc/dnf/aliases.d/"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I use repository "alias-command"
+  Given I use repository "alias-command"
 
 
 Scenario: Add alias

--- a/dnf-behave-tests/features/environment.py
+++ b/dnf-behave-tests/features/environment.py
@@ -177,6 +177,12 @@ def before_scenario(context, scenario):
             context.config.userdata.get('destructive', 'no') == 'yes'):
         scenario.skip(reason="DESTRUCTIVE")
 
+    # if we are skipping a scenario, don't create the environment
+    # in case of a destructive scenario, that could mean modifying the current (non-temporary) system!
+    if scenario.status == model.Status.skipped:
+        context.dnf = None
+        return
+
     context.dnf = DNFContext(context.config.userdata,
                              force_installroot='force_installroot' in scenario.tags,
                              no_installroot='no_installroot' in scenario.effective_tags)

--- a/dnf-behave-tests/features/history-error.feature
+++ b/dnf-behave-tests/features/history-error.feature
@@ -44,6 +44,17 @@ Given I successfully execute "chmod o+rwx {context.dnf.tempdir}"
   And file "{context.dnf.tempdir}/history.sqlite" exists
 
 
+@bz1634385
+@no_installroot
+Scenario: history database not present under a regular user
+ When I execute dnf with args "--setopt=persistdir={context.dnf.tempdir} repoquery --userinstalled" as an unprivileged user
+ Then the exit code is 0
+  And stderr is
+      """
+      History database is not readable, using in-memory database instead: Failed to access "{context.dnf.tempdir}/history.sqlite": Permission denied
+      """
+
+
 @bz1761976
 @no_installroot
 Scenario: read permission error on the history database

--- a/dnf-behave-tests/features/history-error.feature
+++ b/dnf-behave-tests/features/history-error.feature
@@ -1,5 +1,8 @@
 Feature: Handling of errors on the history database
 
+Background:
+Given I use repository "dnf-ci-fedora"
+
 
 Scenario: history list on a broken history database
 Given I create file "/var/lib/dnf/history.sqlite" with
@@ -28,4 +31,41 @@ Given I use repository "dnf-ci-fedora"
       History database is not writable: SQLite error on "{context.dnf.installroot}/var/lib/dnf/history.sqlite": Executing an SQL statement failed: file is not a database
       History database is not writable: SQLite error on "{context.dnf.installroot}/var/lib/dnf/history.sqlite": Executing an SQL statement failed: file is not a database
       Error: SQLite error on "{context.dnf.installroot}/var/lib/dnf/history.sqlite": Executing an SQL statement failed: file is not a database
+      """
+
+
+@bz1634385
+@no_installroot
+Scenario: history database not present under a regular user, who has write permission
+Given I successfully execute "chmod o+rwx {context.dnf.tempdir}"
+ When I execute dnf with args "--setopt=persistdir={context.dnf.tempdir} repoquery --userinstalled" as an unprivileged user
+ Then the exit code is 0
+  And stderr is empty
+  And file "{context.dnf.tempdir}/history.sqlite" exists
+
+
+@bz1761976
+@no_installroot
+Scenario: read permission error on the history database
+Given I successfully execute dnf with args "--setopt=persistdir={context.dnf.tempdir} install abcde"
+  And I successfully execute "chmod o-r {context.dnf.tempdir}/history.sqlite"
+ When I execute dnf with args "--setopt=persistdir={context.dnf.tempdir} history abcde" as an unprivileged user
+ Then the exit code is 0
+  And stderr is
+      """
+      History database is not readable, using in-memory database instead: Failed to access "{context.dnf.tempdir}/history.sqlite": Permission denied
+      """
+
+
+@bz1761976
+@no_installroot
+Scenario: read permission error on the history database directory
+Given I successfully execute dnf with args "--setopt=persistdir={context.dnf.tempdir} install abcde"
+  # executable permission on directory means its contents can't be read
+  And I successfully execute "chmod o-x {context.dnf.tempdir}"
+ When I execute dnf with args "--setopt=persistdir={context.dnf.tempdir} history abcde" as an unprivileged user
+ Then the exit code is 0
+  And stderr is
+      """
+      History database is not readable, using in-memory database instead: Failed to access "{context.dnf.tempdir}/history.sqlite": Permission denied
       """

--- a/dnf-behave-tests/features/installonly.feature
+++ b/dnf-behave-tests/features/installonly.feature
@@ -85,9 +85,7 @@ Scenario: Remove all installonly packages but keep the latest
 @no_installroot
 @destructive
 Scenario: Remove all installonly packages but keep the latest and running kernel-core-0:4.18.16-300.fc29.x86_64
-  Given I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I fake kernel release to "4.18.16-300.fc29.x86_64"
    When I execute dnf with args "install kernel-core --repofrompath=r,{context.dnf.repos[dnf-ci-fedora].path} --repo=r --nogpgcheck"
    Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/config-with-repos.feature
+++ b/dnf-behave-tests/features/microdnf/config-with-repos.feature
@@ -5,10 +5,7 @@ Feature: Repositories configured in main configuration file
 
 
 Background: Configure repositories in the main configuration file
-  Given I delete file "/etc/dnf/dnf.conf"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I create file "/etc/dnf/dnf.conf" with
+  Given I create file "/etc/dnf/dnf.conf" with
      """
      [main]
      gpgcheck = 0

--- a/dnf-behave-tests/features/microdnf/install-nodocs-1.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-1.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 Scenario: Install a documentation package from local repodata
 Given I use repository "microdnf-install-nodocs"
  When I execute microdnf with args "install man-pages"

--- a/dnf-behave-tests/features/microdnf/install-nodocs-2.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-2.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1769831
 Scenario: Install package with option from local repodata with local packages
 Given I use repository "microdnf-install-nodocs"

--- a/dnf-behave-tests/features/microdnf/install-nodocs-3.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-3.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1771012
 Scenario: Install package with --nodocs option from local repodata with local packages
 Given I use repository "microdnf-install-nodocs"

--- a/dnf-behave-tests/features/microdnf/install1.feature
+++ b/dnf-behave-tests/features/microdnf/install1.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1734350
 @bz1779757
 Scenario: Install package from local repodata with local packages

--- a/dnf-behave-tests/features/microdnf/install2.feature
+++ b/dnf-behave-tests/features/microdnf/install2.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1734350
 Scenario: Install package from local repodata with local xml:base
 #2. local repo with local packages (different package location specified using xml:base)

--- a/dnf-behave-tests/features/microdnf/install3.feature
+++ b/dnf-behave-tests/features/microdnf/install3.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1734350
 Scenario: Install package from local repodata with xml:base pointing to remote packages
 #3. local repo with remote packages (different package location specified using xml:base)

--- a/dnf-behave-tests/features/microdnf/install4.feature
+++ b/dnf-behave-tests/features/microdnf/install4.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1734350
 Scenario: Install packages from local repodata that have packages with xml:base pointing to a remote as well as local packages
 #4. local repo with local and remote packages; installing both at the same time.

--- a/dnf-behave-tests/features/microdnf/install5.feature
+++ b/dnf-behave-tests/features/microdnf/install5.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1734350
 Scenario: Install packages from remote repodata with remote packages
 #5. remote repo with remote packages

--- a/dnf-behave-tests/features/microdnf/install6.feature
+++ b/dnf-behave-tests/features/microdnf/install6.feature
@@ -2,12 +2,6 @@
 Feature: microdnf install command on packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1734350
 Scenario: Install packages from remote repodata with xml:base pointing to packages on different remote
 #6. remote repo with remote packages (different package location (different url) specified using xml:base)

--- a/dnf-behave-tests/features/microdnf/install7.feature
+++ b/dnf-behave-tests/features/microdnf/install7.feature
@@ -2,12 +2,6 @@
 Feature: Install package
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1691353
 Scenario: Install an RPM without null lines
   Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/features/microdnf/install8.feature
+++ b/dnf-behave-tests/features/microdnf/install8.feature
@@ -2,12 +2,6 @@
 Feature: microdnf is able to downgrade packages
 
 
-Background:
-Given I delete file "/etc/dnf/dnf.conf"
-  And I delete file "/etc/yum.repos.d/*.repo" with globs
-  And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 @bz1725863
 Scenario: Install a package specifying a lower version than currently installed
 Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/features/microdnf/install_weak_deps.feature
+++ b/dnf-behave-tests/features/microdnf/install_weak_deps.feature
@@ -6,10 +6,7 @@ Feature: Tests --setopt=install_weak_deps=
 
 
 Background: Prepare environment
-  Given I delete file "/etc/dnf/dnf.conf"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I execute microdnf with args "remove abcde flac"
+  Given I execute microdnf with args "remove abcde flac"
     And I use repository "dnf-ci-fedora"
 
 

--- a/dnf-behave-tests/features/microdnf/reinstall-reason.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall-reason.feature
@@ -3,12 +3,6 @@ Feature: Reinstall must keep the "reason" why a package was installed
   E.g. if package with dependency is installed, and the dependency is reinstalled, and the main package is then removed, the dependency is removed as well.
 
 
-Background:
-  Given I delete file "/etc/dnf/dnf.conf"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-
-
 # no bug, PR https://github.com/rpm-software-management/microdnf/pull/61
 @not.with_os=rhel__eq__8
 Scenario: Reinstall a dependency, and then remove the main package

--- a/dnf-behave-tests/features/microdnf/reinstall1.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall1.feature
@@ -3,10 +3,7 @@ Feature: Reinstall
 
 
 Background: Install CQRlib-devel and CQRlib
-  Given I delete file "/etc/dnf/dnf.conf"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "install CQRlib-devel"
    Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/reinstall2.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall2.feature
@@ -3,10 +3,7 @@ Feature: Reinstall
 
 
 Background: Install CQRlib-devel and CQRlib
-  Given I delete file "/etc/dnf/dnf.conf"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "install CQRlib-devel"
    Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/reinstall3.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall3.feature
@@ -3,10 +3,7 @@ Feature: Reinstall
 
 
 Background: Install CQRlib-devel and CQRlib
-  Given I delete file "/etc/dnf/dnf.conf"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "install CQRlib-devel"
    Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/repolist-disabled.feature
+++ b/dnf-behave-tests/features/microdnf/repolist-disabled.feature
@@ -4,10 +4,7 @@ Feature: Repolist when all repositories are disabled
 
 
 Background:
-  Given I delete file "/etc/dnf/dnf.conf"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I use repository "dnf-ci-fedora" with configuration
+  Given I use repository "dnf-ci-fedora" with configuration
         |key      | value |
         | enabled | 0     |
 

--- a/dnf-behave-tests/features/microdnf/repolist.feature
+++ b/dnf-behave-tests/features/microdnf/repolist.feature
@@ -4,10 +4,7 @@ Feature: Repolist
 
 
 Background: Using repositories dnf-ci-fedora and dnf-ci-thirdparty-updates
-  Given I delete file "/etc/dnf/dnf.conf"
-    And I delete file "/etc/yum.repos.d/*.repo" with globs
-    And I delete directory "/var/lib/dnf/modulefailsafe/"
-    And I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-thirdparty-updates"
     And I use repository "dnf-ci-fedora-updates" with configuration
         | key     | value |

--- a/dnf-behave-tests/features/microdnf/repoquery-globs.feature
+++ b/dnf-behave-tests/features/microdnf/repoquery-globs.feature
@@ -3,10 +3,7 @@
 Feature: Glob tests for expanding all the various glob patterns.
 
 Background:
- Given I delete file "/etc/dnf/dnf.conf"
-   And I delete file "/etc/yum.repos.d/*.repo" with globs
-   And I delete directory "/var/lib/dnf/modulefailsafe/"
-   And I use repository "repoquery-globs"
+ Given I use repository "repoquery-globs"
 
 
 # <name> globs

--- a/dnf-behave-tests/features/microdnf/repoquery.feature
+++ b/dnf-behave-tests/features/microdnf/repoquery.feature
@@ -3,10 +3,7 @@
 Feature: The common repoquery tests, core functionality, odds and ends.
 
 Background:
- Given I delete file "/etc/dnf/dnf.conf"
-   And I delete file "/etc/yum.repos.d/*.repo" with globs
-   And I delete directory "/var/lib/dnf/modulefailsafe/"
-   And I use repository "repoquery-main"
+ Given I use repository "repoquery-main"
 
 
 # simple nevra matching tests


### PR DESCRIPTION
Some generic improvements to the behave steps, as well as a step to run dnf under an unprivileged user.

Following that are tests for error handling of Swdb for an unprivileged user (permissions, database missing).

I've adopted @j-mracek's https://github.com/rpm-software-management/ci-dnf-stack/pull/810 and updated for the new step. @j-mracek please have a look, I've preserved your authorship even though I've modified the commit quite a bit. Hope you're happy with it :slightly_smiling_face: 

@dmach please feel free to check the test cases cover all the possible situations that can occur with Swdb, I couldn't think of more, seems there aren't that many in the end.

The tests are for https://github.com/rpm-software-management/libdnf/pull/935