### PR TITLE
Remove 'required' argument to make it compatible for rhel8 with pytho…

### DIFF
--- a/container-test
+++ b/container-test
@@ -43,7 +43,7 @@ def command_line_parser():
         help="Increase verbosity")
 
     subparsers = parser.add_subparsers(
-        dest="command", required=True, help="List of available commands:")
+        dest="command", help="List of available commands:")
 
     # build command
     build_parser = subparsers.add_parser(


### PR DESCRIPTION
Remove 'required' argument to make it compatible for RHEL 8 with python 3.6.