### PR TITLE
[Dockerfile] Fix dependency on langpacks

### DIFF
--- a/Dockerfile.f30
+++ b/Dockerfile.f30
@@ -59,8 +59,7 @@ RUN set -x && \
     dnf -y install \
         # behave and test requirements
         findutils \
-        glibc-all-langpacks \
-        langpacks-en \
+        glibc-langpack-en \
         libfaketime \
         python3-behave \
         python3-pexpect \

--- a/Dockerfile.f31
+++ b/Dockerfile.f31
@@ -59,8 +59,7 @@ RUN set -x && \
     dnf -y install \
         # behave and test requirements
         findutils \
-        glibc-all-langpacks \
-        langpacks-en \
+        glibc-langpack-en \
         libfaketime \
         python3-behave \
         python3-pexpect \


### PR DESCRIPTION
The locale used in encoding.feature are actually provided by
glibc-langpack-en. Previously, it worked because this package was
installed as a weak dependency, but it's better to not count on that.