### PR TITLE
Create the config file from the steps

### DIFF
--- a/dnf-behave-tests/features/append_options.feature
+++ b/dnf-behave-tests/features/append_options.feature
@@ -5,12 +5,9 @@ Feature: DNF test of append option
 
 Background: Enable repository and set excludes in configuration
   Given I use repository "dnf-ci-fedora-updates"
-    And I do not set config file
-    And I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    exclude = lame, lz4
-    """
+    And I configure dnf with
+        | key     | value     |
+        | exclude | lame, lz4 |
 
 
 Scenario: Test that excludes from config file are applied

--- a/dnf-behave-tests/features/config-best.feature
+++ b/dnf-behave-tests/features/config-best.feature
@@ -52,15 +52,6 @@ Scenario: When installing with option --nobest, install a package from repo with
 Scenario: When installing with best=1 set in dnf.conf, fail on broken packages, and advise to use --nobest
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
-    And I do not set config file
-    And I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    best=True
-    """
    When I execute dnf with args "install glibc -x glibc-common-0:2.28-26.fc29.x86_64"
    Then the exit code is 1
     And stdout contains "try to add .*'--nobest' to use not only best candidate packages"

--- a/dnf-behave-tests/features/encoding.feature
+++ b/dnf-behave-tests/features/encoding.feature
@@ -2,12 +2,9 @@ Feature: Test encoding
 
 
 Scenario: UTF-8 characters in .repo filename
-  Given I do not set config file
-    And I create file "/etc/dnf/dnf.conf" with
-        """
-        [main]
-        reposdir=/testrepos
-        """
+  Given I configure dnf with
+        | key      | value      |
+        | reposdir | /testrepos |
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key     | value                                            |
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora  |
@@ -22,12 +19,9 @@ Scenario: UTF-8 characters in .repo filename
 @not.with_os=rhel__eq__8
 @bz1803038
 Scenario: non-UTF-8 characters in .repo filename
-  Given I do not set config file
-    And I create file "/etc/dnf/dnf.conf" with
-        """
-        [main]
-        reposdir=/testrepos
-        """
+  Given I configure dnf with
+        | key      | value      |
+        | reposdir | /testrepos |
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key     | value                                            |
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora  |

--- a/dnf-behave-tests/features/install-installed.feature
+++ b/dnf-behave-tests/features/install-installed.feature
@@ -26,15 +26,6 @@ Scenario: Install installed RPM when upgrade is available with --best
 @bz1670776 @bz1671683
 Scenario: Install installed RPM when upgrade is available with best=True (in dnf.conf)
   Given I use repository "dnf-ci-fedora"
-    And I do not set config file
-    And I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    best=True
-    """
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following
@@ -58,15 +49,9 @@ Scenario: Install installed RPM when upgrade is available with best=True (in dnf
 @bz1670776 @bz1671683
 Scenario: Install installed RPM when upgrade is available with best=False (in dnf.conf)
   Given I use repository "dnf-ci-fedora"
-    And I do not set config file
-    And I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    best=False
-    """
+  Given I configure dnf with
+        | key  | value |
+        | best | False |
    When I execute dnf with args "install glibc"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/list.feature
+++ b/dnf-behave-tests/features/list.feature
@@ -217,7 +217,7 @@ Examples:
 Scenario: dnf list available pkgs with long names piped to grep
 Given I use repository "dnf-ci-thirdparty"
  When I execute dnf with args "clean all"
- When I execute "eval dnf -y --releasever={context.dnf.releasever} --installroot={context.dnf.installroot} --config={context.dnf.config} --setopt=module_platform_id={context.dnf.module_platform_id} --disableplugin='*' list available | grep 1" in "{context.dnf.installroot}"
+ When I execute "eval dnf -y --releasever={context.dnf.releasever} --installroot={context.dnf.installroot} --setopt=module_platform_id={context.dnf.module_platform_id} --disableplugin='*' list available | grep 1" in "{context.dnf.installroot}"
  Then the exit code is 0
  Then stdout contains "forTestingPurposesWeEvenHaveReallyLongVersions.x86_64\s+1435347658326856238756823658aaaa-1\s+dnf-ci-thirdparty"
 

--- a/dnf-behave-tests/features/microdnf/config-with-repos.feature
+++ b/dnf-behave-tests/features/microdnf/config-with-repos.feature
@@ -5,26 +5,21 @@ Feature: Repositories configured in main configuration file
 
 
 Background: Configure repositories in the main configuration file
-  Given I create file "/etc/dnf/dnf.conf" with
-     """
-     [main]
-     gpgcheck = 0
-     
-     [repo-A]
-     name = repo-A test repository
-     enabled = 1
-     baseurl = http://url.xyz
-     
-     [repo-B]
-     name = repo-B test repository
-     enabled = 0
-     baseurl = http://url.xyz
-     
-     [repo-C]
-     name = repo-C test repository
-     enabled = 1
-     baseurl = http://url.xyz
-     """
+  Given I configure dnf with
+        | key      | value                  |
+        | gpgcheck | 0                      |
+        | [repo-A] |                        |
+        | name     | repo-A test repository |
+        | enabled  | 1                      |
+        | baseurl  | http://url.xyz         |
+        | [repo-B] |                        |
+        | name     | repo-B test repository |
+        | enabled  | 0                      |
+        | baseurl  | http://url.xyz         |
+        | [repo-C] |                        |
+        | name     | repo-C test repository |
+        | enabled  | 1                      |
+        | baseurl  | http://url.xyz         |
 
 
 Scenario: Repositories configured only in the main configuration file

--- a/dnf-behave-tests/features/plugin-api.feature
+++ b/dnf-behave-tests/features/plugin-api.feature
@@ -3,12 +3,9 @@ Feature: Plugin API
 
 Background:
 Given I do not disable plugins
-  And I do not set config file
-  And I create and substitute file "/etc/dnf/dnf.conf" with
-  """
-  [main]
-  pluginpath={context.dnf.installroot}/plugins
-  """
+  And I configure dnf with
+      | key        | value                             |
+      | pluginpath | {context.dnf.installroot}/plugins |
 
 
 @bz1650446

--- a/dnf-behave-tests/features/plugin-enable.feature
+++ b/dnf-behave-tests/features/plugin-enable.feature
@@ -21,12 +21,9 @@ Given I create file "/etc/dnf/plugins/debuginfo-install.conf" with
   [main]
   enabled=0
   """
-Given I do not set config file
-  And I create and substitute file "/etc/dnf/dnf.conf" with
-  """
-  [main]
-  pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
-  """
+  And I configure dnf with
+      | key            | value                                     |
+      | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
  When I execute dnf with args "-v repolist"
  Then stdout does not contain "Loaded plugins:.* debuginfo-install.*"
 
@@ -38,11 +35,8 @@ Given I create file "/etc/dnf/plugins/debuginfo-install.conf" with
   [main]
   enabled=0
   """
-Given I do not set config file
-  And I create and substitute file "/etc/dnf/dnf.conf" with
-  """
-  [main]
-  pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
-  """
+  And I configure dnf with
+      | key            | value                                     |
+      | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
  When I execute dnf with args "-v repolist --enableplugin=debuginfo-install"
  Then stdout contains "Loaded plugins:.* debuginfo-install.*"

--- a/dnf-behave-tests/features/plugins-core/config-manager.feature
+++ b/dnf-behave-tests/features/plugins-core/config-manager.feature
@@ -172,8 +172,7 @@ Scenario: --setopt does not modify repo when used without --save and one argumen
 # Requires PR: https://github.com/rpm-software-management/dnf-plugins-core/pull/373
 @not.with_os=rhel__eq__8
 Scenario: config-manager --save saves to correct config file
-  Given I do not set config file
-    And I create file "alternative.conf" with
+  Given I create file "alternative.conf" with
         """
         [main]
         """

--- a/dnf-behave-tests/features/plugins-core/post-transaction-actions.feature
+++ b/dnf-behave-tests/features/plugins-core/post-transaction-actions.feature
@@ -4,21 +4,15 @@ Feature: Tests for post-transaction-actions plugin
 
 Background:
   Given I enable plugin "post-transaction-actions"
-    And I create and substitute file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
-    """
+    And I configure dnf with
+      | key            | value                                     |
+      | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
     And I create and substitute file "/etc/dnf/plugins/post-transaction-actions.conf" with
     """
     [main]
     enabled = 1
     actiondir = {context.dnf.installroot}/etc/dnf/plugins/post-transaction-actions.d/
     """
-    And I do not set config file
     And I use repository "dnf-ci-fedora"
 
 

--- a/dnf-behave-tests/features/plugins-core/versionlock-exclude.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-exclude.feature
@@ -5,14 +5,9 @@ Background: Set up versionlock infrastructure in the installroot
   Given I enable plugin "versionlock"
   # plugins do not honor installroot when searching their configuration
   # following steps are merely to set up versionlock plugin inside installroot
-  And I create and substitute file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
-    """
+  And I configure dnf with
+    | key            | value                                     |
+    | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
   And I create and substitute file "/etc/dnf/plugins/versionlock.conf" with
     """
     [main]
@@ -23,7 +18,6 @@ Background: Set up versionlock infrastructure in the installroot
     """
     !wget-0:1.19.6-5.fc29.*
     """
-  And I do not set config file
   # check that both excluded and newer versions of the package are available
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"

--- a/dnf-behave-tests/features/plugins-core/versionlock-list-manipulation.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-list-manipulation.feature
@@ -5,14 +5,9 @@ Background: Set up versionlock infrastructure in the installroot
   Given I enable plugin "versionlock"
   # plugins do not honor installroot when searching their configuration
   # all the next steps are merely to set up versionlock plugin inside installroot
-  And I create and substitute file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
-    """
+  And I configure dnf with
+    | key            | value                                     |
+    | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
   And I create and substitute file "/etc/dnf/plugins/versionlock.conf" with
     """
     [main]
@@ -22,7 +17,6 @@ Background: Set up versionlock infrastructure in the installroot
   And I create file "/etc/dnf/plugins/versionlock.list" with
     """
     """
-  And I do not set config file
 
 
 Scenario: Basic commands add/exclude/list/delete/clear for manipulation with versionlock.list file are working

--- a/dnf-behave-tests/features/plugins-core/versionlock-list.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-list.feature
@@ -5,14 +5,9 @@ Background: Set up versionlock infrastructure in the installroot
   Given I enable plugin "versionlock"
   # plugins do not honor installroot when searching their configuration
   # all the next steps are merely to set up versionlock plugin inside installroot
-  And I create and substitute file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
-    """
+  And I configure dnf with
+    | key            | value                                     |
+    | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
   And I create and substitute file "/etc/dnf/plugins/versionlock.conf" with
     """
     [main]
@@ -22,7 +17,6 @@ Background: Set up versionlock infrastructure in the installroot
   And I create file "/etc/dnf/plugins/versionlock.list" with
     """
     """
-  And I do not set config file
   # check that both locked and newer versions of the package are available
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"

--- a/dnf-behave-tests/features/plugins-core/versionlock-lock.feature
+++ b/dnf-behave-tests/features/plugins-core/versionlock-lock.feature
@@ -5,14 +5,9 @@ Background: Set up versionlock infrastructure in the installroot
   Given I enable plugin "versionlock"
   # plugins do not honor installroot when searching their configuration
   # all the next steps are merely to set up versionlock plugin inside installroot
-  And I create and substitute file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
-    """
+  And I configure dnf with
+    | key            | value                                     |
+    | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
   And I create and substitute file "/etc/dnf/plugins/versionlock.conf" with
     """
     [main]
@@ -23,7 +18,6 @@ Background: Set up versionlock infrastructure in the installroot
     """
     wget-0:1.19.5-5.fc29.*
     """
-  And I do not set config file
   # check that both locked and newer versions of the package are available
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"

--- a/dnf-behave-tests/features/plugins-path.feature
+++ b/dnf-behave-tests/features/plugins-path.feature
@@ -7,12 +7,9 @@ Scenario: Redirect pluginspath
    Then the exit code is 0
    When I execute dnf with args "versionlock --help"
    Then the exit code is 0
-  Given I do not set config file
-    And I create and substitute file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    pluginpath={context.dnf.installroot}/test/plugins
-    """
+  Given I configure dnf with
+        | key        | value                                  |
+        | pluginpath | {context.dnf.installroot}/test/plugins |
     And I create file "/test/plugins/download.py" with
     """
     import dnf.cli
@@ -47,12 +44,9 @@ Scenario: Redirect pluginsconfpath in dnf.conf
   Given I do not disable plugins
    When I execute dnf with args "versionlock"
    Then the exit code is 0
-  Given I do not set config file
-    And I create and substitute file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    pluginconfpath={context.dnf.installroot}/test/pluginconfpath
-    """
+  Given I configure dnf with
+        | key            | value                                         |
+        | pluginconfpath | {context.dnf.installroot}/test/pluginconfpath |
   Given I create file "/test/pluginconfpath/versionlock.conf" with
     """
     [main]

--- a/dnf-behave-tests/features/plugins-third/swidtags.feature
+++ b/dnf-behave-tests/features/plugins-third/swidtags.feature
@@ -40,21 +40,15 @@ Scenario: Run swidtags without command prints usage
 Scenario: SWID tags are locally generated
   Given I use repository "dnf-ci-fedora"
     # enable locally generated SWID tags
-    And I create and substitute file "/etc/dnf/dnf.conf" with
-      """
-      [main]
-      gpgcheck=1
-      installonly_limit=3
-      clean_requirements_on_remove=True
-      pluginconfpath={context.dnf.installroot}/etc/dnf/plugins
-      """
+  Given I configure dnf with
+        | key            | value                                         |
+        | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins     |
     And I create and substitute file "/etc/dnf/plugins/swidtags.conf" with
       """
       [main]
       enabled = 1
       rpm2swidtag_command = /usr/bin/rpm2swidtag
       """
-    And I do not set config file
     # make sure there are no swid tags
     And I delete directory "/var/lib/swidtag"
     # passive part of swidtags plugin generates tags after transaction

--- a/dnf-behave-tests/features/repo-sync.feature
+++ b/dnf-behave-tests/features/repo-sync.feature
@@ -4,15 +4,12 @@ Feature: Tests for the repository syncing functionality
 @bz1679509
 @bz1692452
 Scenario: The default value of skip_if_unavailable is False
-  Given I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    reposdir=/testrepos
-    """
+  Given I configure dnf with
+        | key      | value      |
+        | reposdir | /testrepos |
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key             | value              |
         | baseurl         | /non/existent/repo |
-    And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 1
     And stderr is
@@ -25,16 +22,13 @@ Scenario: The default value of skip_if_unavailable is False
 
 @bz1689931
 Scenario: There is global skip_if_unavailable option
-  Given I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    reposdir=/testrepos
-    skip_if_unavailable=True
-    """
+  Given I configure dnf with
+        | key                 | value      |
+        | reposdir            | /testrepos |
+        | skip_if_unavailable | True       |
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key             | value              |
         | baseurl         | /non/existent/repo |
-    And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 0
     And stdout matches line by line
@@ -52,16 +46,13 @@ Scenario: There is global skip_if_unavailable option
 
 
 Scenario: Per repo skip_if_unavailable configuration
-  Given I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    reposdir=/testrepos
-    """
+  Given I configure dnf with
+        | key      | value      |
+        | reposdir | /testrepos |
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key                 | value              |
         | baseurl             | /non/existent/repo |
         | skip_if_unavailable | True               |
-    And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 0
     And stdout matches line by line
@@ -80,17 +71,14 @@ Scenario: Per repo skip_if_unavailable configuration
 
 @bz1689931
 Scenario: The repo configuration takes precedence over the global one
-  Given I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    reposdir=/testrepos
-    skip_if_unavailable=True
-    """
+  Given I configure dnf with
+        | key                 | value      |
+        | reposdir            | /testrepos |
+        | skip_if_unavailable | True       |
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key                 | value              |
         | baseurl             | /non/existent/repo |
         | skip_if_unavailable | False              |
-    And I do not set config file
    When I execute dnf with args "makecache"
    Then the exit code is 1
     And stderr is

--- a/dnf-behave-tests/features/repository.feature
+++ b/dnf-behave-tests/features/repository.feature
@@ -3,7 +3,6 @@ Feature: Handling local base url in repository in installroot
 
 Scenario: Handling remote base url in repository in installroot
   Given I use repository "dnf-ci-fedora" as http
-    And I do not set config file
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -170,18 +170,6 @@ def given_I_do_not_assumeyes(context):
     context.dnf._set("assumeyes_option", "")
 
 
-@behave.given("I do not set config file")
-def step_impl(context):
-    context.dnf._set("config", "")
-
-
-@behave.given("I set config file to \"{configfile}\"")
-def step_impl(context, configfile):
-    configfile = configfile.format(context=context)
-    full_path = os.path.join(context.dnf.installroot, configfile.lstrip("/"))
-    context.dnf._set("config", full_path)
-
-
 @behave.given("I do not set releasever")
 def step_impl(context):
     context.dnf._set("releasever", "")

--- a/dnf-behave-tests/features/steps/config.py
+++ b/dnf-behave-tests/features/steps/config.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import behave
+
+from common.lib.behave_ext import check_context_table
+from lib.config import write_config
+
+
+@behave.step("I configure dnf with")
+def step_configure_dnf(context):
+    """
+    Merges the new configuration values with what is stored in DNFContext and
+    writes the config file at <installroot>/etc/dnf/dnf.conf.
+
+    [main] is the default section, you can add more sections like so:
+
+    Given I configure dnf with
+          | key          | value |
+          | best         | False |
+          | [my_section] |       |
+          | foo          | bar   |
+    """
+    check_context_table(context, ["key", "value"])
+    section = "[main]"
+    context.dnf.config.setdefault(section, {})
+    for k, v in context.table:
+        if k.startswith("[") and v == "":
+            section = k
+            context.dnf.config.setdefault(section, {})
+
+        context.dnf.config[section][k] = v
+
+    write_config(context)

--- a/dnf-behave-tests/features/steps/lib/config.py
+++ b/dnf-behave-tests/features/steps/lib/config.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+
+from common.lib.file import create_file_with_contents, ensure_directory_exists
+
+
+def write_config(context):
+    config_dir = os.path.join(context.dnf.installroot, "etc/dnf")
+    ensure_directory_exists(config_dir)
+
+    conf_text = ""
+    # sort and put [main] first
+    for section, values in \
+            sorted(list(context.dnf.config.items()), key=lambda i: "" if i[0] == "[main]" else i[0]):
+        conf_text += "%s\n" % section
+        for k, v in values.items():
+            if v != "":
+                conf_text += "%s=%s\n" % (k, v.format(context=context))
+
+    create_file_with_contents(os.path.join(config_dir, "dnf.conf"), conf_text)

--- a/dnf-behave-tests/features/transaction-output.feature
+++ b/dnf-behave-tests/features/transaction-output.feature
@@ -6,7 +6,7 @@ Scenario: Check whitespace between columns with long values in transaction table
 Given I use repository "dnf-ci-thirdparty"
  When I execute dnf with args "clean all"
  # Piping to grep is forcing DNF to print into non standard terminal which is by default limited to 80 columns.
-  And I execute "eval dnf -y --releasever={context.dnf.releasever} --installroot={context.dnf.installroot} --config={context.dnf.config} --setopt=module_platform_id={context.dnf.module_platform_id} --disableplugin='*' install forTestingPurposesWeEvenHaveReallyLongVersions | grep -v xxxxxx" in "{context.dnf.installroot}"
+  And I execute "eval dnf -y --releasever={context.dnf.releasever} --installroot={context.dnf.installroot} --setopt=module_platform_id={context.dnf.module_platform_id} --disableplugin='*' install forTestingPurposesWeEvenHaveReallyLongVersions | grep -v xxxxxx" in "{context.dnf.installroot}"
  Then the exit code is 0
   And Transaction is following
       | Action        | Package                                                                                    |

--- a/dnf-behave-tests/features/upgrade.feature
+++ b/dnf-behave-tests/features/upgrade.feature
@@ -53,15 +53,9 @@ Scenario: Upgrade all RPMs from multiple repositories with best=False
   Given I use repository "dnf-ci-fedora-updates"
   Given I use repository "dnf-ci-fedora-updates-testing"
     And I use repository "dnf-ci-thirdparty-updates"
-    And I do not set config file
-    And I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    best=False
-    """
+  Given I configure dnf with
+        | key  | value |
+        | best | False |
    When I execute dnf with args "upgrade"
    Then the exit code is 0
     And stderr is
@@ -87,15 +81,6 @@ Scenario: Upgrade all RPMs from multiple repositories with best=True
   Given I use repository "dnf-ci-fedora-updates"
   Given I use repository "dnf-ci-fedora-updates-testing"
     And I use repository "dnf-ci-thirdparty-updates"
-    And I do not set config file
-    And I create file "/etc/dnf/dnf.conf" with
-    """
-    [main]
-    gpgcheck=1
-    installonly_limit=3
-    clean_requirements_on_remove=True
-    best=True
-    """
    When I execute dnf with args "upgrade"
    Then the exit code is 1
     And stderr is

--- a/dnf-behave-tests/fixtures/dnf.conf
+++ b/dnf-behave-tests/fixtures/dnf.conf
@@ -1,5 +1,0 @@
-[main]
-gpgcheck=1
-installonly_limit=3
-clean_requirements_on_remove=True
-best=True


### PR DESCRIPTION
Creates the dnf.conf in the default path inside installroot from behave steps.

@kontura it uses an empty value to unset a config option. We may need to use something else (like "<unset>" or any special placeholder?) for it to work with the protected packages option, since I think you need to set it to an empty value?