### PR TITLE
copr plugin tests

### DIFF
--- a/dnf-behave-tests/features/plugins-core/copr.feature
+++ b/dnf-behave-tests/features/plugins-core/copr.feature
@@ -1,0 +1,203 @@
+@destructive
+Feature: Test the COPR plugin
+
+Background:
+Given I enable plugin "copr"
+  And I create directory "/{context.dnf.tempdir}/copr"
+  And I start http server "copr" at "{context.dnf.tempdir}/copr"
+  And I create and substitute file "//etc/dnf/plugins/copr.conf" with
+      """
+      [main]
+      distribution = Fedora
+      releasever = 30
+      [testhub]
+      hostname = localhost
+      protocol = http
+      port = {context.dnf.ports[copr]}
+      """
+  And I create and substitute file "/{context.dnf.tempdir}/copr/coprs/testuser/testproject/repo/fedora-30/dnf.repo" with
+      """
+      [copr:localhost:testuser:testproject]
+      name=Copr test project
+      baseurl=http://project_base_url/
+      type=rpm-md
+      """
+
+
+Scenario: Test enabling and disabling a project
+ When I execute dnf with args "copr enable testhub/testuser/testproject"
+ Then the exit code is 0
+  And stdout is
+      """
+      Repository successfully enabled.
+      """
+  And stderr is
+      """
+      Enabling a Copr repository. Please note that this repository is not part
+      of the main distribution, and quality may vary.
+
+      The Fedora Project does not exercise any power over the contents of
+      this repository beyond the rules outlined in the Copr FAQ at
+      <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+      and packages are not held to any quality or security level.
+
+      Please do not file bug reports about these packages in Fedora
+      Bugzilla. In case of problems, contact the owner of this repository.
+      """
+ When I execute dnf with args "copr disable testhub/testuser/testproject"
+ Then the exit code is 0
+  And stdout is
+      """
+      Repository successfully disabled.
+      """
+  And stderr is empty
+
+
+Scenario: Test disabling a project that is not enabled
+ When I execute dnf with args "copr disable testhub/testuser/testproject"
+ Then the exit code is 1
+  And stderr is
+      """
+      Error: Failed to disable copr repo testuser/testproject
+      """
+
+
+Scenario: Test enabling a non-existent repo
+ When I execute dnf with args "copr enable testhub/testuser/nonexistent"
+ Then the exit code is 1
+  And stderr is
+      """
+      Enabling a Copr repository. Please note that this repository is not part
+      of the main distribution, and quality may vary.
+
+      The Fedora Project does not exercise any power over the contents of
+      this repository beyond the rules outlined in the Copr FAQ at
+      <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+      and packages are not held to any quality or security level.
+
+      Please do not file bug reports about these packages in Fedora
+      Bugzilla. In case of problems, contact the owner of this repository.
+      Error: Such repository does not exist.
+      """
+
+
+Scenario: Test enabling a repo with invalid copr configuration
+Given I create and substitute file "//etc/dnf/plugins/copr.conf" with
+      """
+      [main]
+      distribution = Fedora
+      releasever = 30
+      [testhub]
+      hostname = localhost
+      protocol = http
+      # hopefully nothing is ever listening on this port
+      port = 2
+      """
+ When I execute dnf with args "copr enable testhub/testuser/testproject"
+ Then the exit code is 1
+  And stderr is
+      """
+      Enabling a Copr repository. Please note that this repository is not part
+      of the main distribution, and quality may vary.
+
+      The Fedora Project does not exercise any power over the contents of
+      this repository beyond the rules outlined in the Copr FAQ at
+      <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+      and packages are not held to any quality or security level.
+
+      Please do not file bug reports about these packages in Fedora
+      Bugzilla. In case of problems, contact the owner of this repository.
+      Curl error (7): Couldn't connect to server for http://localhost:2/coprs/testuser/testproject/repo/fedora-30/dnf.repo?arch=x86_64 [Failed to connect to localhost port 2: Connection refused]
+      """
+
+
+Scenario: Test enabling a repo without any builds for the distribution
+Given I create and substitute file "//etc/dnf/plugins/copr.conf" with
+      """
+      [main]
+      distribution = Fedora
+      releasever = 31
+      [testhub]
+      hostname = localhost
+      protocol = http
+      port = {context.dnf.ports[copr]}
+      """
+ When I execute dnf with args "copr enable testhub/testuser/testproject"
+ Then the exit code is 1
+  And stderr is
+      """
+      Enabling a Copr repository. Please note that this repository is not part
+      of the main distribution, and quality may vary.
+
+      The Fedora Project does not exercise any power over the contents of
+      this repository beyond the rules outlined in the Copr FAQ at
+      <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+      and packages are not held to any quality or security level.
+
+      Please do not file bug reports about these packages in Fedora
+      Bugzilla. In case of problems, contact the owner of this repository.
+      Error: This repository does not have any builds yet so you cannot enable it now.
+      """
+
+
+Scenario: Test enabling and disabling a repository with dependencies
+Given I create and substitute file "/{context.dnf.tempdir}/copr/coprs/testuser/project-with-deps/repo/fedora-30/dnf.repo" with
+      """
+      [copr:localhost:testuser:project-with-deps]
+      name=Copr test project
+      baseurl=http://repo_base_url/
+      type=rpm-md
+
+      [coprdep:localhost:testuser:dep1]
+      name=Copr dependency 1
+      baseurl=http://repo_base_url/
+      type=rpm-md
+
+      [coprdep:some-external-repo]
+      name=Copr dependency 2
+      baseurl=https://repo_base_url/
+      type=rpm-md
+      """
+ When I execute dnf with args "copr enable testhub/testuser/project-with-deps"
+ Then the exit code is 0
+  And stdout is
+      """
+      Repository successfully enabled.
+      """
+  And stderr is
+      """
+      Enabling a Copr repository. Please note that this repository is not part
+      of the main distribution, and quality may vary.
+
+      The Fedora Project does not exercise any power over the contents of
+      this repository beyond the rules outlined in the Copr FAQ at
+      <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+      and packages are not held to any quality or security level.
+
+      Please do not file bug reports about these packages in Fedora
+      Bugzilla. In case of problems, contact the owner of this repository.
+
+      Maintainer of the enabled Copr repository decided to make
+      it dependent on other repositories. Such repositories are
+      usually necessary for successful installation of RPMs from
+      the main Copr repository (they provide runtime dependencies).
+
+      Be aware that the note about quality and bug-reporting
+      above applies here too, Fedora Project doesn't control the
+      content. Please review the list:
+
+       1. [coprdep:localhost:testuser:dep1]
+          baseurl=http://repo_base_url/
+
+       2. [coprdep:some-external-repo]
+          baseurl=https://repo_base_url/
+
+      These repositories have been enabled automatically.
+      """
+ When I execute dnf with args "copr disable testhub/testuser/project-with-deps"
+ Then the exit code is 0
+  And stdout is
+      """
+      Repository successfully disabled.
+      """
+  And stderr is empty

--- a/dnf-behave-tests/features/steps/fixtures/ftpd.py
+++ b/dnf-behave-tests/features/steps/fixtures/ftpd.py
@@ -28,19 +28,22 @@ class FtpServerContext(ServerContext):
     """
 
     @staticmethod
-    def ftp_server(address, path):
-        os.chdir(path)
-        authorizer = DummyAuthorizer()
-        # Read only anonymous user
-        authorizer.add_anonymous(path)
+    def ftp_server(address, path, error):
+        try:
+            os.chdir(path)
+            authorizer = DummyAuthorizer()
+            # Read only anonymous user
+            authorizer.add_anonymous(path)
 
-        handler = NoLogFtpHandler
-        handler.authorizer = authorizer
+            handler = NoLogFtpHandler
+            handler.authorizer = authorizer
 
-        # with 'localhost' in the address, the FTPServer defaults to IPv6; the
-        # ready check would then need to be opening an AF_INET6 socket...
-        ftpd = FTPServer(('127.0.0.1', address[1]), handler)
-        ftpd.serve_forever()
+            # with 'localhost' in the address, the FTPServer defaults to IPv6; the
+            # ready check would then need to be opening an AF_INET6 socket...
+            ftpd = FTPServer(('127.0.0.1', address[1]), handler)
+            ftpd.serve_forever()
+        except Exception as e:
+            error.value = str(e)
 
     def new_ftp_server(self, path):
         return self._start_server(path, self.ftp_server)

--- a/dnf-behave-tests/features/steps/fixtures/httpd.py
+++ b/dnf-behave-tests/features/steps/fixtures/httpd.py
@@ -68,23 +68,29 @@ class HttpServerContext(ServerContext):
     """
 
     @staticmethod
-    def http_server(address, path, log, conf):
-        os.chdir(path)
-        httpd = TCPServer(address, LoggingHttpHandler)
-        httpd._log = log
-        httpd._conf = conf
-        httpd.serve_forever()
+    def http_server(address, path, error, log, conf):
+        try:
+            os.chdir(path)
+            httpd = TCPServer(address, LoggingHttpHandler)
+            httpd._log = log
+            httpd._conf = conf
+            httpd.serve_forever()
+        except Exception as e:
+            error.value = str(e)
 
     @staticmethod
-    def https_server(address, path, cacert, cert, key, client_verification=False):
-        os.chdir(path)
-        httpd = TCPServer(address, NoLogHttpHandler)
-        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=cacert)
-        context.load_cert_chain(certfile=cert, keyfile=key)
-        if client_verification:
-            context.verify_mode = ssl.CERT_REQUIRED
-        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
-        httpd.serve_forever()
+    def https_server(address, path, error, cacert, cert, key, client_verification=False):
+        try:
+            os.chdir(path)
+            httpd = TCPServer(address, NoLogHttpHandler)
+            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=cacert)
+            context.load_cert_chain(certfile=cert, keyfile=key)
+            if client_verification:
+                context.verify_mode = ssl.CERT_REQUIRED
+            httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+            httpd.serve_forever()
+        except Exception as e:
+            error.value = str(e)
 
     def __init__(self):
         super(HttpServerContext, self).__init__()

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -4,9 +4,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import behave
-from fnmatch import fnmatch
 import os
-import parse
+
+# make sure the server_type is registered in behave
+import steps.server
 
 from common.lib.behave_ext import check_context_table
 from common.lib.checksum import sha256_checksum
@@ -205,15 +206,7 @@ def step_configure_new_repository(context, repo):
     write_repo_config(context, repo, repo_config(repo, dict(context.table)))
 
 
-@parse.with_pattern(r"http|https|ftp")
-def parse_repo_type(text):
-    if text in ("http", "https", "ftp"):
-        return text
-    assert False
-behave.register_type(repo_type=parse_repo_type)
-
-
-@behave.step("I make packages from repository \"{repo}\" accessible via {rtype:repo_type}")
+@behave.step("I make packages from repository \"{repo}\" accessible via {rtype:server_type}")
 def make_repo_packages_accessible(context, repo, rtype):
     """
     Starts a new HTTP/FTP server at the repository's location and saves
@@ -225,7 +218,7 @@ def make_repo_packages_accessible(context, repo, rtype):
     context.dnf.ports[repo] = port
 
 
-@behave.step("I use repository \"{repo}\" as {rtype:repo_type}")
+@behave.step("I use repository \"{repo}\" as {rtype:server_type}")
 def step_use_repository_as(context, repo, rtype):
     """
     Starts a new HTTP/FTP server at the repository's location and then
@@ -289,31 +282,6 @@ def step_set_up_metalink_for_repository(context, repo):
     create_repo_conf(context, repo)
 
 
-@behave.step("the server starts responding with HTTP status code {code}")
-def step_server_down(context, code):
-    context.scenario.httpd.conf['status'] = int(code)
-
-
-@behave.step("I start capturing outbound HTTP requests")
-def step_start_http_capture(context):
-    context.scenario.httpd.conf['logging'] = True
-
-
-@behave.step('I require client certificate verification with certificate "{client_cert}" and key "{client_key}"')
-def step_impl(context, client_cert, client_key):
-    if "client_ssl" not in context.dnf:
-        context.dnf["client_ssl"] = dict()
-    context.dnf["client_ssl"]["certificate"] = os.path.join(context.dnf.fixturesdir,
-                                                            client_cert)
-    context.dnf["client_ssl"]["key"] = os.path.join(context.dnf.fixturesdir,
-                                                    client_key)
-
-
-@behave.step("I forget any HTTP requests captured so far")
-def step_clear_http_logs(context):
-    context.scenario.httpd.clear_log()
-
-
 @behave.step("I am running a system identified as the \"{system}\"")
 def given_system(context, system):
     behave.use_fixture(osrelease_fixture, context)
@@ -332,59 +300,3 @@ def given_system(context, system):
 def given_no_osrelease(context):
     behave.use_fixture(osrelease_fixture, context)
     context.scenario.osrelease.delete()
-
-
-@behave.step("{quantifier} HTTP {command} request should match")
-@behave.step("{quantifier} HTTP {command} requests should match")
-def step_check_http_log(context, quantifier, command):
-    # Obtain the httpd log for this command
-    log = [record
-           for record in context.scenario.httpd.log
-           if record.command == command]
-    assert log, 'No HTTP requests have been received!'
-
-    # Find matches
-    if 'header' in context.table.headings:
-        good = [record
-                for record in log
-                for row in context.table
-                if record.headers[row['header']] == row['value']]
-    elif 'path' in context.table.headings:
-        good = [record
-                for record in log
-                for row in context.table
-                if fnmatch(record.path, row['path'])]
-    else:
-        assert False, 'No supported column heading found in the table'
-
-    bad = [record for record in log if record not in good]
-
-    def dump(log):
-        return '\n' + '\n'.join(map(str, log)) + '\n'
-
-    if quantifier == 'every':
-        assert not bad, \
-            '%i requests did not match:%s' \
-            % (len(bad), dump(bad))
-    elif quantifier.startswith('exactly '):
-        num = quantifier.split(' ')[1]
-        if num == 'one':
-            num = 1
-        num = int(num)
-        assert len(good) == num, \
-            'Expected %i matches but got %i instead, full log:%s' \
-            % (num, len(good), dump(log))
-    elif quantifier == 'no':
-        assert not good, \
-            'Expected no matches but got %i:%s' \
-            % (len(good), dump(good))
-
-
-@behave.step("HTTP log contains")
-def step_http_log_contains(context):
-    expected = context.text.format(context=context).rstrip().split('\n')
-    found = ["%s %s" % (r.command, r.path) for r in context.scenario.httpd.log]
-
-    for e in expected:
-        if e not in found:
-            raise AssertionError('HTTP log does not contain "%s": %s' % (e, "\n" + "\n".join(found) + "\n"))

--- a/dnf-behave-tests/features/steps/server.py
+++ b/dnf-behave-tests/features/steps/server.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import behave
+from fnmatch import fnmatch
+import os
+import parse
+
+from fixtures import start_server_based_on_type
+
+
+@parse.with_pattern(r"http|https|ftp")
+def parse_server_type(text):
+    if text in ("http", "https", "ftp"):
+        return text
+    assert False
+behave.register_type(server_type=parse_server_type)
+
+
+@behave.step("the server starts responding with HTTP status code {code}")
+def step_server_down(context, code):
+    context.scenario.httpd.conf['status'] = int(code)
+
+
+@behave.step("I start capturing outbound HTTP requests")
+def step_start_http_capture(context):
+    context.scenario.httpd.conf['logging'] = True
+
+
+@behave.step('I require client certificate verification with certificate "{client_cert}" and key "{client_key}"')
+def step_impl(context, client_cert, client_key):
+    if "client_ssl" not in context.dnf:
+        context.dnf["client_ssl"] = dict()
+    context.dnf["client_ssl"]["certificate"] = os.path.join(context.dnf.fixturesdir,
+                                                            client_cert)
+    context.dnf["client_ssl"]["key"] = os.path.join(context.dnf.fixturesdir,
+                                                    client_key)
+
+
+@behave.step("I forget any HTTP requests captured so far")
+def step_clear_http_logs(context):
+    context.scenario.httpd.clear_log()
+
+
+@behave.step("{quantifier} HTTP {command} request should match")
+@behave.step("{quantifier} HTTP {command} requests should match")
+def step_check_http_log(context, quantifier, command):
+    # Obtain the httpd log for this command
+    log = [record
+           for record in context.scenario.httpd.log
+           if record.command == command]
+    assert log, 'No HTTP requests have been received!'
+
+    # Find matches
+    if 'header' in context.table.headings:
+        good = [record
+                for record in log
+                for row in context.table
+                if record.headers[row['header']] == row['value']]
+    elif 'path' in context.table.headings:
+        good = [record
+                for record in log
+                for row in context.table
+                if fnmatch(record.path, row['path'])]
+    else:
+        assert False, 'No supported column heading found in the table'
+
+    bad = [record for record in log if record not in good]
+
+    def dump(log):
+        return '\n' + '\n'.join(map(str, log)) + '\n'
+
+    if quantifier == 'every':
+        assert not bad, \
+            '%i requests did not match:%s' \
+            % (len(bad), dump(bad))
+    elif quantifier.startswith('exactly '):
+        num = quantifier.split(' ')[1]
+        if num == 'one':
+            num = 1
+        num = int(num)
+        assert len(good) == num, \
+            'Expected %i matches but got %i instead, full log:%s' \
+            % (num, len(good), dump(log))
+    elif quantifier == 'no':
+        assert not good, \
+            'Expected no matches but got %i:%s' \
+            % (len(good), dump(good))
+
+
+@behave.step("HTTP log contains")
+def step_http_log_contains(context):
+    expected = context.text.format(context=context).rstrip().split('\n')
+    found = ["%s %s" % (r.command, r.path) for r in context.scenario.httpd.log]
+
+    for e in expected:
+        if e not in found:
+            raise AssertionError('HTTP log does not contain "%s": %s' % (e, "\n" + "\n".join(found) + "\n"))

--- a/dnf-behave-tests/features/steps/server.py
+++ b/dnf-behave-tests/features/steps/server.py
@@ -19,6 +19,15 @@ def parse_server_type(text):
 behave.register_type(server_type=parse_server_type)
 
 
+@behave.step("I start {stype:server_type} server \"{id}\" at \"{path}\"")
+def step_start_new_server(context, stype, id, path):
+    """
+    Starts a new HTTP/FTP server at path. The port can then be retrieved through the id.
+    """
+    host, port = start_server_based_on_type(context, path.format(context=context), stype)
+    context.dnf.ports[id] = port
+
+
 @behave.step("the server starts responding with HTTP status code {code}")
 def step_server_down(context, code):
     context.scenario.httpd.conf['status'] = int(code)


### PR DESCRIPTION
Basic set of tests for the copr plugin, including a test for https://github.com/rpm-software-management/dnf-plugins-core/pull/388.

Also adds a step for creating a stand-alone http server and printing of server failures to the output.

@dturecek @praiskup @xsuchy