### PR TITLE
Backport for 8.2.0

### DIFF
--- a/dnf-behave-tests/features/repoquery/deps.feature
+++ b/dnf-behave-tests/features/repoquery/deps.feature
@@ -343,6 +343,26 @@ Scenario: repoquery --whatrequires NAME --whatrequires NAME
       middle2-1:1.0-1.x86_64
       """
 
+Scenario: repoquery --whatrequires NAME (buildrequires, srpm)
+ When I execute dnf with args "repoquery --whatrequires bottom5-prov1"
+ Then the exit code is 0
+  And stdout is
+      """
+      middle3-1:1.0-1.x86_64
+      middle4-1:1.0-1.src
+      """
+
+@bz1812596
+Scenario: repoquery --whatrequires NEVRA (buildrequires, srpm)
+ When I execute dnf with args "repoquery --whatrequires bottom5"
+ Then the exit code is 0
+  And stdout is
+      """
+      middle3-1:1.0-1.x86_64
+      middle4-1:1.0-1.src
+      middle5-1:1.0-1.x86_64
+      """
+
 
 # --whatprovides
 Scenario: repoquery --whatprovides NAME

--- a/dnf-behave-tests/features/repoquery/deps.feature
+++ b/dnf-behave-tests/features/repoquery/deps.feature
@@ -235,6 +235,7 @@ Scenario: repoquery --whatrequires NAME
       middle1-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       middle2-1:2.0-1.x86_64
+      middle3-1:1.0-1.x86_64
       """
 
 @bz1782906

--- a/dnf-behave-tests/features/repoquery/deps.feature
+++ b/dnf-behave-tests/features/repoquery/deps.feature
@@ -264,6 +264,7 @@ Scenario: repoquery --whatrequires NAME (file provide)
   And stdout is
       """
       middle1-1:2.0-1.x86_64
+      middle3-1:1.0-1.x86_64
       """
 
 Scenario: repoquery --whatrequires PROVIDE_NAME

--- a/dnf-behave-tests/features/repoquery/rich-deps.feature
+++ b/dnf-behave-tests/features/repoquery/rich-deps.feature
@@ -93,7 +93,6 @@ Given I successfully execute dnf with args "install x1"
       a1-0:1.0-1.x86_64
       """
 
-@not.with_os=rhel__eq__8
 @bz1534123
 @bz1698034
 Scenario: repoquery --whatconflicts for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)"
@@ -158,7 +157,6 @@ Scenario: repoquery --whatsuggests for "((b1 with b1-prov2 > 1.7) or (c1 <= 1.0 
       a1-0:1.0-1.x86_64
       """
 
-@not.with_os=rhel__eq__8
 @bz1534123
 @bz1698034
 Scenario: repoquery --whatsuggests for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" - only d1-1.0 should match

--- a/dnf-behave-tests/fixtures/specs/repoquery-deps/bottom5-1:1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-deps/bottom5-1:1.0-1.spec
@@ -1,0 +1,19 @@
+Name:           bottom5
+Epoch:          1
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Provides:       bottom5-prov1
+Provides:       python3dist(bottom5)
+
+Summary:        Bottom level package (other packages depend on it).
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-deps/middle3-1:1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-deps/middle3-1:1.0-1.spec
@@ -1,0 +1,21 @@
+Name:           middle3
+Epoch:          1
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Requires(post):      bottom1-prov1
+Requires(pre):       bottom3-prov1
+Requires(postun):    bottom4-prov1
+Requires(preun):     bottom5-prov1
+
+Summary:        Mid level package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-deps/middle4-1:1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-deps/middle4-1:1.0-1.spec
@@ -1,0 +1,18 @@
+Name:           middle4
+Epoch:          1
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+BuildRequires:  bottom5-prov1
+
+Summary:        Mid level package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-deps/middle5-1:1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-deps/middle5-1:1.0-1.spec
@@ -1,0 +1,18 @@
+Name:           middle5
+Epoch:          1
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Requires:       python3dist(bottom5)
+
+Summary:        Mid level package.
+
+%description
+Dummy.
+
+%files
+
+%changelog


### PR DESCRIPTION
Backporting tests for a repoquery fix.
rich deps matching by using provide expansion from libdnf

includes:
https://github.com/rpm-software-management/ci-dnf-stack/pull/577
https://github.com/rpm-software-management/ci-dnf-stack/pull/805
https://github.com/rpm-software-management/ci-dnf-stack/pull/807

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1830952