### PR TITLE
Fix history longer than 80 scenario

### DIFF
--- a/dnf-behave-tests/features/history-list.feature
+++ b/dnf-behave-tests/features/history-list.feature
@@ -194,12 +194,13 @@ Scenario: history lame (no transaction with such package)
 
 @bz1786335
 @bz1786316
+# TODO change this to actually verify stdout
 Scenario: history longer than 80 characters
- When I execute dnf with args "history | head -1 | wc -c"
+ When I execute dnf with args "history | head -1 | wc -c | wc -c"
  Then the exit code is 0
   And stdout is
   """
-  244
+  4
   """
 
 @bz1786335


### PR DESCRIPTION
This scenario is failing for different installroot paths
Now it checks that the length is a 3 digit number