### PR TITLE
Improved shell scripts to be more robust (tested with ShellCheck)

### DIFF
--- a/dnf-behave-tests/fixtures/certificates/generate_certificates.sh
+++ b/dnf-behave-tests/fixtures/certificates/generate_certificates.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
-PROG_PATH=$(dirname $(readlink -f -- $0))
-. ${PROG_PATH}/x509certgen
+PROG_PATH="$(dirname "$(readlink -f -- "$0")")"
+# shellcheck source=dnf-behave-tests/fixtures/certificates/x509certgen
+. "${PROG_PATH}/x509certgen"
 rm -rf "$PROG_PATH/testcerts"
 mkdir -p "$PROG_PATH/testcerts"
 pushd "$PROG_PATH/testcerts"

--- a/dnf-behave-tests/fixtures/gpgkeys/sign.sh
+++ b/dnf-behave-tests/fixtures/gpgkeys/sign.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 set -xe
 
-DIR=$(dirname $(readlink -f $0))
+DIR=$(dirname "$(readlink -f "$0")")
 REPODIR="$DIR/../repos"
 SPECS="$DIR/../specs"
 
-rm -r ${DIR}/keys || true
-mkdir ${DIR}/keys
+rm -r "${DIR}/keys" || true
+mkdir "${DIR}/keys"
 
-for KEY_NAME in $(ls ${DIR}/keyspecs); do
+KEYSPECS=$(ls "${DIR}/keyspecs")
+for KEY_NAME in $KEYSPECS; do
 
     # set defaults
     USE_SIGN_SUBKEY=0
@@ -16,24 +17,25 @@ for KEY_NAME in $(ls ${DIR}/keyspecs); do
 
     # read config file for key
     if [ -f "${DIR}/keyspecs/${KEY_NAME}/config" ]; then
+        # shellcheck source=dnf-behave-tests/fixtures/gpgkeys/keyspecs/dnf-ci-gpg/config
         . "${DIR}/keyspecs/${KEY_NAME}/config"
     fi
 
     KEY_DIR="${DIR}/keys/${KEY_NAME}"
-    mkdir ${KEY_DIR}
+    mkdir "${KEY_DIR}"
 
     # create key (without password, without expire)
-    HOME=${KEY_DIR} gpg2 --batch --passphrase '' --quick-gen-key ${KEY_NAME} default default 0
+    HOME=${KEY_DIR} gpg2 --batch --passphrase '' --quick-gen-key "${KEY_NAME}" default default 0
 
     if [ "${USE_SIGN_SUBKEY}" = "1" ]; then
         # add sign subkey
-        KEY_ID=$(HOME=${KEY_DIR} gpg2 --list-keys --with-colons ${KEY_NAME}  | grep '^fpr:' | head -n 1 | cut -d : -f 10)
-        HOME=${KEY_DIR} gpg2 --batch --passphrase '' --quick-add-key ${KEY_ID} default sign 0
+        KEY_ID=$(HOME=${KEY_DIR} gpg2 --list-keys --with-colons "${KEY_NAME}"  | grep '^fpr:' | head -n 1 | cut -d : -f 10)
+        HOME=${KEY_DIR} gpg2 --batch --passphrase '' --quick-add-key "${KEY_ID}" default sign 0
     fi
 
     # export public and private key
-    HOME=${KEY_DIR} gpg2 --export -a ${KEY_NAME} > "${KEY_DIR}/${KEY_NAME}-public"
-    HOME=${KEY_DIR} gpg2 --export-secret-keys -a ${KEY_NAME} > "${KEY_DIR}/${KEY_NAME}-private"
+    HOME=${KEY_DIR} gpg2 --export -a "${KEY_NAME}" > "${KEY_DIR}/${KEY_NAME}-public"
+    HOME=${KEY_DIR} gpg2 --export-secret-keys -a "${KEY_NAME}" > "${KEY_DIR}/${KEY_NAME}-private"
 
     if [ "${USE_NOEOF_KEYS}" = "1" ]; then
       # remove EOF from keyfiles
@@ -48,8 +50,8 @@ for KEY_NAME in $(ls ${DIR}/keyspecs); do
 EOF
 
     # sign packages
-    for package in $(cat "${DIR}/keyspecs/${KEY_NAME}/packages"); do
+    while IFS= read -r package; do
         HOME=${KEY_DIR} rpm --addsign "${REPODIR}/${package}"
-    done
+    done < "${DIR}/keyspecs/${KEY_NAME}/packages"
 done
 

--- a/dnf-behave-tests/fixtures/specs/break-packages.sh
+++ b/dnf-behave-tests/fixtures/specs/break-packages.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-DIR=$(dirname $(readlink -f $0))
+DIR="$(dirname "$(readlink -f "$0")")"
 REPODIR="${DIR}/../repos"
 
 # broken-package in dnf-ci-gpg must have incorrect checksum (appending at the end is enough)
-echo "broken-package" >> ${REPODIR}/dnf-ci-gpg/noarch/broken-package-0.2.4-1.fc29.noarch.rpm
+echo "broken-package" >> "${REPODIR}/dnf-ci-gpg/noarch/broken-package-0.2.4-1.fc29.noarch.rpm"
 

--- a/dnf-behave-tests/fixtures/specs/build.sh
+++ b/dnf-behave-tests/fixtures/specs/build.sh
@@ -5,7 +5,7 @@ export LC_ALL=C
 
 set -e
 
-DIR=$(dirname $(readlink -f $0))
+DIR="$(dirname "$(readlink -f "$0")")"
 ARCH="x86_64"
 DIST=".fc29"
 REPODIR="$DIR/../repos"
@@ -31,23 +31,23 @@ done
 
 if [ "$FORCE_REBUILD" = true ]; then
     # remove all generated content
-    find $DIR -name *.sha256 -delete
+    find "$DIR" -name "*.sha256" -delete
     rm -rf "$REPODIR"
 fi
 
 mkdir -p "$REPODIR"
 
-for path in $DIR/*/*.spec; do
-    REPO=$(basename $(dirname $path))
-    SPEC_NAME=$(basename $path)
-    SPEC_DIR=$(dirname $path)
+for path in "$DIR"/*/*.spec; do
+    REPO="$(basename "$(dirname "$path")")"
+    SPEC_NAME=$(basename "$path")
+    SPEC_DIR=$(dirname "$path")
     CSUM_FILE="$SPEC_NAME.sha256"
     CSUM_CHANGED=0
 
     # detect spec change -> force rebuild
     pushd "$SPEC_DIR" > /dev/null
     if [ -f "$CSUM_FILE" ]; then
-        sha256sum -c --status $CSUM_FILE || CSUM_CHANGED=1
+        sha256sum -c --status "$CSUM_FILE" || CSUM_CHANGED=1
     else
         CSUM_CHANGED=1
     fi
@@ -61,32 +61,32 @@ for path in $DIR/*/*.spec; do
     # rebuild changed or new specs
     if [ $CSUM_CHANGED -eq 1 ]; then
         echo "Building $path..."
-        eval $RPMBUILD_CMD --target=$ARCH $path
+        eval "$RPMBUILD_CMD" --target=$ARCH "$path"
 
         # In addition to default $ARCH (x86_64) also build packages with architectures
         # whose names are contained in the specfile name
         if [[ "$SPEC_NAME" =~ "i686" ]]; then
-            eval $RPMBUILD_CMD --target=i686 $path
+            eval "$RPMBUILD_CMD" --target=i686 "$path"
         fi
 
         if [[ "$SPEC_NAME" =~ "i386" ]]; then
-            eval $RPMBUILD_CMD --target=i386 $path
+            eval "$RPMBUILD_CMD" --target=i386 "$path"
         fi
 
         if [[ "$SPEC_NAME" =~ "ppc64" ]]; then
-            eval $RPMBUILD_CMD --target=ppc64 $path
+            eval "$RPMBUILD_CMD" --target=ppc64 "$path"
         fi
 
         pushd "$SPEC_DIR" > /dev/null
         echo "Spec has changed, writing new checksum: $path"
-        sha256sum $(basename $path) > $CSUM_FILE
+        sha256sum "$(basename "$path")" > "$CSUM_FILE"
         popd > /dev/null
     fi
 
 done
 
-${GPGDIR}/sign.sh
-${DIR}/break-packages.sh
-${CERTSDIR}/generate_certificates.sh
+"${GPGDIR}/sign.sh"
+"${DIR}/break-packages.sh"
+"${CERTSDIR}/generate_certificates.sh"
 
 echo "DONE: Test data created"

--- a/dnf-testing.sh
+++ b/dnf-testing.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
-PROG_PATH=$(dirname $(realpath -s -- $0))
+PROG_PATH="$(dirname "$(realpath -s -- "$0")")"
 
-pushd $PROG_PATH > /dev/null
+pushd "$PROG_PATH" > /dev/null || return
 
 # first check whether platform-python binary exists (for RHEL8)
 if [[ -x "/usr/libexec/platform-python" ]]; then
     PYTHON=/usr/libexec/platform-python
 else
     # use python3 with fall back to python2
-    PYTHON=`command -v python3`
-    if [ -z $PYTHON ]; then
-        PYTHON=`command -v python2`
+    PYTHON=$(command -v python3)
+    if [ -z "$PYTHON" ]; then
+        PYTHON=$(command -v python2)
     fi
 fi
-if [ ! $PYTHON ]; then
+if [ ! "$PYTHON" ]; then
     printf >&2 "Error: Python interpreter not found.\n"
     exit 1
 fi
 
-exec "$PYTHON" container-test "$@"
+"$PYTHON" container-test "$@"
 
-popd
+popd || exit

--- a/scripts/build_nightlies.sh
+++ b/scripts/build_nightlies.sh
@@ -20,7 +20,7 @@ run_build(){
     rm -rf "$gitdir"
 }
 
-pushd $(dirname $(readlink -f $0))
+pushd "$(dirname "$(readlink -f "$0")")"
     for chroot in "${CHROOTS[@]}"; do
         run_build "$chroot" &
     done


### PR DESCRIPTION
Improvement of shell scripts to be more robust and avoid any common corner cases based on ShellCheck static bash code analysis.
Some example: [remove "exec " if script should continue after this command](https://github.com/koalaman/shellcheck/wiki/SC2093), [quote to prevent word splitting](https://github.com/koalaman/shellcheck/wiki/SC2046), [read lines rather than words, pipe/redirect to a 'while read' loop.](https://github.com/koalaman/shellcheck/wiki/SC2013), etc.
Tested with shellcheck:
```
$ shellcheck -S error -x ./dnf-testing.sh ./scripts/build_nightlies.sh ./dnf-behave-tests/fixtures/certificates/generate_certificates.sh ./dnf-behave-tests/fixtures/specs/break-packages.sh ./dnf-behave-tests/fixtures/specs/build.sh ./dnf-behave-tests/fixtures/rpm2spec/repos/download.sh ./dnf-behave-tests/fixtures/gpgkeys/sign.sh
$ echo $?
0
```
