### PR TITLE
Fix expected output of repoquery --querytags

### DIFF
--- a/dnf-behave-tests/features/repoquery/main.feature
+++ b/dnf-behave-tests/features/repoquery/main.feature
@@ -630,8 +630,6 @@ Scenario: dnf repoquery --querytags
  Then the exit code is 0
   And stdout is
       """
-      Available query-tags: use --queryformat ".. %{{tag}} .."
-
       name, arch, epoch, version, release, reponame (repoid), evr,
       debug_name, source_name, source_debug_name,
       installtime, buildtime, size, downloadsize, installsize,


### PR DESCRIPTION
The first line was recently removed from the repoquery --querytags
output to make it machine-readable.

Changed by commit https://github.com/rpm-software-management/dnf/commit/37f715c8e13f0d1c2074f57420cb3991f1645284