### PR TITLE
[microdnf] Fix and enable tests for "--setopt=install_weak_deps=0/1"

### DIFF
--- a/dnf-behave-tests/features/microdnf/install_weak_deps.feature
+++ b/dnf-behave-tests/features/microdnf/install_weak_deps.feature
@@ -1,13 +1,8 @@
-@no_installroot
-# There is logical bug in libdnf and the test is not correct.
-# Disable test until it will be fixed.
-@xfail
 Feature: Tests --setopt=install_weak_deps=
 
 
 Background: Prepare environment
-  Given I execute microdnf with args "remove abcde flac"
-    And I use repository "dnf-ci-fedora"
+ Given I use repository "dnf-ci-fedora"
 
 
 Scenario: Install "abcde" without weak dependencies
@@ -16,6 +11,7 @@ Scenario: Install "abcde" without weak dependencies
     And microdnf transaction is
         | Action        | Package                                   |
         | install       | abcde-0:2.9.2-1.fc29.noarch               |
+        | install       | wget-0:1.19.5-5.fc29.x86_64               |
 
 
 Scenario: Install "abcde" with weak dependencies
@@ -25,3 +21,4 @@ Scenario: Install "abcde" with weak dependencies
         | Action        | Package                                   |
         | install       | abcde-0:2.9.2-1.fc29.noarch               |
         | install       | flac-0:1.3.2-8.fc29.x86_64                |
+        | install       | wget-0:1.19.5-5.fc29.x86_64               |


### PR DESCRIPTION
There was a bug in libdnf - in dnf_context_run(). Solved transaction was always resolved with hard-coded parameters. And the test was incorrect and was marked as xfail some time ago.

The libdnf was fixed in version 0.42.0 (new API function "dnf_transaction_set_dont_solve_goal" was added) and microdnf tweaked to use it (https://github.com/rpm-software-management/microdnf/pull/68).

With new CI support for microdnf installroot the tests was fixed. And xfail removed.

Depends on installroot support in CI: PR https://github.com/rpm-software-management/ci-dnf-stack/pull/756