### PR TITLE
Add dnf.librepo.log to the log-rotate test (RhBug:1816573)

### DIFF
--- a/dnf-behave-tests/common/file.py
+++ b/dnf-behave-tests/common/file.py
@@ -197,7 +197,7 @@ def step_impl(context, first, second):
             first, ts_first, second, ts_second)
 
 
-@behave.step('size of file "{filepath}" is less than "{expected_size}"')
+@behave.step('size of file "{filepath}" is at most "{expected_size}"')
 def file_size_less_than(context, filepath, expected_size):
     full_path = prepend_installroot(context, filepath)
     size = os.path.getsize(full_path)

--- a/dnf-behave-tests/features/log-rotate.feature
+++ b/dnf-behave-tests/features/log-rotate.feature
@@ -4,12 +4,14 @@ Feature: Log rotation
 @bz1702690
 Scenario: Size and number of log files respects log_size and log_rotate options
   Given I use repository "dnf-ci-fedora"
-    And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 install glibc"
-    And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 remove glibc"
-    And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 install glibc"
-    And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 remove glibc"
-    And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 install glibc"
-    And I execute dnf with args "--setopt=log_size=512 --setopt=log_rotate=2 remove glibc"
+    And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 install glibc"
+    And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 remove glibc"
+    And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 install glibc"
+    And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 remove glibc"
+    And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 install glibc"
+    And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 remove glibc"
+    And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 install glibc"
+    And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 remove glibc"
 
    When I execute "ls {context.dnf.installroot}/var/log | grep "dnf\.log""
    Then stdout is
@@ -18,14 +20,9 @@ Scenario: Size and number of log files respects log_size and log_rotate options
         dnf.log.1
         dnf.log.2
         """
-      # The log size can be higher than the maximum by the size of the last line,
-      # so after cutting the last line, the size must be strictly lower than the maximum
-   When I execute "head -n1 {context.dnf.installroot}/var/log/dnf.log > {context.dnf.installroot}/tmp_dnf.log"
-   Then size of file "tmp_dnf.log" is less than "512"
-   When I execute "head -n1 {context.dnf.installroot}/var/log/dnf.log.1 > {context.dnf.installroot}/tmp_dnf.log.1"
-   Then size of file "tmp_dnf.log.1" is less than "512"
-   When I execute "head -n1 {context.dnf.installroot}/var/log/dnf.log.2 > {context.dnf.installroot}/tmp_dnf.log.2"
-   Then size of file "tmp_dnf.log.2" is less than "512"
+   Then size of file "var/log/dnf.log" is at most "1024"
+   Then size of file "var/log/dnf.log.1" is at most "1024"
+   Then size of file "var/log/dnf.log.2" is at most "1024"
 
    When I execute "ls {context.dnf.installroot}/var/log | grep "dnf\.rpm\.log""
    Then stdout is
@@ -34,9 +31,6 @@ Scenario: Size and number of log files respects log_size and log_rotate options
         dnf.rpm.log.1
         dnf.rpm.log.2
         """
-   When I execute "head -n1 {context.dnf.installroot}/var/log/dnf.rpm.log > {context.dnf.installroot}/tmp_dnf.rpm.log"
-   Then size of file "tmp_dnf.rpm.log" is less than "512"
-   When I execute "head -n1 {context.dnf.installroot}/var/log/dnf.rpm.log.1 > {context.dnf.installroot}/tmp_dnf.rpm.log.1"
-   Then size of file "tmp_dnf.rpm.log.1" is less than "512"
-   When I execute "head -n1 {context.dnf.installroot}/var/log/dnf.rpm.log.2 > {context.dnf.installroot}/tmp_dnf.rpm.log.2"
-   Then size of file "tmp_dnf.rpm.log.2" is less than "512"
+   Then size of file "var/log/dnf.rpm.log" is at most "1024"
+   Then size of file "var/log/dnf.rpm.log.1" is at most "1024"
+   Then size of file "var/log/dnf.rpm.log.2" is at most "1024"

--- a/dnf-behave-tests/features/log-rotate.feature
+++ b/dnf-behave-tests/features/log-rotate.feature
@@ -2,6 +2,7 @@ Feature: Log rotation
 
 
 @bz1702690
+@bz1816573
 Scenario: Size and number of log files respects log_size and log_rotate options
   Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 install glibc"
@@ -34,3 +35,14 @@ Scenario: Size and number of log files respects log_size and log_rotate options
    Then size of file "var/log/dnf.rpm.log" is at most "1024"
    Then size of file "var/log/dnf.rpm.log.1" is at most "1024"
    Then size of file "var/log/dnf.rpm.log.2" is at most "1024"
+
+   When I execute "ls {context.dnf.installroot}/var/log | grep "dnf\.librepo\.log""
+   Then stdout is
+        """
+        dnf.librepo.log
+        dnf.librepo.log.1
+        dnf.librepo.log.2
+        """
+   Then size of file "var/log/dnf.librepo.log" is at most "1024"
+   Then size of file "var/log/dnf.librepo.log.1" is at most "1024"
+   Then size of file "var/log/dnf.librepo.log.2" is at most "1024"


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/libdnf/pull/999 and https://github.com/rpm-software-management/dnf/pull/1639