### PR TITLE
Revert "Add dnf.librepo.log to the log-rotate test (RhBug:1816573)"

### DIFF
--- a/dnf-behave-tests/features/log-rotate.feature
+++ b/dnf-behave-tests/features/log-rotate.feature
@@ -2,7 +2,6 @@ Feature: Log rotation
 
 
 @bz1702690
-@bz1816573
 Scenario: Size and number of log files respects log_size and log_rotate options
   Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "--setopt=log_size=1024 --setopt=log_rotate=2 install glibc"
@@ -35,14 +34,3 @@ Scenario: Size and number of log files respects log_size and log_rotate options
    Then size of file "var/log/dnf.rpm.log" is at most "1024"
    Then size of file "var/log/dnf.rpm.log.1" is at most "1024"
    Then size of file "var/log/dnf.rpm.log.2" is at most "1024"
-
-   When I execute "ls {context.dnf.installroot}/var/log | grep "dnf\.librepo\.log""
-   Then stdout is
-        """
-        dnf.librepo.log
-        dnf.librepo.log.1
-        dnf.librepo.log.2
-        """
-   Then size of file "var/log/dnf.librepo.log" is at most "1024"
-   Then size of file "var/log/dnf.librepo.log.1" is at most "1024"
-   Then size of file "var/log/dnf.librepo.log.2" is at most "1024"


### PR DESCRIPTION
This reverts commit 061825d07ab7d2c705df58bab249f8a07cec8e06.

The dnf.librepo.log file rotating is not fixed in RHEL8.3 and gating is
currently failing on it.