### PR TITLE
rhel-8.3: Test that reposync downloads latest NEVRAs

### DIFF
--- a/dnf-behave-tests/features/plugins-core/reposync.feature
+++ b/dnf-behave-tests/features/plugins-core/reposync.feature
@@ -272,6 +272,23 @@ Scenario: Reposync --newest-only downloads packages from all streams and latest 
     And file "//{context.dnf.tempdir}/dnf-ci-multicontext-hybrid-multiversion-modular/x86_64/postgresql-9.8.1-1.module_9790+c535b823.x86_64.rpm" exists
 
 
+@bz1833074
+Scenario: Reposync --newest-only downloads latest modular packages versions even if they are not part of the latest context version
+  Given I use repository "reposync-newest-modular"
+   When I execute dnf with args "reposync --newest-only --download-path={context.dnf.tempdir}"
+   Then the exit code is 0
+   When I execute "ls {context.dnf.tempdir}/reposync-newest-modular/x86_64/"
+   # labirinto-0.9-1 is the highest non-modular NEVRA
+   # labirinto-1.0-2 is part of the latest stream version
+   # labirinto-1.0-9 is the highest modular NEVRA
+   Then stdout is
+        """
+        labirinto-0.9-1.x86_64.rpm
+        labirinto-1.0-2.module.x86_64.rpm
+        labirinto-1.0-9.module.x86_64.rpm
+        """
+
+
 @bz1795965
 Scenario: Reposync accepts --norepopath to synchronize single repository
   Given I use repository "reposync" as http

--- a/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-0.8-1.spec
+++ b/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-0.8-1.spec
@@ -1,0 +1,15 @@
+Name:           labirinto
+Epoch:          0
+Version:        0.8
+Release:        1
+
+License:        MIT and ASL 2.0 and ISC and BSD
+
+Summary:        Test package
+
+%description
+Labirinto description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-0.9-1.spec
+++ b/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-0.9-1.spec
@@ -1,0 +1,15 @@
+Name:           labirinto
+Epoch:          0
+Version:        0.9
+Release:        1
+
+License:        MIT and ASL 2.0 and ISC and BSD
+
+Summary:        Test package
+
+%description
+Labirinto description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-1.0-1.module.spec
+++ b/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-1.0-1.module.spec
@@ -1,0 +1,15 @@
+Name:           labirinto
+Epoch:          0
+Version:        1.0
+Release:        1.module
+
+License:        MIT and ASL 2.0 and ISC and BSD
+
+Summary:        Test package
+
+%description
+Labirinto description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-1.0-2.module.spec
+++ b/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-1.0-2.module.spec
@@ -1,0 +1,15 @@
+Name:           labirinto
+Epoch:          0
+Version:        1.0
+Release:        2.module
+
+License:        MIT and ASL 2.0 and ISC and BSD
+
+Summary:        Test package
+
+%description
+Labirinto description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-1.0-9.module.spec
+++ b/dnf-behave-tests/fixtures/specs/reposync-newest-modular/labirinto-1.0-9.module.spec
@@ -1,0 +1,15 @@
+Name:           labirinto
+Epoch:          0
+Version:        1.0
+Release:        9.module
+
+License:        MIT and ASL 2.0 and ISC and BSD
+
+Summary:        Test package
+
+%description
+Labirinto description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/reposync-newest-modular/modules.yaml
+++ b/dnf-behave-tests/fixtures/specs/reposync-newest-modular/modules.yaml
@@ -1,0 +1,102 @@
+---
+document: modulemd
+version: 2
+data:
+  name: badlatest
+  stream: stream
+  version: 2018
+  context: aaaaaaaa
+  arch: x86_64
+  summary: The latest rpm NEVRA is not in the latest module version
+  description: >-
+    This should not happen.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT and ASL 2.0 and ISC and BSD
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  profiles:
+    default:
+      rpms:
+      - labirinto
+  artifacts:
+    rpms:
+    - labirinto-0:1.0-9.module.x86_64
+    - labirinto-0:1.0-9.module.src
+...
+---
+document: modulemd
+version: 2
+data:
+  name: badlatest
+  stream: stream
+  version: 2019
+  context: aaaaaaaa
+  arch: x86_64
+  summary: The latest rpm NEVRA is not in the latest module version
+  description: >-
+    This should not happen.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT and ASL 2.0 and ISC and BSD
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  profiles:
+    default:
+      rpms:
+      - labirinto
+  artifacts:
+    rpms:
+    - labirinto-0:1.0-1.module.x86_64
+    - labirinto-0:1.0-1.module.src
+...
+---
+document: modulemd
+version: 2
+data:
+  name: badlatest
+  stream: stream
+  version: 2020
+  context: aaaaaaaa
+  arch: x86_64
+  summary: The latest rpm NEVRA is not in the latest module version
+  description: >-
+    This should not happen.
+  license:
+    module:
+    - MIT
+    content:
+    - MIT and ASL 2.0 and ISC and BSD
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  profiles:
+    default:
+      rpms:
+      - labirinto
+  artifacts:
+    rpms:
+    - labirinto-0:1.0-2.module.x86_64
+    - labirinto-0:1.0-2.module.src
+...
+---
+document: modulemd-defaults
+version: 1
+data:
+    module: badlatest
+    stream: stream
+    profiles:
+        stream: [default]
+...


### PR DESCRIPTION
Backport reposync test into 8.3 branch.

Original PR: #875 

https://bugzilla.redhat.com/show_bug.cgi?id=1833074