### PR TITLE
Parse "replacing" line in microdnf transaction table

### DIFF
--- a/dnf-behave-tests/features/microdnf/install8.feature
+++ b/dnf-behave-tests/features/microdnf/install8.feature
@@ -12,3 +12,4 @@ Given I use repository "dnf-ci-fedora"
   And microdnf transaction is
       | Action        | Package                                   |
       | downgrade     | flac-0:1.3.2-8.fc29.x86_64                |
+      | downgraded    | flac-0:1.3.3-3.fc29.x86_64                |


### PR DESCRIPTION
Microdnf started to report obsoleted, downgraded, upgraded and
reinstalled packages (i.e. the nevra that is removed) all with
keyword "replacing".

The context table can now contain actions "upgraded", "downgraded",
"reinstalled" and "obsoleted". These actions can be compared with
the RPMDB as usual, and for comparison with the microdnf output,
they are all considered as "replaced" actions.