### PR TITLE
container-test: Label the junit volume with SElinux shared content label

### DIFF
--- a/container-test
+++ b/container-test
@@ -198,7 +198,7 @@ class BehaveRunner(object):
                     os.path.join('/opt/behave', self.command_line_args.suite))])
             if hasattr(self.command_line_args, 'junit_directory') \
                 and self.command_line_args.junit_directory:
-                self._volumes.extend(['--volume', '{}:/junit:Z'.format(
+                self._volumes.extend(['--volume', '{}:/junit:z'.format(
                     self.command_line_args.junit_directory)])
         return self._volumes
 


### PR DESCRIPTION
There are currently two containers being run in parallel and it seems
that mounting the junit volume with "Z" is preventing one of the
containers from writing into the directory. "z" should allow multiple
containers to write to the directory.