### PR TITLE
Tests for the system-upgrade plugin

### DIFF
--- a/dnf-behave-tests/features/plugins-extras/system-upgrade.feature
+++ b/dnf-behave-tests/features/plugins-extras/system-upgrade.feature
@@ -1,0 +1,119 @@
+@destructive
+Feature: Test the system-upgrade plugin
+
+Background:
+Given I enable plugin "system_upgrade"
+  # Install the initial package versions first, then set the (target)
+  # releasever and switch the repositories to http (so that system-upgrade
+  # actually downloads the packages instead of using the local path). It is not
+  # possible to set up an http server for a repository with two different
+  # releasever variations.
+  And I use repository "system-upgrade-f$releasever"
+  And I use repository "system-upgrade-2-f$releasever"
+  And I successfully execute dnf with args "install pkg-a pkg-b pkg-both"
+  And I set releasever to "30"
+  And I use repository "system-upgrade-f$releasever" as http
+  And I use repository "system-upgrade-2-f$releasever" as http
+  And I set environment variable "DNF_SYSTEM_UPGRADE_NO_REBOOT" to "1"
+
+
+Scenario: Test system-upgrade when reboot wasn't performed
+ When I execute dnf with args "system-upgrade download"
+ Then the exit code is 0
+  And DNF Transaction is following
+      | Action        | Package               |
+      | upgrade       | pkg-a-2.0-1.noarch    |
+      | upgrade       | pkg-both-2.0-1.noarch |
+      | downgrade     | pkg-b-1.0-1.noarch    |
+  And stdout contains lines
+      """
+      Download complete! Use 'dnf system-upgrade reboot' to start the upgrade.
+      To remove cached metadata and transaction use 'dnf system-upgrade clean'
+      The downloaded packages were saved in cache until the next successful transaction.
+      You can remove cached packages by executing 'dnf clean packages'.
+      """
+ When I execute dnf with args "system-upgrade upgrade"
+ Then the exit code is 0
+  And stdout is
+      """
+      trigger file does not exist. exiting quietly.
+      """
+
+
+Scenario: Test system-upgrade basic functionality
+ When I execute dnf with args "system-upgrade download"
+ Then the exit code is 0
+  And DNF Transaction is following
+      | Action        | Package               |
+      | upgrade       | pkg-a-2.0-1.noarch    |
+      | upgrade       | pkg-both-2.0-1.noarch |
+      | downgrade     | pkg-b-1.0-1.noarch    |
+  And stdout contains lines
+      """
+      Download complete! Use 'dnf system-upgrade reboot' to start the upgrade.
+      To remove cached metadata and transaction use 'dnf system-upgrade clean'
+      The downloaded packages were saved in cache until the next successful transaction.
+      You can remove cached packages by executing 'dnf clean packages'.
+      """
+Given I successfully execute dnf with args "system-upgrade reboot"
+  And I stop http server for repository "system-upgrade-f$releasever"
+  And I stop http server for repository "system-upgrade-2-f$releasever"
+ When I execute dnf with args "system-upgrade upgrade"
+ Then the exit code is 0
+  And transaction is following
+      | Action        | Package               |
+      | upgrade       | pkg-a-2.0-1.noarch    |
+      | upgrade       | pkg-both-2.0-1.noarch |
+      | downgrade     | pkg-b-1.0-1.noarch    |
+
+
+Scenario: Test system-upgrade with --destdir
+ When I execute dnf with args "system-upgrade download --destdir={context.dnf.tempdir}/destdir"
+ Then the exit code is 0
+  And DNF Transaction is following
+      | Action        | Package               |
+      | upgrade       | pkg-a-2.0-1.noarch    |
+      | upgrade       | pkg-both-2.0-1.noarch |
+      | downgrade     | pkg-b-1.0-1.noarch    |
+  And stdout contains lines
+      """
+      Download complete! Use 'dnf system-upgrade reboot' to start the upgrade.
+      To remove cached metadata and transaction use 'dnf system-upgrade clean'
+      The downloaded packages were saved in cache until the next successful transaction.
+      You can remove cached packages by executing 'dnf clean packages'.
+      """
+Given I successfully execute dnf with args "system-upgrade reboot"
+  And I stop http server for repository "system-upgrade-f$releasever"
+  And I stop http server for repository "system-upgrade-2-f$releasever"
+ When I execute dnf with args "system-upgrade upgrade"
+ Then the exit code is 0
+  And transaction is following
+      | Action        | Package               |
+      | upgrade       | pkg-a-2.0-1.noarch    |
+      | upgrade       | pkg-both-2.0-1.noarch |
+      | downgrade     | pkg-b-1.0-1.noarch    |
+
+
+Scenario: Test system-upgrade with --no-downgrade
+ When I execute dnf with args "system-upgrade download --no-downgrade"
+ Then the exit code is 0
+  And DNF Transaction is following
+      | Action        | Package               |
+      | upgrade       | pkg-a-2.0-1.noarch    |
+      | upgrade       | pkg-both-2.0-1.noarch |
+  And stdout contains lines
+      """
+      Download complete! Use 'dnf system-upgrade reboot' to start the upgrade.
+      To remove cached metadata and transaction use 'dnf system-upgrade clean'
+      The downloaded packages were saved in cache until the next successful transaction.
+      You can remove cached packages by executing 'dnf clean packages'.
+      """
+Given I successfully execute dnf with args "system-upgrade reboot"
+  And I stop http server for repository "system-upgrade-f$releasever"
+  And I stop http server for repository "system-upgrade-2-f$releasever"
+ When I execute dnf with args "system-upgrade upgrade"
+ Then the exit code is 0
+  And transaction is following
+      | Action        | Package               |
+      | upgrade       | pkg-a-2.0-1.noarch    |
+      | upgrade       | pkg-both-2.0-1.noarch |

--- a/dnf-behave-tests/features/steps/cmd.py
+++ b/dnf-behave-tests/features/steps/cmd.py
@@ -52,6 +52,11 @@ def execute_step(context, step):
     context.execute_steps(step)
 
 
+@behave.step("I set environment variable \"{var}\" to \"{value}\"")
+def set_environment_variable(context, var, value):
+    os.environ[var] = value
+
+
 @behave.step("I move the clock {direction} to \"{when}\"")
 def faketime(context, direction, when):
     assert os.path.exists('/usr/bin/faketime'), 'Faketime binary must be installed'

--- a/dnf-behave-tests/features/steps/fixtures/__init__.py
+++ b/dnf-behave-tests/features/steps/fixtures/__init__.py
@@ -26,3 +26,10 @@ def start_server_based_on_type(context, server_dir, rtype, certs=None):
             raise AssertionError("Unknown server type: %s" % rtype)
 
     return host, port
+
+
+def stop_server_type(context, path, rtype):
+    if rtype == "ftp":
+        context.scenario.ftpd.stop_server(path)
+    else:
+        context.scenario.httpd.stop_server(path)

--- a/dnf-behave-tests/features/steps/fixtures/server.py
+++ b/dnf-behave-tests/features/steps/fixtures/server.py
@@ -64,6 +64,9 @@ class ServerContext(object):
 
         return address
 
+    def stop_server(self, path):
+        self.servers.pop(path)[1].terminate()
+
     def get_address(self, path):
         """
         Get address of the server bound to the "path" directory.

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -119,6 +119,14 @@ def generate_metalink(destdir, url):
         f.write(data + '\n')
 
 
+@behave.given("I set releasever to \"{releasever}\"")
+def step_impl(context, releasever):
+    context.dnf._set("releasever", releasever)
+    for repo, info in context.dnf.repos.items():
+        if "$releasever" in repo:
+            generate_repodata(context, repo)
+
+
 @behave.step("I use repository \"{repo}\"")
 def step_use_repository(context, repo):
     """

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -14,7 +14,7 @@ from common.lib.checksum import sha256_checksum
 from common.lib.cmd import run_in_context
 from common.lib.diff import print_lines_diff
 from common.lib.file import copy_tree, create_file_with_contents, delete_file, ensure_directory_exists
-from fixtures import start_server_based_on_type
+from fixtures import start_server_based_on_type, stop_server_type
 from fixtures.osrelease import osrelease_fixture
 
 
@@ -264,6 +264,17 @@ def step_use_repository_as(context, repo, rtype):
     repo_info.update_config(config)
     generate_repodata(context, repo)
     create_repo_conf(context, repo)
+
+
+@behave.step("I stop {rtype:server_type} server for repository \"{repo}\"")
+def step_stop_server_for_repo(context, rtype, repo):
+    """
+    Stops the server that is running for the repository.
+    """
+    repo_info = get_repo_info(context, repo)
+    server_dir = repo_info.path.replace("$releasever", context.dnf.releasever)
+
+    stop_server_type(context, server_dir, rtype)
 
 
 @behave.step("I set up metalink for repository \"{repo}\"")

--- a/dnf-behave-tests/fixtures/specs/system-upgrade-2-f29/pkg-both-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/system-upgrade-2-f29/pkg-both-1.0-1.spec
@@ -1,0 +1,15 @@
+Name:           pkg-both
+Version:        1.0
+Release:        1
+Summary:        A package.
+
+License:        Public Domain
+
+BuildArch:      noarch
+
+%description
+A package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/system-upgrade-2-f30/pkg-both-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/system-upgrade-2-f30/pkg-both-2.0-1.spec
@@ -1,0 +1,15 @@
+Name:           pkg-both
+Version:        2.0
+Release:        1
+Summary:        A package.
+
+License:        Public Domain
+
+BuildArch:      noarch
+
+%description
+A package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/system-upgrade-f29/pkg-a-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/system-upgrade-f29/pkg-a-1.0-1.spec
@@ -1,0 +1,15 @@
+Name:           pkg-a
+Version:        1.0
+Release:        1
+Summary:        A package.
+
+License:        Public Domain
+
+BuildArch:      noarch
+
+%description
+A package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/system-upgrade-f29/pkg-b-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/system-upgrade-f29/pkg-b-2.0-1.spec
@@ -1,0 +1,15 @@
+Name:           pkg-b
+Version:        2.0
+Release:        1
+Summary:        A package.
+
+License:        Public Domain
+
+BuildArch:      noarch
+
+%description
+A package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/system-upgrade-f29/pkg-both-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/system-upgrade-f29/pkg-both-1.0-1.spec
@@ -1,0 +1,15 @@
+Name:           pkg-both
+Version:        1.0
+Release:        1
+Summary:        A package.
+
+License:        Public Domain
+
+BuildArch:      noarch
+
+%description
+A package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/system-upgrade-f30/pkg-a-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/system-upgrade-f30/pkg-a-2.0-1.spec
@@ -1,0 +1,15 @@
+Name:           pkg-a
+Version:        2.0
+Release:        1
+Summary:        A package.
+
+License:        Public Domain
+
+BuildArch:      noarch
+
+%description
+A package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/system-upgrade-f30/pkg-b-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/system-upgrade-f30/pkg-b-1.0-1.spec
@@ -1,0 +1,15 @@
+Name:           pkg-b
+Version:        1.0
+Release:        1
+Summary:        A package.
+
+License:        Public Domain
+
+BuildArch:      noarch
+
+%description
+A package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/system-upgrade-f30/pkg-both-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/system-upgrade-f30/pkg-both-2.0-1.spec
@@ -1,0 +1,15 @@
+Name:           pkg-both
+Version:        2.0
+Release:        1
+Summary:        A package.
+
+License:        Public Domain
+
+BuildArch:      noarch
+
+%description
+A package.
+
+%files
+
+%changelog


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf-plugins-extras/pull/184 (without it it reboots the system the tests are run on).