### PR TITLE
Add a test for installing x86_64 package not pulling in i686 through deps

### DIFF
--- a/dnf-behave-tests/features/install-remove-multilib.feature
+++ b/dnf-behave-tests/features/install-remove-multilib.feature
@@ -50,3 +50,25 @@ Scenario: Removing package of inferior arch also removes dependencies
       | remove        | packageB-0:1.0-1.i686        |
       | remove        | library-0:1.0-1.i686         |
 
+
+@bz1782899
+Scenario: Installing a package upgrade with best will not pull in secondary arch packages (non-trivial dependency tree)
+Given I successfully execute dnf with args "install foo-1.0-1.x86_64"
+ When I execute dnf with args "install foo --best"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                        |
+      | upgrade       | foo-2.0-1.x86_64               |
+      | upgrade       | python3-foo-2.0-1.x86_64       |
+      | upgrade       | python3-foo-clibs-2.0-1.x86_64 |
+
+
+@xfail
+# https://github.com/openSUSE/libsolv/issues/404
+Scenario: Installing an older version of x86_64 pulls in a newer version of i686 through dependencies
+ When I execute dnf with args "install foo-1.0"
+ Then Transaction is following
+      | Action        | Package                        |
+      | install       | foo-1.0-1.x86_64               |
+      | install-dep   | python3-foo-1.0-1.x86_64       |
+      | install-dep   | python3-foo-clibs-1.0-1.x86_64 |

--- a/dnf-behave-tests/fixtures/specs/install-remove-multilib/foo-1.0.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/install-remove-multilib/foo-1.0.i686.spec
@@ -1,0 +1,16 @@
+Name:           foo
+Version:        1.0
+Release:        1
+
+Requires:       python3-foo
+
+License:        Public Domain
+URL:            None
+Summary:        Dummy
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/install-remove-multilib/foo-2.0.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/install-remove-multilib/foo-2.0.i686.spec
@@ -1,0 +1,16 @@
+Name:           foo
+Version:        2.0
+Release:        1
+
+Requires:       python3-foo
+
+License:        Public Domain
+URL:            None
+Summary:        Dummy
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/install-remove-multilib/python3-foo-1.0.noarch.spec
+++ b/dnf-behave-tests/fixtures/specs/install-remove-multilib/python3-foo-1.0.noarch.spec
@@ -1,0 +1,17 @@
+Name:           python3-foo
+Version:        1.0
+Release:        1
+
+Requires:       python3-foo-clibs
+Requires:       foo = 1.0-1
+
+License:        Public Domain
+URL:            None
+Summary:        Dummy
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/install-remove-multilib/python3-foo-2.0.noarch.spec
+++ b/dnf-behave-tests/fixtures/specs/install-remove-multilib/python3-foo-2.0.noarch.spec
@@ -1,0 +1,17 @@
+Name:           python3-foo
+Version:        2.0
+Release:        1
+
+Requires:       python3-foo-clibs
+Requires:       foo = 2.0-1
+
+License:        Public Domain
+URL:            None
+Summary:        Dummy
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/install-remove-multilib/python3-foo-clibs-1.0.x86_64.spec
+++ b/dnf-behave-tests/fixtures/specs/install-remove-multilib/python3-foo-clibs-1.0.x86_64.spec
@@ -1,0 +1,16 @@
+Name:           python3-foo-clibs
+Version:        1.0
+Release:        1
+
+Requires:       foo%{?_isa} = 1.0-1
+
+License:        Public Domain
+URL:            None
+Summary:        Dummy
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/install-remove-multilib/python3-foo-clibs-2.0.x86_64.spec
+++ b/dnf-behave-tests/fixtures/specs/install-remove-multilib/python3-foo-clibs-2.0.x86_64.spec
@@ -1,0 +1,16 @@
+Name:           python3-foo-clibs
+Version:        2.0
+Release:        1
+
+Requires:       foo%{?_isa} = 2.0-1
+
+License:        Public Domain
+URL:            None
+Summary:        Dummy
+
+%description
+Dummy.
+
+%files
+
+%changelog


### PR DESCRIPTION
The test is a simplified reproducer from:
https://bugzilla.redhat.com/show_bug.cgi?id=1782899

Which is fixed in libsolv upstream and should be released in 0.7.16.

Also adds a test for a problem discovered when reproducing the above,
which was subsequently reported in libsolv too.