### PR TITLE
Add test for zchunk repos (mirrors without range support)

### DIFF
--- a/dnf-behave-tests/features/steps/fixtures/ftpd.py
+++ b/dnf-behave-tests/features/steps/fixtures/ftpd.py
@@ -51,7 +51,7 @@ class FtpServerContext(ServerContext):
 
 @fixture
 def ftpd_fixture(context):
-    if not hasattr(context.scenario, "httpd"):
+    if not hasattr(context.scenario, "ftpd"):
         context.scenario.ftpd = FtpServerContext()
 
     yield context.scenario.ftpd

--- a/dnf-behave-tests/features/zchunk.feature
+++ b/dnf-behave-tests/features/zchunk.feature
@@ -1,0 +1,126 @@
+@use.with_os=fedora__ge__31
+Feature: zchunk tests
+
+
+Scenario: I can install an RPM from local mirror with zchunk repo and enabled zchunk
+Given I copy repository "simple-base" for modification
+  And I use repository "simple-base"
+  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
+  And I configure dnf with
+      | key    | value |
+      | zchunk | True  |
+ When I execute dnf with args "install labirinto"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                       |
+      | install       | labirinto-0:1.0-1.fc29.x86_64 |
+
+
+@bz1886706
+Scenario: I can install an RPM from FTP mirror with zchunk repo and enabled zchunk
+Given I copy repository "simple-base" for modification
+  And I use repository "simple-base" as ftp
+  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
+  And I configure dnf with
+      | key    | value |
+      | zchunk | True  |
+ When I execute dnf with args "install labirinto"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                       |
+      | install       | labirinto-0:1.0-1.fc29.x86_64 |
+
+
+Scenario: I can install an RPM from FTP mirror with zchunk repo and disabled zchunk
+Given I copy repository "simple-base" for modification
+  And I use repository "simple-base" as ftp
+  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
+  And I configure dnf with
+      | key    | value |
+      | zchunk | False |
+ When I execute dnf with args "install labirinto"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                       |
+      | install       | labirinto-0:1.0-1.fc29.x86_64 |
+
+
+Scenario: when zchunk is enabled, prefer HTTP over FTP
+Given I copy repository "simple-base" for modification
+  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
+  And I start http server "http_server" at "/{context.dnf.repos[simple-base].path}"
+  And I start ftp server "ftp_server" at "/{context.dnf.repos[simple-base].path}"
+  And I create and substitute file "/tmp/mirrorlist" with
+      """
+      ftp://localhost:{context.dnf.ports[ftp_server]}/
+      http://localhost:{context.dnf.ports[http_server]}/
+      """
+  And I configure a new repository "testrepo" with
+      | key        | value                                    |
+      | mirrorlist | {context.dnf.installroot}/tmp/mirrorlist |
+  And I configure dnf with
+      | key    | value |
+      | zchunk | True  |
+  And I start capturing outbound HTTP requests
+ When I execute dnf with args "install labirinto -v"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                       |
+      | install       | labirinto-0:1.0-1.fc29.x86_64 |
+  And exactly 2 HTTP GET requests should match:
+      | path                      |
+      | /repodata/primary.xml.zck |
+  And exactly 2 HTTP GET request should match:
+      | path                        |
+      | /repodata/filelists.xml.zck |
+
+
+Scenario: when zchunk is enabled, prefer HTTP over FTP (reversed)
+Given I copy repository "simple-base" for modification
+  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
+  And I start http server "http_server" at "/{context.dnf.repos[simple-base].path}"
+  And I start ftp server "ftp_server" at "/{context.dnf.repos[simple-base].path}"
+  And I create and substitute file "/tmp/mirrorlist" with
+      """
+      http://localhost:{context.dnf.ports[http_server]}/
+      ftp://localhost:{context.dnf.ports[ftp_server]}/
+      """
+  And I configure a new repository "testrepo" with
+      | key        | value                                    |
+      | mirrorlist | {context.dnf.installroot}/tmp/mirrorlist |
+  And I configure dnf with
+      | key    | value |
+      | zchunk | True  |
+  And I start capturing outbound HTTP requests
+ When I execute dnf with args "install labirinto -v"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                       |
+      | install       | labirinto-0:1.0-1.fc29.x86_64 |
+  And exactly 2 HTTP GET requests should match:
+      | path                      |
+      | /repodata/primary.xml.zck |
+  And exactly 2 HTTP GET request should match:
+      | path                        |
+      | /repodata/filelists.xml.zck |
+
+
+Scenario: using mirror wihtout ranges supports and zchunk results in only two GET requests per file (the first try is with range specified)
+Given I copy repository "simple-base" for modification
+  And I use repository "simple-base" as http
+  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
+  And I configure dnf with
+      | key    | value |
+      | zchunk | True |
+  And I start capturing outbound HTTP requests
+ When I execute dnf with args "install labirinto"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                       |
+      | install       | labirinto-0:1.0-1.fc29.x86_64 |
+  And exactly 2 HTTP GET requests should match:
+      | path                      |
+      | /repodata/primary.xml.zck |
+  And exactly 2 HTTP GET request should match:
+      | path                        |
+      | /repodata/filelists.xml.zck |


### PR DESCRIPTION
Tests for: https://github.com/rpm-software-management/librepo/pull/206

It would be nice to also have tests for mirrors with range support (for example using rangehttpserver - `pip install rangehttpserver`), we could even test that the correct zchunks get downloaded if we update the metadata. However this would be a new dependency that is used only for Fedora.

https://bugzilla.redhat.com/show_bug.cgi?id=1886706