### PR TITLE
Fix system-upgrade comps tests

### DIFF
--- a/dnf-behave-tests/features/plugins-extras/system-upgrade-comps.feature
+++ b/dnf-behave-tests/features/plugins-extras/system-upgrade-comps.feature
@@ -70,7 +70,9 @@ Scenario: Upgrade group when there were excluded packages during installation - 
     And I stop http server for repository "system-upgrade-comps-f$releasever"
    When I execute dnf with args "system-upgrade upgrade"
    Then the exit code is 0
-    And transaction is empty
+    And transaction is following
+        | Action        | Package                            |
+        | group-upgrade | A-group                            |
 
 
 Scenario: Upgrade group when there were removed packages since installation - don't install these packages
@@ -88,7 +90,9 @@ Scenario: Upgrade group when there were removed packages since installation - do
     And I stop http server for repository "system-upgrade-comps-f$releasever"
    When I execute dnf with args "system-upgrade upgrade"
    Then the exit code is 0
-    And transaction is empty
+    And transaction is following
+        | Action        | Package                            |
+        | group-upgrade | A-group                            |
 
 
 Scenario: Upgrade environment when there are new groups/packages - install new groups/packages
@@ -134,7 +138,10 @@ Scenario: Upgrade environment when there were excluded packages during installat
     And I stop http server for repository "system-upgrade-comps-f$releasever"
    When I execute dnf with args "system-upgrade upgrade"
    Then the exit code is 0
-    And transaction is empty
+    And transaction is following
+        | Action        | Package                            |
+        | group-upgrade | A-group                            |
+        | env-upgrade   | A-environment                      |
 
 
 Scenario: Upgrade environment when there were removed packages since installation - don't install these packages
@@ -153,7 +160,10 @@ Scenario: Upgrade environment when there were removed packages since installatio
     And I stop http server for repository "system-upgrade-comps-f$releasever"
    When I execute dnf with args "system-upgrade upgrade"
    Then the exit code is 0
-    And transaction is empty
+    And transaction is following
+        | Action        | Package                            |
+        | group-upgrade | A-group                            |
+        | env-upgrade   | A-environment                      |
 
 
 Scenario: Upgrade empty group
@@ -170,7 +180,9 @@ Scenario: Upgrade empty group
     And I stop http server for repository "system-upgrade-comps-f$releasever"
    When I execute dnf with args "system-upgrade upgrade"
    Then the exit code is 0
-    And transaction is empty
+    And transaction is following
+        | Action        | Package                            |
+        | group-upgrade | empty-group                        |
 
 
 Scenario: Upgrade empty environment
@@ -187,7 +199,9 @@ Scenario: Upgrade empty environment
     And I stop http server for repository "system-upgrade-comps-f$releasever"
    When I execute dnf with args "system-upgrade upgrade"
    Then the exit code is 0
-    And transaction is empty
+    And transaction is following
+        | Action        | Package                            |
+        | env-upgrade   | empty-environment                  |
 
 
 Scenario: Upgrade environment when all groups are removed
@@ -205,4 +219,6 @@ Scenario: Upgrade environment when all groups are removed
     And I stop http server for repository "system-upgrade-comps-f$releasever"
    When I execute dnf with args "system-upgrade upgrade"
    Then the exit code is 0
-    And transaction is empty
+    And transaction is following
+        | Action        | Package                            |
+        | env-upgrade   | A-environment                      |

--- a/dnf-behave-tests/features/plugins-extras/system-upgrade-comps.feature
+++ b/dnf-behave-tests/features/plugins-extras/system-upgrade-comps.feature
@@ -1,4 +1,3 @@
-@destructive
 @use.with_os=fedora__ge__31
 Feature: Test the system-upgrade plugin with comps
 


### PR DESCRIPTION
The new transaction store/replay code stores the comps actions into the transaction json, so they are replayed during the upgrade transaction.