### PR TITLE
Update tests for storing comps items in in-progress transaction

### DIFF
--- a/dnf-behave-tests/features/plugins-extras/system-upgrade-comps.feature
+++ b/dnf-behave-tests/features/plugins-extras/system-upgrade-comps.feature
@@ -27,6 +27,7 @@ Scenario: Upgrade group when there are new package versions - upgrade packages
         | Action        | Package                            |
         | upgrade       | A-mandatory-0:2.0-1.x86_64         |
         | upgrade       | A-default-0:2.0-1.x86_64           |
+        | group-upgrade | A-group                            |
 
 
 Scenario: Upgrade group when there are new packages - install new packages
@@ -53,6 +54,7 @@ Scenario: Upgrade group when there are new packages - install new packages
         | upgrade       | A-default-0:2.0-1.x86_64           |
         | install-group | B-mandatory-0:1.0-1.x86_64         |
         | install-group | B-default-0:1.0-1.x86_64           |
+        | group-upgrade | AB-group                           |
 
 
 Scenario: Upgrade group when there were excluded packages during installation - don't install these packages
@@ -120,6 +122,9 @@ Scenario: Upgrade environment when there are new groups/packages - install new g
         | upgrade       | A-default-0:2.0-1.x86_64           |
         | install-group | B-mandatory-0:1.0-1.x86_64         |
         | install-group | B-default-0:1.0-1.x86_64           |
+        | group-install | B-group                            |
+        | group-upgrade | A-group                            |
+        | env-upgrade   | AB-environment                     |
 
 
 Scenario: Upgrade environment when there were excluded packages during installation - don't install these packages

--- a/dnf-behave-tests/features/transaction-sr/replay.feature
+++ b/dnf-behave-tests/features/transaction-sr/replay.feature
@@ -466,9 +466,9 @@ Given I create file "/{context.dnf.tempdir}/transaction.json" with
   And I execute "echo 'select * from comps_group_package;' | sqlite3 -noheader -list {context.dnf.installroot}/var/lib/dnf/history.sqlite"
   And stdout is
       """
-      1|9|top-a|1|4
-      2|9|top-b|1|2
-      3|9|top-c|0|8
+      1|6|top-a|1|4
+      2|6|top-b|1|2
+      3|6|top-c|0|8
       """
 
 
@@ -548,9 +548,9 @@ Given I create file "/{context.dnf.tempdir}/transaction.json" with
   And I execute "echo 'select * from comps_group_package;' | sqlite3 -noheader -list {context.dnf.installroot}/var/lib/dnf/history.sqlite"
   And stdout is
       """
-      1|8|top-a|1|4
-      2|8|top-b|0|2
-      3|8|top-c|0|8
+      1|6|top-a|1|4
+      2|6|top-b|0|2
+      3|6|top-c|0|8
       """
 
 
@@ -616,9 +616,9 @@ Given I successfully execute dnf with args "install @test-group"
   And I execute "echo 'select * from comps_group_package;' | sqlite3 -noheader -list {context.dnf.installroot}/var/lib/dnf/history.sqlite"
   And stdout is
       """
-      1|9|top-a|1|4
-      2|9|top-b|1|2
-      3|9|top-c|0|8
+      1|6|top-a|1|4
+      2|6|top-b|1|2
+      3|6|top-c|0|8
       4|10|top-a|1|4
       5|10|top-b|1|2
       6|10|top-c|0|8
@@ -696,9 +696,9 @@ Given I successfully execute dnf with args "install @test-group"
   And I execute "echo 'select * from comps_group_package;' | sqlite3 -noheader -list {context.dnf.installroot}/var/lib/dnf/history.sqlite"
   And stdout is
       """
-      1|9|top-a|1|4
-      2|9|top-b|1|2
-      3|9|top-c|0|8
+      1|6|top-a|1|4
+      2|6|top-b|1|2
+      3|6|top-c|0|8
       4|10|top-a|1|4
       5|10|top-b|1|2
       6|10|top-c|0|8
@@ -793,8 +793,8 @@ Given I create file "/{context.dnf.tempdir}/transaction.json" with
   And I execute "echo 'select * from comps_environment_group;' | sqlite3 -noheader -list {context.dnf.installroot}/var/lib/dnf/history.sqlite"
   And stdout is
       """
-      1|9|test-env-group|1|4
-      2|9|test-env-optgroup|0|8
+      1|7|test-env-group|1|4
+      2|7|test-env-optgroup|0|8
       """
 
 
@@ -884,8 +884,8 @@ Given I successfully execute dnf with args "install @test-env"
   And I execute "echo 'select * from comps_environment_group;' | sqlite3 -noheader -list {context.dnf.installroot}/var/lib/dnf/history.sqlite"
   And stdout is
       """
-      1|9|test-env-group|1|4
-      2|9|test-env-optgroup|0|8
+      1|6|test-env-group|1|4
+      2|6|test-env-optgroup|0|8
       3|11|test-env-group|1|4
       4|11|test-env-optgroup|0|8
       """
@@ -987,8 +987,8 @@ Given I successfully execute dnf with args "install @test-env"
   And I execute "echo 'select * from comps_environment_group;' | sqlite3 -noheader -list {context.dnf.installroot}/var/lib/dnf/history.sqlite"
   And stdout is
       """
-      1|9|test-env-group|1|4
-      2|9|test-env-optgroup|0|8
+      1|6|test-env-group|1|4
+      2|6|test-env-optgroup|0|8
       3|12|test-env-group|1|4
       4|12|test-env-optgroup|0|8
       """


### PR DESCRIPTION
In addition to system-upgrade now consistently storing comps in the
transaction json, some ids have changed in history.sqlite due to
different timing of insertions.