### PR TITLE
Adjust test for from_repo attribute

### DIFF
--- a/dnf-behave-tests/features/repoquery/main.feature
+++ b/dnf-behave-tests/features/repoquery/main.feature
@@ -637,7 +637,6 @@ Given I successfully execute dnf with args "install bottom-a1"
       bottom-a1-1.0-1 repoquery-main --
       bottom-a1-2.0-1 @System -repoquery-main-
       bottom-a1-2.0-1 repoquery-main --
-      bottom-a1-2.0-1 repoquery-main -repoquery-main-
       bottom-a2-1.0-1 @System --
       bottom-a2-1.0-1 repoquery-main --
       bottom-a3-1.0-1 repoquery-main --


### PR DESCRIPTION
The original code also returned reponame for available package when
NEVRA was identical to installed package.