### PR TITLE
Add test for module remove --all with argument that has no match

### DIFF
--- a/dnf-behave-tests/features/module/remove.feature
+++ b/dnf-behave-tests/features/module/remove.feature
@@ -214,4 +214,8 @@ Scenario: module removed with --all and not existing module argument - no traceb
    When I execute dnf with args "module remove --all noexists"
    Then the exit code is 0
     And Transaction is empty
-    And stderr does not contain "Traceback"
+    And stderr is
+        """
+        Problems in request:
+        missing groups or modules: noexists
+        """

--- a/dnf-behave-tests/features/module/remove.feature
+++ b/dnf-behave-tests/features/module/remove.feature
@@ -206,3 +206,12 @@ Scenario: Packages belonging to multiple modules are not removed with --all
         | Action                    | Package                |
         | remove                    | luke-0:1.0-1.x86_64    |
     And stdout does not contain "belongs to multiple modules, skipping"
+
+@bz1904490
+Scenario: module removed with --all and not existing module argument - no traceback
+  Given I use repository "dnf-ci-fifthparty"
+    And I use repository "dnf-ci-fifthparty-modular"
+   When I execute dnf with args "module remove --all noexists"
+   Then the exit code is 0
+    And Transaction is empty
+    And stderr does not contain "Traceback"


### PR DESCRIPTION
It tests that command passes and does not generate a traceback.