### PR TITLE
Fix a possible issue caused by repo sync that can sometimes occur

### DIFF
--- a/dnf-behave-tests/features/module/platform.feature
+++ b/dnf-behave-tests/features/module/platform.feature
@@ -38,10 +38,10 @@ Scenario: I can't see pseudo-module in module listing
 Scenario: I can't list info for the pseudo-module
  When I execute dnf with args "module info pseudoplatform"
  Then the exit code is 1
-  And stdout matches line by line
+  And stdout is
    """
-   ^dnf-ci-pseudo-platform-modular\s+
-   ^Unable to resolve argument pseudoplatform
+   <REPOSYNC>
+   Unable to resolve argument pseudoplatform
    """
   And stderr is
    """


### PR DESCRIPTION
The line `dnf-ci-pseudo-platform-modular test repository  1.4 MB/s | 1.7 kB     00:00` can be changed to `Last metadata expiration check: 0:00:01 ago on Thu Dec 10 08:38:47 2020.` in the right conditions.

For example this failing tests: https://baseos-stg-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/dnf-dnf-test/296/testReport/