### PR TITLE
<REPOSYNC> doesn't have to be the first line (fixes verbose mode matching)

### DIFF
--- a/dnf-behave-tests/common/output.py
+++ b/dnf-behave-tests/common/output.py
@@ -12,18 +12,20 @@ from common.lib.text import lines_match_to_regexps_line_by_line
 
 
 def handle_reposync(expected, found):
-    if expected[0] == "<REPOSYNC>":
-        sync_line = re.compile(r".*[0-9.]+ +[kMG]?B/s \| +[0-9.]+ +[kMG]?B +[0-9]{2}:[0-9]{2}")
-        last_check_line = re.compile(r"Last metadata expiration check: .*")
-        i = 0
+    line_number = 0
+    for line in expected:
+        if line == "<REPOSYNC>":
+            sync_line = re.compile(r".*[0-9.]+ +[kMG]?B/s \| +[0-9.]+ +[kMG]?B +[0-9]{2}:[0-9]{2}")
+            last_check_line = re.compile(r"Last metadata expiration check: .*")
 
-        while i < len(found) and (
-                sync_line.fullmatch(found[i].strip())
-                or last_check_line.fullmatch(found[i].strip())):
-            i += 1
+            while line_number < len(found) and (
+                    sync_line.fullmatch(found[line_number].strip())
+                    or last_check_line.fullmatch(found[line_number].strip())):
+                found.pop(line_number)
 
-        expected = expected[1:]
-        found = found[i:]
+            expected.pop(line_number)
+            break
+        line_number += 1
 
     return expected, found
 

--- a/dnf-behave-tests/features/updateinfo.feature
+++ b/dnf-behave-tests/features/updateinfo.feature
@@ -423,7 +423,6 @@ Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode
    Then the exit code is 0
     And stdout matches line by line
     """
-    <REPOSYNC>
     DNF version: .*
     cachedir: .*
     User-Agent: constructed: .*
@@ -432,6 +431,7 @@ Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode
     dnf-ci-fedora-updates: using metadata from .*
     repo: using cache for: dnf-ci-fedora
     dnf-ci-fedora: using metadata from .*
+    <REPOSYNC>
     2999     bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
     CVE-2999 bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
     """
@@ -446,7 +446,6 @@ Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode
    Then the exit code is 0
     And stdout matches line by line
     """
-    <REPOSYNC>
     YUM version: .*
     cachedir: .*
     User-Agent: constructed: .*
@@ -455,6 +454,7 @@ Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode
     dnf-ci-fedora-updates: using metadata from .*
     repo: using cache for: dnf-ci-fedora
     dnf-ci-fedora: using metadata from .*
+    <REPOSYNC>
     2999     bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
     CVE-2999 bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
     """


### PR DESCRIPTION
For these particular tests `<REPOSYNC>` matches the potential `Last
metadata expiration check: 0:00:01 ago on Thu Dec 10 08:38:47 2020`
the downloading of repository is matched by the regex
`dnf-ci-fedora-updates test repository .* MB/s | .*`

I concede this is not the most clear or readable approach and we could
create something like `<REPOSYNC_VERBOSE>` to match the whole beginning
part but that would hide what repositories are used which I think is
a useful part of the verbose output.

For: https://baseos-stg-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/dnf-libdnf-test/226/testReport/