### PR TITLE
Test install by name of obsoleted older version creates two valid upgrade paths

### DIFF
--- a/dnf-behave-tests/features/obsoletes.feature
+++ b/dnf-behave-tests/features/obsoletes.feature
@@ -9,12 +9,26 @@ Background: Use dnf-ci-obsoletes repository
   Given I use repository "dnf-ci-obsoletes"
 
 
+# PackageA has a split in its upgrade-path both PackageA-Obsoleter-1.0-1 and PackageA-3.0-1 are valid.
+# PackageA-3.0-1 is picked because it lexicographically precedes PackageA-Obsoleter-1.0-1.
+@bz1902279
 Scenario: Install of obsoleted package, but higher version than obsoleted present
    When I execute dnf with args "install PackageA"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
         | install       | PackageA-0:3.0-1.x86_64                   |
+
+
+# PackageE has a split in its upgrade-path both PackageA-Obsoleter-1.0-1 and PackageE-3.0-1 are valid.
+# PackageA-Obsoleter-1.0-1 is picked because it lexicographically precedes PackageE-3.0-1.
+@bz1902279
+Scenario: Install of obsoleting package, even though higher version than obsoleted present
+   When I execute dnf with args "install PackageE"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                                   |
+        | install       | PackageA-Obsoleter-0:1.0-1.x86_64         |
 
 
 Scenario: Upgrade of obsoleted package by package of higher version than obsoleted

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-obsoletes/PackageE-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-obsoletes/PackageE-1.0-1.spec
@@ -1,4 +1,4 @@
-Name:           PackageA-Obsoleter
+Name:           PackageE
 Epoch:          0
 Version:        1.0
 Release:        1
@@ -7,10 +7,6 @@ License:        Public Domain
 URL:            None
 
 Summary:        The made up package for obsoletes testing.
-
-Provides:       PackageA = 2.0
-Obsoletes:      PackageA < 2.0
-Obsoletes:      PackageE < 2.0
 
 %description
 

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-obsoletes/PackageE-3.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-obsoletes/PackageE-3.0-1.spec
@@ -1,16 +1,12 @@
-Name:           PackageA-Obsoleter
+Name:           PackageE
 Epoch:          0
-Version:        1.0
+Version:        3.0
 Release:        1
 
 License:        Public Domain
 URL:            None
 
 Summary:        The made up package for obsoletes testing.
-
-Provides:       PackageA = 2.0
-Obsoletes:      PackageA < 2.0
-Obsoletes:      PackageE < 2.0
 
 %description
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1902279

Described in doc update: https://github.com/rpm-software-management/dnf/pull/1708