### PR TITLE
Test error message when "proxy_username" is set but not "proxy_password"

### DIFF
--- a/dnf-behave-tests/features/error_messages.feature
+++ b/dnf-behave-tests/features/error_messages.feature
@@ -1,0 +1,24 @@
+Feature: Test error messages
+
+
+@bz1888946
+Scenario: Global option 'proxy_username' is set but not 'proxy_password'
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+    And I configure dnf with
+        | key            | value |
+        | proxy_username | user  |
+   When I execute dnf with args "repoquery abcde"
+   Then the exit code is 1
+    And stderr contains "'proxy_username' is set but not 'proxy_password'"
+
+
+@bz1888946
+Scenario: Repository option 'proxy_username' is set but not 'proxy_password'
+  Given I use repository "dnf-ci-fedora" with configuration
+        | key            | value |
+        | proxy_username | user  |
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "repoquery abcde"
+   Then the exit code is 1
+    And stderr contains "'proxy_username' is set but not 'proxy_password'"

--- a/dnf-behave-tests/features/microdnf/error_messages.feature
+++ b/dnf-behave-tests/features/microdnf/error_messages.feature
@@ -1,0 +1,24 @@
+Feature: Test error messages
+
+
+@bz1888946
+Scenario: Global option 'proxy_username' is set but not 'proxy_password'
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+    And I configure dnf with
+        | key            | value |
+        | proxy_username | user  |
+   When I execute microdnf with args "repoquery abcde"
+   Then the exit code is 1
+    And stderr contains "'proxy_username' is set but not 'proxy_password'"
+
+
+@bz1888946
+Scenario: Repository option 'proxy_username' is set but not 'proxy_password'
+  Given I use repository "dnf-ci-fedora" with configuration
+        | key            | value |
+        | proxy_username | user  |
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "repoquery abcde"
+   Then the exit code is 1
+    And stderr contains "'proxy_username' is set but not 'proxy_password'"


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/libdnf/pull/1087