### PR TITLE
microdnf: Add tests of "upgrade" command

### DIFF
--- a/dnf-behave-tests/features/microdnf/upgrade-all.feature
+++ b/dnf-behave-tests/features/microdnf/upgrade-all.feature
@@ -1,0 +1,55 @@
+Feature: Upgrade all RPMs
+
+
+Background: Install some RPMs from one repository
+  Given I use repository "dnf-ci-fedora"
+    # "/usr" directory is needed to load rpm database (to overcome bad heuristics in libdnf created by Colin Walters)
+    And I create directory "/usr"
+   When I execute microdnf with args "install glibc flac wget"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | install       | glibc-0:2.28-9.fc29.x86_64                |
+        | install       | flac-0:1.3.2-8.fc29.x86_64                |
+        | install       | wget-0:1.19.5-5.fc29.x86_64               |
+        | install-dep   | setup-0:2.12.1-1.fc29.noarch              |
+        | install-dep   | filesystem-0:3.9-2.fc29.x86_64            |
+        | install-dep   | basesystem-0:11-6.fc29.noarch             |
+        | install-dep   | glibc-common-0:2.28-9.fc29.x86_64         |
+        | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario: Upgrade all RPMs from one repository
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+        | upgrade       | flac-0:1.3.3-3.fc29.x86_64                |
+        | upgraded      | flac-0:1.3.2-8.fc29.x86_64                |
+        | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
+        | upgraded      | wget-0:1.19.5-5.fc29.x86_64               |
+
+
+Scenario: Upgrade all RPMs from one repository using '*'
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade '*'"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+        | upgrade       | flac-0:1.3.3-3.fc29.x86_64                |
+        | upgraded      | flac-0:1.3.2-8.fc29.x86_64                |
+        | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
+        | upgraded      | wget-0:1.19.5-5.fc29.x86_64               |

--- a/dnf-behave-tests/features/microdnf/upgrade-pkgspec.feature
+++ b/dnf-behave-tests/features/microdnf/upgrade-pkgspec.feature
@@ -1,0 +1,73 @@
+Feature: Upgrade RPMs by pkgspec
+
+
+Background: Install glibc
+  Given I use repository "dnf-ci-fedora"
+    # "/usr" directory is needed to load rpm database (to overcome bad heuristics in libdnf created by Colin Walters)
+    And I create directory "/usr"
+   When I execute microdnf with args "install glibc"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | install       | glibc-0:2.28-9.fc29.x86_64                |
+        | install-dep   | setup-0:2.12.1-1.fc29.noarch              |
+        | install-dep   | filesystem-0:3.9-2.fc29.x86_64            |
+        | install-dep   | basesystem-0:11-6.fc29.noarch             |
+        | install-dep   | glibc-common-0:2.28-9.fc29.x86_64         |
+        | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario Outline: Upgrade an RPM by <pkgspec-type>
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade <pkgspec>"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+@tier1
+Examples: Name
+  | pkgspec-type                    | pkgspec                       |
+  | name                            | glibc                         |
+
+Examples: Other pkgspecs
+  | pkgspec-type                    | pkgspec                       |
+  | name-version                    | glibc-2.28                    |
+  | name-version-release            | glibc-2.28-26.fc29            |
+  | name-version-release.arch       | glibc-2.28-26.fc29.x86_64     |
+  | name-epoch:version-release.arch | glibc-0:2.28-26.fc29.x86_64   |
+  | name.arch                       | glibc.x86_64                  |
+
+
+Scenario: Upgrade an RPM by name containing dashes
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade glibc-common"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario: Upgrade an RPM by pkgspec contining wildcards
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade glibc-*.x86_64"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |

--- a/dnf-behave-tests/features/microdnf/upgrade-provides.feature
+++ b/dnf-behave-tests/features/microdnf/upgrade-provides.feature
@@ -1,0 +1,96 @@
+Feature: Upgrade RPMs by provides
+
+
+Background: Install glibc
+  Given I use repository "dnf-ci-fedora"
+    # "/usr" directory is needed to load rpm database (to overcome bad heuristics in libdnf created by Colin Walters)
+    And I create directory "/usr"
+   When I execute microdnf with args "install glibc"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | install       | glibc-0:2.28-9.fc29.x86_64                |
+        | install-dep   | setup-0:2.12.1-1.fc29.noarch              |
+        | install-dep   | filesystem-0:3.9-2.fc29.x86_64            |
+        | install-dep   | basesystem-0:11-6.fc29.noarch             |
+        | install-dep   | glibc-common-0:2.28-9.fc29.x86_64         |
+        | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario Outline: Upgrade an RPM by provide <operator> e:v-r
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade 'glibc <operator> <e:v-r>'"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+@tier1
+Examples:
+  | operator      | e:v-r                |
+  | =             | 0:2.28-26.fc29       |
+  | >             | 0:2.28-9.fc29        |
+  | >=            | 0:2.28-26.fc29       |
+  | <             | 0:2.28-27.fc29       |
+  | <=            | 0:2.28-26.fc29       |
+
+
+Scenario: Upgrade an RPM by provide
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade 'libm.so.6()(64bit)'"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario: Upgrade an RPM by file provide
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade /etc/ld.so.conf"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario: Upgrade an RPM by file provide that is directory
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade /var/db"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario: Upgrade an RPM by file provide containing wildcards
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade /etc/ld*.conf"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |

--- a/dnf-behave-tests/features/microdnf/upgrade.feature
+++ b/dnf-behave-tests/features/microdnf/upgrade.feature
@@ -1,0 +1,131 @@
+Feature: Upgrade single RPMs
+
+
+Background: Install RPMs
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty"
+    # "/usr" directory is needed to load rpm database (to overcome bad heuristics in libdnf created by Colin Walters)
+    And I create directory "/usr"
+   When I execute microdnf with args "install glibc flac wget SuperRipper"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | install       | glibc-0:2.28-9.fc29.x86_64                |
+        | install       | flac-0:1.3.2-8.fc29.x86_64                |
+        | install       | wget-0:1.19.5-5.fc29.x86_64               |
+        | install       | SuperRipper-0:1.0-1.x86_64                |
+        | install-dep   | setup-0:2.12.1-1.fc29.noarch              |
+        | install-dep   | filesystem-0:3.9-2.fc29.x86_64            |
+        | install-dep   | basesystem-0:11-6.fc29.noarch             |
+        | install-dep   | glibc-common-0:2.28-9.fc29.x86_64         |
+        | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+        | install-dep   | abcde-0:2.9.2-1.fc29.noarch               |
+        | install-weak  | FlacBetterEncoder-0:1.0-1.x86_64          |
+
+
+@tier1
+Scenario: Upgrade one RPM
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade glibc"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario: Upgrade one RPM using "update" command alias
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "update glibc"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+
+
+Scenario: Upgrade two RPMs
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute microdnf with args "upgrade glibc flac"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+        | upgrade       | flac-0:1.3.3-3.fc29.x86_64                |
+        | upgraded      | flac-0:1.3.2-8.fc29.x86_64                |
+
+
+@tier1
+@bz1670776 @bz1671683
+Scenario: Upgrade all RPMs from multiple repositories with best=False
+  Given I use repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates-testing"
+    And I use repository "dnf-ci-thirdparty-updates"
+  Given I configure dnf with
+        | key  | value |
+        | best | False |
+   When I execute microdnf with args "upgrade"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+        | upgrade       | flac-0:1.4.0-1.fc29.x86_64                |
+        | upgraded      | flac-0:1.3.2-8.fc29.x86_64                |
+        | upgrade       | wget-1:1.19.5-5.fc29.x86_64               |
+        | upgraded      | wget-0:1.19.5-5.fc29.x86_64               |
+        | upgrade       | SuperRipper-0:1.2-1.x86_64                |
+        | upgraded      | SuperRipper-0:1.0-1.x86_64                |
+        | upgrade       | abcde-0:2.9.3-1.fc29.noarch               |
+        | upgraded      | abcde-0:2.9.2-1.fc29.noarch               |
+
+
+@tier1
+@bz1670776 @bz1671683
+Scenario: Upgrade all RPMs from multiple repositories with best=True
+  Given I use repository "dnf-ci-fedora-updates"
+  Given I use repository "dnf-ci-fedora-updates-testing"
+    And I use repository "dnf-ci-thirdparty-updates"
+   When I execute microdnf with args "upgrade"
+   Then the exit code is 1
+    And stderr is
+    """
+    error: Could not depsolve transaction; 1 problem detected:
+     Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
+      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64
+    """
+   When I execute microdnf with args "upgrade --nobest"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                                   |
+        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
+        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
+        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+        | upgrade       | flac-0:1.4.0-1.fc29.x86_64                |
+        | upgraded      | flac-0:1.3.2-8.fc29.x86_64                |
+        | upgrade       | wget-1:1.19.5-5.fc29.x86_64               |
+        | upgraded      | wget-0:1.19.5-5.fc29.x86_64               |
+        | upgrade       | SuperRipper-0:1.2-1.x86_64                |
+        | upgraded      | SuperRipper-0:1.0-1.x86_64                |
+        | upgrade       | abcde-0:2.9.3-1.fc29.noarch               |
+        | upgraded      | abcde-0:2.9.2-1.fc29.noarch               |


### PR DESCRIPTION
These microdnf tests are based on DNF tests.

Requires microdnf PR:
https://github.com/rpm-software-management/microdnf/pull/93

Requires fixes/improvements of CI stack:
https://github.com/rpm-software-management/ci-dnf-stack/pull/930
https://github.com/rpm-software-management/ci-dnf-stack/pull/931

Requested in:
https://bugzilla.redhat.com/show_bug.cgi?id=1905471