### PR TITLE
Add @not.with_os=rhel__eq__8

### DIFF
--- a/dnf-behave-tests/features/microdnf/config-with-repos.feature
+++ b/dnf-behave-tests/features/microdnf/config-with-repos.feature
@@ -21,6 +21,7 @@ Background: Configure repositories in the main configuration file
         | baseurl  | http://url.xyz         |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repositories configured only in the main configuration file
    When I execute microdnf with args "repolist --all"
    Then the exit code is 0
@@ -33,6 +34,7 @@ Scenario: Repositories configured only in the main configuration file
      """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repositories configured in the main configuration file and in *.repo files
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates" with configuration

--- a/dnf-behave-tests/features/microdnf/config.feature
+++ b/dnf-behave-tests/features/microdnf/config.feature
@@ -37,6 +37,7 @@ Given I copy repository "simple-base" for modification
 
 
 @bz1866253
+@not.with_os=rhel__eq__8
 Scenario: microdnf respects --config option
 Given I use repository "simple-base"
   And I create file "/test/microdnf.conf" with

--- a/dnf-behave-tests/features/microdnf/install-nodocs-1.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-1.feature
@@ -2,6 +2,7 @@
 Feature: microdnf install command on packages
 
 
+@not.with_os=rhel__eq__8
 Scenario: Install a documentation package from local repodata
 Given I use repository "microdnf-install-nodocs"
  When I execute microdnf with args "install man-pages"

--- a/dnf-behave-tests/features/microdnf/install-nodocs-2.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-2.feature
@@ -3,6 +3,7 @@ Feature: microdnf install command on packages
 
 
 @bz1769831
+@not.with_os=rhel__eq__8
 Scenario: Install package with option from local repodata with local packages
 Given I use repository "microdnf-install-nodocs"
  When I execute microdnf with args "--setopt=tsflags=nodocs install man-pages"

--- a/dnf-behave-tests/features/microdnf/install-nodocs-3.feature
+++ b/dnf-behave-tests/features/microdnf/install-nodocs-3.feature
@@ -3,6 +3,7 @@ Feature: microdnf install command on packages
 
 
 @bz1771012
+@not.with_os=rhel__eq__8
 Scenario: Install package with --nodocs option from local repodata with local packages
 Given I use repository "microdnf-install-nodocs"
   And I execute microdnf with args "--nodocs install man-pages"

--- a/dnf-behave-tests/features/microdnf/install1.feature
+++ b/dnf-behave-tests/features/microdnf/install1.feature
@@ -4,6 +4,7 @@ Feature: microdnf install command on packages
 
 @bz1734350
 @bz1779757
+@not.with_os=rhel__eq__8
 Scenario: Install package from local repodata with local packages
 #1. local repo with local packages
 Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/features/microdnf/install2.feature
+++ b/dnf-behave-tests/features/microdnf/install2.feature
@@ -3,6 +3,7 @@ Feature: microdnf install command on packages
 
 
 @bz1734350
+@not.with_os=rhel__eq__8
 Scenario: Install package from local repodata with local xml:base
 #2. local repo with local packages (different package location specified using xml:base)
 Given I copy repository "dnf-ci-fedora" for modification

--- a/dnf-behave-tests/features/microdnf/install3.feature
+++ b/dnf-behave-tests/features/microdnf/install3.feature
@@ -3,6 +3,7 @@ Feature: microdnf install command on packages
 
 
 @bz1734350
+@not.with_os=rhel__eq__8
 Scenario: Install package from local repodata with xml:base pointing to remote packages
 #3. local repo with remote packages (different package location specified using xml:base)
 Given I make packages from repository "dnf-ci-fedora" accessible via http

--- a/dnf-behave-tests/features/microdnf/install4.feature
+++ b/dnf-behave-tests/features/microdnf/install4.feature
@@ -3,6 +3,7 @@ Feature: microdnf install command on packages
 
 
 @bz1734350
+@not.with_os=rhel__eq__8
 Scenario: Install packages from local repodata that have packages with xml:base pointing to a remote as well as local packages
 #4. local repo with local and remote packages; installing both at the same time.
 Given I make packages from repository "dnf-ci-fedora" accessible via http

--- a/dnf-behave-tests/features/microdnf/install5.feature
+++ b/dnf-behave-tests/features/microdnf/install5.feature
@@ -3,6 +3,7 @@ Feature: microdnf install command on packages
 
 
 @bz1734350
+@not.with_os=rhel__eq__8
 Scenario: Install packages from remote repodata with remote packages
 #5. remote repo with remote packages
 Given I use repository "dnf-ci-fedora" as http

--- a/dnf-behave-tests/features/microdnf/install6.feature
+++ b/dnf-behave-tests/features/microdnf/install6.feature
@@ -3,6 +3,7 @@ Feature: microdnf install command on packages
 
 
 @bz1734350
+@not.with_os=rhel__eq__8
 Scenario: Install packages from remote repodata with xml:base pointing to packages on different remote
 #6. remote repo with remote packages (different package location (different url) specified using xml:base)
 Given I make packages from repository "dnf-ci-fedora" accessible via http

--- a/dnf-behave-tests/features/microdnf/install7.feature
+++ b/dnf-behave-tests/features/microdnf/install7.feature
@@ -3,6 +3,7 @@ Feature: Install package
 
 
 @bz1691353
+@not.with_os=rhel__eq__8
 Scenario: Install an RPM without null lines
   Given I use repository "dnf-ci-fedora"
    When I execute microdnf with args "install lame"

--- a/dnf-behave-tests/features/microdnf/install_weak_deps.feature
+++ b/dnf-behave-tests/features/microdnf/install_weak_deps.feature
@@ -5,6 +5,7 @@ Background: Prepare environment
  Given I use repository "dnf-ci-fedora"
 
 
+@not.with_os=rhel__eq__8
 Scenario: Install "abcde" without weak dependencies
    When I execute microdnf with args "install --setopt=install_weak_deps=0 abcde"
    Then the exit code is 0
@@ -14,6 +15,7 @@ Scenario: Install "abcde" without weak dependencies
         | install       | wget-0:1.19.5-5.fc29.x86_64               |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Install "abcde" with weak dependencies
    When I execute microdnf with args "install --setopt=install_weak_deps=1 abcde"
    Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/metadata_cache.feature
+++ b/dnf-behave-tests/features/microdnf/metadata_cache.feature
@@ -1,6 +1,7 @@
 Feature: microdnf can use repository metadata cache
 
 @bz1771147
+@not.with_os=rhel__eq__8
 Scenario: Microdnf respects metadata_expire
 Given I use repository "simple-base" as http
  When I execute microdnf with args "repoquery labirinto"

--- a/dnf-behave-tests/features/microdnf/protect-running-kernel.feature
+++ b/dnf-behave-tests/features/microdnf/protect-running-kernel.feature
@@ -9,6 +9,7 @@ Background: Install fake kernel
 
 
 @bz1698145
+@not.with_os=rhel__eq__8
 Scenario: Running kernel is protected
    When I execute microdnf with args "remove dnf-ci-kernel"
    Then the exit code is 1
@@ -20,6 +21,7 @@ Scenario: Running kernel is protected
 
 
 @bz1698145
+@not.with_os=rhel__eq__8
 Scenario: Running kernel is not protected with config protect_running_kernel=False
   Given I configure dnf with
         | key                       | value            |
@@ -32,6 +34,7 @@ Scenario: Running kernel is not protected with config protect_running_kernel=Fal
 
 
 @bz1698145
+@not.with_os=rhel__eq__8
 Scenario: Running kernel is protected when in protected_packages even with config protect_running_kernel=False
   Given I configure dnf with
         | key                       | value            |
@@ -46,6 +49,7 @@ Scenario: Running kernel is protected when in protected_packages even with confi
 
 
 @bz1698145
+@not.with_os=rhel__eq__8
 Scenario: Running kernel is protected against obsoleting
    When I execute microdnf with args "install dnf-ci-obsolete"
    Then the exit code is 1

--- a/dnf-behave-tests/features/microdnf/reinstall-reason.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall-reason.feature
@@ -3,6 +3,7 @@ Feature: Reinstall must keep the "reason" why a package was installed
   E.g. if package with dependency is installed, and the dependency is reinstalled, and the main package is then removed, the dependency is removed as well.
 
 
+@not.with_os=rhel__eq__8
 # no bug, PR https://github.com/rpm-software-management/microdnf/pull/61
 Scenario: Reinstall a dependency, and then remove the main package
   Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/features/microdnf/reinstall1.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall1.feature
@@ -13,6 +13,7 @@ Background: Install CQRlib-devel and CQRlib
         | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Reinstall an RPM from the same repository
    When I execute microdnf with args "reinstall CQRlib"
    Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/reinstall2.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall2.feature
@@ -13,6 +13,7 @@ Background: Install CQRlib-devel and CQRlib
         | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Reinstall an RPM from different repository
   Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute microdnf with args "reinstall CQRlib"

--- a/dnf-behave-tests/features/microdnf/reinstall3.feature
+++ b/dnf-behave-tests/features/microdnf/reinstall3.feature
@@ -13,6 +13,7 @@ Background: Install CQRlib-devel and CQRlib
         | install       | CQRlib-devel-0:1.1.2-16.fc29.x86_64       |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Reinstall an RPM that is not available
   Given I drop repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "reinstall CQRlib"

--- a/dnf-behave-tests/features/microdnf/repo-config.feature
+++ b/dnf-behave-tests/features/microdnf/repo-config.feature
@@ -23,6 +23,7 @@ Given I use repository "simple-base"
 
 
 @bz1807864
+@not.with_os=rhel__eq__8
 Scenario: multiline config for gpg works with remote repo
 Given I use repository "simple-base" as http
   And I create and substitute file "/etc/yum.repos.d/simple-base.repo" with
@@ -43,6 +44,7 @@ Given I use repository "simple-base" as http
 
 
 @bz1807864
+@not.with_os=rhel__eq__8
 Scenario: multiline multivalue comma and space separated config for gpg works with remote repo
 Given I use repository "simple-base" as http
   And I create and substitute file "/etc/yum.repos.d/simple-base.repo" with
@@ -62,6 +64,7 @@ Given I use repository "simple-base" as http
       | install       | dedalo-signed-0:1.0-1.fc29.x86_64 |
 
 
+@not.with_os=rhel__eq__8
 Scenario: multiline config for baseurl
 Given I use repository "simple-base" as http
   And I create and substitute file "/etc/yum.repos.d/simple-base.repo" with
@@ -81,6 +84,7 @@ Given I use repository "simple-base" as http
 
 
 @bz1797265
+@not.with_os=rhel__eq__8
 Scenario: install older version of available pkg from repo with higher (smaller number) priority
 Given I use repository "simple-base" with configuration
       | key      | value |

--- a/dnf-behave-tests/features/microdnf/repolist-disabled.feature
+++ b/dnf-behave-tests/features/microdnf/repolist-disabled.feature
@@ -9,18 +9,21 @@ Background:
         | enabled | 0     |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist without arguments
    When I execute microdnf with args "repolist"
    Then the exit code is 0
     And stdout is empty
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist with "--enabled"
    When I execute microdnf with args "repolist --enabled"
    Then the exit code is 0
     And stdout is empty
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist with "--disabled"
    When I execute microdnf with args "repolist --disabled"
    Then the exit code is 0
@@ -31,6 +34,7 @@ Scenario: Repolist with "--disabled"
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist with "--all"
    When I execute microdnf with args "repolist --all"
    Then the exit code is 0
@@ -41,6 +45,7 @@ Scenario: Repolist with "--all"
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist with "--enabled --disabled"
    When I execute microdnf with args "repolist --enabled --disabled"
    Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/repolist.feature
+++ b/dnf-behave-tests/features/microdnf/repolist.feature
@@ -14,6 +14,7 @@ Background: Using repositories dnf-ci-fedora and dnf-ci-thirdparty-updates
         | enabled | 0     |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist without arguments
    When I execute microdnf with args "repolist"
    Then the exit code is 0
@@ -25,6 +26,7 @@ Scenario: Repolist without arguments
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist with "--enabled"
    When I execute microdnf with args "repolist --enabled"
    Then the exit code is 0
@@ -36,6 +38,7 @@ Scenario: Repolist with "--enabled"
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist with "--disabled"
    When I execute microdnf with args "repolist --disabled"
    Then the exit code is 0
@@ -47,6 +50,7 @@ Scenario: Repolist with "--disabled"
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist with "--all"
    When I execute microdnf with args "repolist --all"
    Then the exit code is 0
@@ -60,6 +64,7 @@ Scenario: Repolist with "--all"
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Repolist with "--enabled --disabled"
    When I execute microdnf with args "repolist --enabled --disabled"
    Then the exit code is 0
@@ -75,6 +80,7 @@ Scenario: Repolist with "--enabled --disabled"
 
 # Tests for "--disablerepo" and "--enablerepo" including wildcards support
 @bz1781420
+@not.with_os=rhel__eq__8
 Scenario: Disable all repos and then enable "dnf-ci-fedora-updates" repo
    When I execute microdnf with args "repolist --disablerepo=* --enablerepo=dnf-ci-fedora-updates --all"
    Then the exit code is 0
@@ -88,6 +94,7 @@ Scenario: Disable all repos and then enable "dnf-ci-fedora-updates" repo
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Disable "dnf-ci-thirdparty*" repos and enable "dnf-ci-fedora*" repos
    When I execute microdnf with args "repolist --disablerepo=dnf-ci-thirdparty* --enablerepo=dnf-ci-fedora* --all"
    Then the exit code is 0
@@ -101,6 +108,7 @@ Scenario: Disable "dnf-ci-thirdparty*" repos and enable "dnf-ci-fedora*" repos
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Only "*-updates" repos are enabled
    When I execute microdnf with args "repolist --disablerepo=* --enablerepo=*-updates --all"
    Then the exit code is 0
@@ -114,6 +122,7 @@ Scenario: Only "*-updates" repos are enabled
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: Test '?' wildcard. Only "dnf-ci-fedora-updates" repo is enabled
    When I execute microdnf with args "repolist --disablerepo=* --enablerepo=dnf-ci-??????-* --all"
    Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/repoquery-globs.feature
+++ b/dnf-behave-tests/features/microdnf/repoquery-globs.feature
@@ -7,6 +7,7 @@ Background:
 
 
 # <name> globs
+@not.with_os=rhel__eq__8
 Scenario: repoquery '*' (lists all available packages)
  When I execute microdnf with args "repoquery '*'"
  Then the exit code is 0
@@ -30,6 +31,7 @@ Scenario: repoquery '*' (lists all available packages)
       toppler-1:1.0-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery top*
  When I execute microdnf with args "repoquery top*"
  Then the exit code is 0
@@ -47,6 +49,7 @@ Scenario: repoquery top*
       toppler-1:1.0-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery top?d
  When I execute microdnf with args "repoquery top?d"
  Then the exit code is 0
@@ -56,6 +59,7 @@ Scenario: repoquery top?d
       toped-1:1.0-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery top?{d,it}
  When I execute microdnf with args "repoquery top?{{d,it}}"
  Then the exit code is 0
@@ -69,6 +73,7 @@ Scenario: repoquery top?{d,it}
       topgit-1:1.17.6-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery top[a-f]d
  When I execute microdnf with args "repoquery top[a-f]d"
  Then the exit code is 0
@@ -78,6 +83,7 @@ Scenario: repoquery top[a-f]d
       toped-1:1.0-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery top[a-fg]*
  When I execute microdnf with args "repoquery top[a-fg]*"
  Then the exit code is 0
@@ -91,6 +97,7 @@ Scenario: repoquery top[a-fg]*
       topgit-1:1.17.6-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery top[^a-g]*
  When I execute microdnf with args "repoquery top[^a-g]*"
  Then the exit code is 0
@@ -100,6 +107,7 @@ Scenario: repoquery top[^a-g]*
       toppler-1:1.0-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery top{ed,pler}
  When I execute microdnf with args "repoquery top{{ed,pler}}"
  Then the exit code is 0
@@ -111,6 +119,7 @@ Scenario: repoquery top{ed,pler}
       toppler-1:1.0-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery top[!n-z]{d,aaa,it}
  When I execute microdnf with args "repoquery top[!n-z]{{d,aaa,it}}"
  Then the exit code is 0
@@ -124,6 +133,7 @@ Scenario: repoquery top[!n-z]{d,aaa,it}
       topgit-1:1.17.6-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery *top[-a-f]*
  When I execute microdnf with args "repoquery *top[-a-f]*"
  Then the exit code is 0
@@ -139,6 +149,7 @@ Scenario: repoquery *top[-a-f]*
 
 
 # <name-version> globs
+@not.with_os=rhel__eq__8
 Scenario: repoquery *top[-a-f]*-1.0
  When I execute microdnf with args "repoquery *top[-a-f]*-1.0"
  Then the exit code is 0
@@ -150,6 +161,7 @@ Scenario: repoquery *top[-a-f]*-1.0
       toped-1:1.0-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery *top[-a-f]*-1.[1-4]*
  When I execute microdnf with args "repoquery *top[-a-f]*-1.[1-4]*"
  Then the exit code is 0
@@ -159,6 +171,7 @@ Scenario: repoquery *top[-a-f]*-1.[1-4]*
       desktop-utils-1:1.23.9-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery *top[-a-f]*-1.[!1-4]*.x86_64
  When I execute microdnf with args "repoquery *top[-a-f]*-1.[!1-4]*.x86_64"
  Then the exit code is 0
@@ -168,6 +181,7 @@ Scenario: repoquery *top[-a-f]*-1.[!1-4]*.x86_64
       toped-1:1.0-1.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery *top*-1.{17,23,99}*
  When I execute microdnf with args "repoquery *top*-1.{{17,23,99}}*"
  Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/repoquery.feature
+++ b/dnf-behave-tests/features/microdnf/repoquery.feature
@@ -7,6 +7,7 @@ Background:
 
 
 # simple nevra matching tests
+@not.with_os=rhel__eq__8
 Scenario: repoquery (no arguments, i.e. list all packages)
  When I execute microdnf with args "repoquery"
  Then the exit code is 0
@@ -36,11 +37,13 @@ Scenario: repoquery (no arguments, i.e. list all packages)
       top-a-2:2.0-2.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME (nonexisting package)
  When I execute microdnf with args "repoquery dummy"
  Then the exit code is 0
   And stdout is empty
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME
  When I execute microdnf with args "repoquery top-a"
  Then the exit code is 0
@@ -54,6 +57,7 @@ Scenario: repoquery NAME
       top-a-2:2.0-2.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME-VERSION
  When I execute microdnf with args "repoquery top-a-2.0"
  Then the exit code is 0
@@ -65,6 +69,7 @@ Scenario: repoquery NAME-VERSION
       top-a-2:2.0-2.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME-VERSION-RELEASE
  When I execute microdnf with args "repoquery top-a-2.0-2"
  Then the exit code is 0
@@ -74,6 +79,7 @@ Scenario: repoquery NAME-VERSION-RELEASE
       top-a-2:2.0-2.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME-EPOCH:VERSION-RELEASE
  When I execute microdnf with args "repoquery top-a-2:2.0-2"
  Then the exit code is 0
@@ -83,11 +89,13 @@ Scenario: repoquery NAME-EPOCH:VERSION-RELEASE
       top-a-2:2.0-2.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME-EPOCH:VERSION-RELEASE old epoch
  When I execute microdnf with args "repoquery top-a-1:2.0-2"
  Then the exit code is 0
   And stdout is empty
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME NAME-EPOCH:VERSION-RELEASE
  When I execute microdnf with args "repoquery bottom-a1 top-a-2:2.0-2"
  Then the exit code is 0
@@ -101,6 +109,7 @@ Scenario: repoquery NAME NAME-EPOCH:VERSION-RELEASE
       top-a-2:2.0-2.x86_64
       """
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME-VERSION NAME-EPOCH:VERSION_GLOB-RELEASE
  When I execute microdnf with args "repoquery bottom-a1-1.0 top-a-1:[12].0-1"
  Then the exit code is 0
@@ -116,6 +125,7 @@ Scenario: repoquery NAME-VERSION NAME-EPOCH:VERSION_GLOB-RELEASE
 
 @xfail
 @bz1735687
+@not.with_os=rhel__eq__8
 Scenario: repoquery NAME-VERSION NAME-EPOCH:VERSION_GLOB2-RELEASE
  When I execute microdnf with args "repoquery bottom-a1-1.0 top-a-1:[1-2].0-1"
  Then the exit code is 0
@@ -131,6 +141,7 @@ Scenario: repoquery NAME-VERSION NAME-EPOCH:VERSION_GLOB2-RELEASE
 
 
 # --available is the default, scenarios above should cover it
+@not.with_os=rhel__eq__8
 Scenario: dnf repoquery --available NAME
  When I execute microdnf with args "repoquery --available top-a-2.0"
  Then the exit code is 0
@@ -143,12 +154,14 @@ Scenario: dnf repoquery --available NAME
       """
 
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery --installed NAME (no such packages)
  When I execute microdnf with args "repoquery --installed bottom-a1"
  Then the exit code is 0
   And stdout is empty
 
 
+@not.with_os=rhel__eq__8
 Scenario: repoquery --installed NAME
 Given I successfully execute microdnf with args "install bottom-a1 bottom-a2"
  When I execute microdnf with args "repoquery --installed bottom-a1"

--- a/dnf-behave-tests/features/microdnf/upgrade-all.feature
+++ b/dnf-behave-tests/features/microdnf/upgrade-all.feature
@@ -19,6 +19,7 @@ Background: Install some RPMs from one repository
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade all RPMs from one repository
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade"
@@ -37,6 +38,7 @@ Scenario: Upgrade all RPMs from one repository
         | upgraded      | wget-0:1.19.5-5.fc29.x86_64               |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade all RPMs from one repository using '*'
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade '*'"

--- a/dnf-behave-tests/features/microdnf/upgrade-pkgspec.feature
+++ b/dnf-behave-tests/features/microdnf/upgrade-pkgspec.feature
@@ -17,6 +17,7 @@ Background: Install glibc
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario Outline: Upgrade an RPM by <pkgspec-type>
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade <pkgspec>"
@@ -45,6 +46,7 @@ Examples: Other pkgspecs
   | name.arch                       | glibc.x86_64                  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade an RPM by name containing dashes
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade glibc-common"
@@ -59,6 +61,7 @@ Scenario: Upgrade an RPM by name containing dashes
         | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade an RPM by pkgspec contining wildcards
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade glibc-*.x86_64"

--- a/dnf-behave-tests/features/microdnf/upgrade-provides.feature
+++ b/dnf-behave-tests/features/microdnf/upgrade-provides.feature
@@ -17,6 +17,7 @@ Background: Install glibc
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario Outline: Upgrade an RPM by provide <operator> e:v-r
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade 'glibc <operator> <e:v-r>'"
@@ -40,6 +41,7 @@ Examples:
   | <=            | 0:2.28-26.fc29       |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade an RPM by provide
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade 'libm.so.6()(64bit)'"
@@ -54,6 +56,7 @@ Scenario: Upgrade an RPM by provide
         | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade an RPM by file provide
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade /etc/ld.so.conf"
@@ -68,6 +71,7 @@ Scenario: Upgrade an RPM by file provide
         | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade an RPM by file provide that is directory
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade /var/db"
@@ -82,6 +86,7 @@ Scenario: Upgrade an RPM by file provide that is directory
         | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade an RPM by file provide containing wildcards
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade /etc/ld*.conf"

--- a/dnf-behave-tests/features/microdnf/upgrade.feature
+++ b/dnf-behave-tests/features/microdnf/upgrade.feature
@@ -24,6 +24,7 @@ Background: Install RPMs
 
 
 @tier1
+@not.with_os=rhel__eq__8
 Scenario: Upgrade one RPM
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade glibc"
@@ -38,6 +39,7 @@ Scenario: Upgrade one RPM
         | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade one RPM using "update" command alias
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "update glibc"
@@ -52,6 +54,7 @@ Scenario: Upgrade one RPM using "update" command alias
         | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: Upgrade two RPMs
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade glibc flac"
@@ -70,6 +73,7 @@ Scenario: Upgrade two RPMs
 
 @tier1
 @bz1670776 @bz1671683
+@not.with_os=rhel__eq__8
 Scenario: Upgrade all RPMs from multiple repositories with best=False
   Given I use repository "dnf-ci-fedora-updates"
   Given I use repository "dnf-ci-fedora-updates-testing"
@@ -99,6 +103,7 @@ Scenario: Upgrade all RPMs from multiple repositories with best=False
 
 @tier1
 @bz1670776 @bz1671683
+@not.with_os=rhel__eq__8
 Scenario: Upgrade all RPMs from multiple repositories with best=True
   Given I use repository "dnf-ci-fedora-updates"
   Given I use repository "dnf-ci-fedora-updates-testing"

--- a/dnf-behave-tests/features/module/add-new-stream-static-context.feature
+++ b/dnf-behave-tests/features/module/add-new-stream-static-context.feature
@@ -4,7 +4,7 @@ Feature: Handling new stream with multicontext modules
 Background:
   Given I set default module platformid to "platform:f29"
 
-
+@not.with_os=rhel__eq__8
 Scenario: Enable new stream with multicontext stream enabled
   Given I use repository "dnf-ci-multicontext-hybrid-multiversion-modular"
     And I use repository "dnf-ci-multicontext-hybrid-multiversion-modular-updates"

--- a/dnf-behave-tests/features/module/enable-contexts.feature
+++ b/dnf-behave-tests/features/module/enable-contexts.feature
@@ -44,6 +44,7 @@ Scenario: Any suitable context is selected when more options are possible
    Then the exit code is 0
 
 
+@not.with_os=rhel__eq__8
 Scenario: An error is printed with no stream and context is possible to enable
    When I execute dnf with args "module enable biotope:pond"
    Then the exit code is 0
@@ -55,6 +56,7 @@ Scenario: An error is printed with no stream and context is possible to enable
 
 
 @bz1670496
+@not.with_os=rhel__eq__8
 Scenario: An error is printed when trying to install different context
    When I execute dnf with args "module enable biotope:pond"
    Then the exit code is 0

--- a/dnf-behave-tests/features/module/enable-dependencies.feature
+++ b/dnf-behave-tests/features/module/enable-dependencies.feature
@@ -237,6 +237,7 @@ Scenario: Enable a module and its dependencies by specifying profile
 #        | food-type    | disabled  |            |           |
 #        | ingredience  | disabled  |            |           |
 
+@not.with_os=rhel__eq__8
 Scenario: Module cannot be disabled if there are other enabled streams requiring it
    When I execute dnf with args "module enable food-type:meat"
    Then the exit code is 0
@@ -297,6 +298,7 @@ Scenario: Enable the default stream of a module and its dependencies
 #        | ingredience  | enabled   | chicken    |           |
 
 # rely on merging bz1649261 fix
+@not.with_os=rhel__eq__8
 Scenario: Cannot enable a stream depending on a disabled module
    When I execute dnf with args "module disable food-type:meat ingredience:chicken"
    Then the exit code is 0

--- a/dnf-behave-tests/features/module/enable-errors.feature
+++ b/dnf-behave-tests/features/module/enable-errors.feature
@@ -96,6 +96,7 @@ Scenario: Fail to install a different stream of an already enabled module using 
         """
 
 @bz1814831
+@not.with_os=rhel__eq__8
 Scenario: Fail to enable a module stream when specifying only module
    When I execute dnf with args "module enable nodejs"
    Then the exit code is 1
@@ -159,6 +160,7 @@ Scenario: Fail to enable a module stream when specifying more streams of the sam
     And stderr contains "broken groups or modules: nodejs:10"
 
 
+@not.with_os=rhel__eq__8
 Scenario: Enabling a stream depending on other than enabled stream should fail
   Given I use repository "dnf-ci-thirdparty-modular"
     And I create file "/etc/dnf/modules.defaults.d/defaults.yaml" with
@@ -193,6 +195,7 @@ Scenario: Enabling a stream depending on other than enabled stream should fail
     And stderr contains "module beverage:soda:1:.x86_64 requires module\(fluid:water\), but none of the providers can be installed"
 
 
+@not.with_os=rhel__eq__8
 Scenario: Enabling a stream depending on a disabled stream should fail
   Given I use repository "dnf-ci-thirdparty-modular"
     And I create file "/etc/dnf/modules.defaults.d/defaults.yaml" with
@@ -230,6 +233,7 @@ Scenario: Enabling a stream depending on a disabled stream should fail
 
 # side-dish:chip requires fluid:oil
 # beverage:beer requires fluid:water
+@not.with_os=rhel__eq__8
 Scenario: Enabling two modules both requiring different streams of another module
   Given I use repository "dnf-ci-thirdparty-modular"
    When I execute dnf with args "module enable side-dish:chips beverage:beer"
@@ -241,6 +245,7 @@ Scenario: Enabling two modules both requiring different streams of another modul
 
 # beverage:beer requires fluid:water
 @bz1651280
+@not.with_os=rhel__eq__8
 Scenario: Enabling module stream and another module requiring another stream
   Given I use repository "dnf-ci-thirdparty-modular"
    When I execute dnf with args "module enable fluid:oil beverage:beer"

--- a/dnf-behave-tests/features/module/install-default.feature
+++ b/dnf-behave-tests/features/module/install-default.feature
@@ -21,6 +21,7 @@ Scenario: Install module, no default profile defined, expecting no profile selec
         """
 
 @bz1814831
+@not.with_os=rhel__eq__8
 Scenario: Install module, no default stream or profile defined, expecting no profile selection
    When I execute dnf with args "module install DnfCiModuleNoDefaults"
    Then the exit code is 1

--- a/dnf-behave-tests/features/module/install-module-static-context.feature
+++ b/dnf-behave-tests/features/module/install-module-static-context.feature
@@ -23,6 +23,7 @@ Scenario: Install module, profile from the latest module context without static_
         | module-profile-install    | nodejs/testlatest                                |
         | install-group             | postgresql-0:9.6.8-1.module_1710+b535a823.x86_64 |
 
+@not.with_os=rhel__eq__8
 Scenario: Install module, profile from the latest module context with static_context-=true
   Given I use repository "dnf-ci-multicontext-hybrid-multiversion-modular-static-context"
    When I execute dnf with args "module enable postgresql:9.6"
@@ -41,6 +42,7 @@ Scenario: Install module, profile from the latest module context with static_con
         | module-profile-install    | nodejs/testlatest                                   |
         | install-group             | postgresql-0:9.6.8-1.module_1710+b535a823_V3.x86_64 |
 
+@not.with_os=rhel__eq__8
 Scenario: Install module, profile and the latest package with static_context=true
   Given I use repository "dnf-ci-multicontext-hybrid-multiversion-modular-static-context"
    When I execute dnf with args "module enable postgresql:9.6"
@@ -59,6 +61,7 @@ Scenario: Install module, profile and the latest package with static_context=tru
         | module-profile-install    | nodejs/minimal                                  |
         | install-group             | nodejs-1:5.4.1-2.module_2011+41787af1_V3.x86_64 |
 
+@not.with_os=rhel__eq__8
 Scenario: Install and upgrade from context with broken dependencies => static_context=true
   Given I use repository "dnf-ci-static-context-requires-change"
    When I execute dnf with args "module install nodejs:5/minimal"
@@ -87,6 +90,7 @@ Scenario: Install and upgrade from context with broken dependencies => static_co
   nodejs-1:6.5.1-2.module_3012+41787ba4_V3.x86_64
   """
 
+@not.with_os=rhel__eq__8
 Scenario: Install and upgrade from context with broken dependencies => static_context=true
   Given I use repository "dnf-ci-static-context-requires-change"
    When I execute dnf with args "module install nodejs:5/nodejs-postgresql --best"

--- a/dnf-behave-tests/features/module/obsoletes.feature
+++ b/dnf-behave-tests/features/module/obsoletes.feature
@@ -10,6 +10,7 @@ Given I use repository "dnf-ci-fedora"
       | module_stream_switch | True  |
 
 
+@not.with_os=rhel__eq__8
 Scenario: stream is not switched according to obsoletes if options not enabled
 Given I execute dnf with args "module install nodejs:5/minimal"
   And I configure dnf with
@@ -24,6 +25,7 @@ Given I execute dnf with args "module install nodejs:5/minimal"
       | nodejs    | enabled   | 5         | minimal   |
 
 
+@not.with_os=rhel__eq__8
 Scenario: stream is switched according to obsoletes in new metadata
 Given I execute dnf with args "module install nodejs:5/minimal"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -34,6 +36,7 @@ Given I execute dnf with args "module install nodejs:5/minimal"
       | nodejs    | enabled   | 10        |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: two stream changes, one of which is obsoletes, do not throw exception
 Given I execute dnf with args "module enable nodejs:5"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -44,6 +47,7 @@ Given I execute dnf with args "module enable nodejs:5"
       | nodejs    |           |           |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: stream is resetted according to obsoletes in new metadata
 Given I execute dnf with args "module install nodejs:8/minimal"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -54,6 +58,7 @@ Given I execute dnf with args "module install nodejs:8/minimal"
       | nodejs    |           |           |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: stream is not resetted before the obsoletes_date in new metadata
 Given I execute dnf with args "module install nodejs:10/minimal"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -64,6 +69,7 @@ Given I execute dnf with args "module install nodejs:10/minimal"
       | nodejs    | enabled   | 10        | minimal   |
 
 
+@not.with_os=rhel__eq__8
 Scenario: stream with context is affected by general obsoletes without context specified
 Given I execute dnf with args "module install nodejs:11/minimal"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -74,6 +80,7 @@ Given I execute dnf with args "module install nodejs:11/minimal"
       | nodejs    |           |           |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: stream with two obsoletes is switched according to the newer one and switching to a different module resets the original one
 Given I execute dnf with args "module install nodejs:5/minimal"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -86,6 +93,7 @@ Given I execute dnf with args "module install nodejs:5/minimal"
       | nodejs     |            |           |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: obsoletes is applied before the current transaction is resolved (effects from obsoletes switch affect the current transaction)
 Given I execute dnf with args "module install nodejs:5/minimal"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -98,6 +106,7 @@ Given I execute dnf with args "module install nodejs:5/minimal"
       | nodejs     |            |           |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: stream is not affected if a valid obsoletes is superseded by a newer one which resets obsoletes
 Given I execute dnf with args "module install nodejs:8/minimal"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -109,6 +118,7 @@ Given I execute dnf with args "module install nodejs:8/minimal"
       | nodejs     | enabled    | 8         | minimal   |
 
 
+@not.with_os=rhel__eq__8
 Scenario: stream is affected if a valid obsoletes with reset is superseded by a newer obsoletes
 Given I execute dnf with args "module install postgresql:6/client"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -120,6 +130,7 @@ Given I execute dnf with args "module install postgresql:6/client"
       | postgresql |            |           |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: active obsoletes isn't affected by future obsoletes (with eol_date)
 Given I execute dnf with args "module install nodejs:11/minimal"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -131,6 +142,7 @@ Given I execute dnf with args "module install nodejs:11/minimal"
       | nodejs    |           |           |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: obsoletes with obsoleted_by and passed eol_date works
 Given I execute dnf with args "module install postgresql:9.6/client"
  When I use repository "dnf-ci-fedora-modular-obsoletes"
@@ -143,6 +155,7 @@ Given I execute dnf with args "module install postgresql:9.6/client"
       | dwm        | enabled    | 6.0       |           |
 
 
+@not.with_os=rhel__eq__8
 Scenario: setting reset into the future (with eol_date) is an error (invalid metadata)
 Given I create file "invalid_modules.yaml" with
       """

--- a/dnf-behave-tests/features/module/platform.feature
+++ b/dnf-behave-tests/features/module/platform.feature
@@ -15,7 +15,8 @@ Given I create file "/etc/os-release" with
     """
  And I do not set default module platformid
 
-  
+
+@not.with_os=rhel__eq__8
 Scenario: I can't enable module requiring different platform pseudo module
 Given I delete file "/etc/os-release"
  When I execute dnf with args "module enable dwm:6.0"

--- a/dnf-behave-tests/features/module/remove.feature
+++ b/dnf-behave-tests/features/module/remove.feature
@@ -208,6 +208,7 @@ Scenario: Packages belonging to multiple modules are not removed with --all
     And stdout does not contain "belongs to multiple modules, skipping"
 
 @bz1904490
+@not.with_os=rhel__eq__8
 Scenario: module removed with --all and not existing module argument - no traceback
   Given I use repository "dnf-ci-fifthparty"
     And I use repository "dnf-ci-fifthparty-modular"

--- a/dnf-behave-tests/features/plugins-core/reposync.feature
+++ b/dnf-behave-tests/features/plugins-core/reposync.feature
@@ -54,6 +54,7 @@ Scenario: Reposync with --downloadcomps option (comps.xml in repo does not exist
 
 
 @bz1895059
+@not.with_os=rhel__eq__8
 Scenario: Reposync with --downloadcomps option (the comps.xml in repodata is not compressed)
   Given I copy repository "dnf-ci-thirdparty-updates" for modification
     And I execute "modifyrepo_c --remove group_gz /{context.dnf.repos[dnf-ci-thirdparty-updates].path}/repodata"


### PR DESCRIPTION
Microdnf tests failing with:
error: (--setopt) Unable to handle: module_platform_id=platform:f29
Requires:
https://github.com/rpm-software-management/microdnf/commit/5621aa58e4cf808e37e91f6a56dcb12c486a65d0

features/module/enable-errors.feature
features/module/install-default.feature
Requires:
https://github.com/rpm-software-management/ci-dnf-stack/pull/923

features/module/remove.feature
Requires:
https://github.com/rpm-software-management/dnf/commit/7d10ddea6291399b3ed794c1d7fff326d2ec3e86

features/plugins-core/reposync.feature
Requires:
https://github.com/rpm-software-management/dnf/commit/01bb29796e926afc4889286513cde638dd8ef625

features/module/add-new-stream-static-context.feature
features/module/enable-contexts.feature
features/module/enable-dependencies.feature
features/module/enable-errors.feature
features/module/install-module-static-context.feature
features/module/platform.feature
Requires:
https://github.com/rpm-software-management/libdnf/pull/1018