### PR TITLE
Speed rpm -qa up by passing --nodigest --nosignature options

### DIFF
--- a/dnf-behave-tests/features/steps/lib/rpmdb.py
+++ b/dnf-behave-tests/features/steps/lib/rpmdb.py
@@ -21,6 +21,9 @@ def get_rpmdb_rpms(installroot="/"):
     """
     result = []
     ts = rpm.TransactionSet(installroot)
+    # we only need to retrieve NEVRAs from rpmdb
+    # skipping signature and digest verification cuts the execution time by ~60%
+    ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES|rpm._RPMVSF_NODIGESTS)
     for hdr in ts.dbMatch():
         name = _str(hdr["name"])
         evr = _str(hdr["evr"])


### PR DESCRIPTION
We need to list NEVRAs, digest or signature verification is not important.
Cuts rpm execution time by ~70%.