### PR TITLE
Use a tempdir as GPG home.

### DIFF
--- a/dnf-behave-tests/fixtures/gpgkeys/sign.sh
+++ b/dnf-behave-tests/fixtures/gpgkeys/sign.sh
@@ -24,34 +24,47 @@ for KEY_NAME in $KEYSPECS; do
     KEY_DIR="${DIR}/keys/${KEY_NAME}"
     mkdir "${KEY_DIR}"
 
+    # workaround for gpgme unable to handle long paths
+    # * create a temp directory /tmp/<tempdir>
+    # * symlink key directory -> /tmp/<tempdir>/gpghome
+    #
+    # gpg usually works as stated in https://bugzilla.redhat.com/show_bug.cgi?id=1813705#c3
+    # but sometimes (in containers without running systemd) /run/user/$UID doesn't exist
+    # and that's why this workaround is needed
+    TMP_DIR=$(mktemp -d)
+    TMP_KEY_DIR="${TMP_DIR}/gpghome"
+    ln -s "${KEY_DIR}" "${TMP_KEY_DIR}"
+
     # create key (without password, without expire)
-    HOME=${KEY_DIR} gpg2 --batch --passphrase '' --quick-gen-key "${KEY_NAME}" default default 0
+    HOME=${TMP_KEY_DIR} gpg2 --batch --passphrase '' --quick-gen-key "${KEY_NAME}" default default 0
 
     if [ "${USE_SIGN_SUBKEY}" = "1" ]; then
         # add sign subkey
-        KEY_ID=$(HOME=${KEY_DIR} gpg2 --list-keys --with-colons "${KEY_NAME}"  | grep '^fpr:' | head -n 1 | cut -d : -f 10)
-        HOME=${KEY_DIR} gpg2 --batch --passphrase '' --quick-add-key "${KEY_ID}" default sign 0
+        KEY_ID=$(HOME=${TMP_KEY_DIR} gpg2 --list-keys --with-colons "${KEY_NAME}"  | grep '^fpr:' | head -n 1 | cut -d : -f 10)
+        HOME=${TMP_KEY_DIR} gpg2 --batch --passphrase '' --quick-add-key "${KEY_ID}" default sign 0
     fi
 
     # export public and private key
-    HOME=${KEY_DIR} gpg2 --export -a "${KEY_NAME}" > "${KEY_DIR}/${KEY_NAME}-public"
-    HOME=${KEY_DIR} gpg2 --export-secret-keys -a "${KEY_NAME}" > "${KEY_DIR}/${KEY_NAME}-private"
+    HOME=${TMP_KEY_DIR} gpg2 --export -a "${KEY_NAME}" > "${TMP_KEY_DIR}/${KEY_NAME}-public"
+    HOME=${TMP_KEY_DIR} gpg2 --export-secret-keys -a "${KEY_NAME}" > "${TMP_KEY_DIR}/${KEY_NAME}-private"
 
     if [ "${USE_NOEOF_KEYS}" = "1" ]; then
       # remove EOF from keyfiles
-      truncate -s -1 "${KEY_DIR}/${KEY_NAME}-public"
-      truncate -s -1 "${KEY_DIR}/${KEY_NAME}-private"
+      truncate -s -1 "${TMP_KEY_DIR}/${KEY_NAME}-public"
+      truncate -s -1 "${TMP_KEY_DIR}/${KEY_NAME}-private"
     fi
 
     # create .rpmmacros
-    cat > "${KEY_DIR}/.rpmmacros" <<EOF
+    cat > "${TMP_KEY_DIR}/.rpmmacros" <<EOF
 %_signature gpg
 %_gpg_name ${KEY_NAME}
 EOF
 
     # sign packages
     while IFS= read -r package || [ -n "$package" ]; do
-        HOME=${KEY_DIR} rpm --addsign "${REPODIR}/${package}"
+        HOME=${TMP_KEY_DIR} rpm --addsign "${REPODIR}/${package}"
     done < "${DIR}/keyspecs/${KEY_NAME}/packages"
+
+    rm -rf "${TMP_DIR}"
 done
 


### PR DESCRIPTION
Gnupg2 is unable to handle long paths.
Using a tempdir with a symlink to the target locations workarounds that.