### PR TITLE
Test repo file load order and comps merging (RhBug:1928181)

### DIFF
--- a/dnf-behave-tests/features/comps-load-order.feature
+++ b/dnf-behave-tests/features/comps-load-order.feature
@@ -1,0 +1,55 @@
+Feature: Comps are merged based on repoconf load order
+
+
+Scenario: Comps merging and repoconf load order of dnf-ci-asd and dnf-ci-fedora repo files
+  Given I create and substitute file "/etc/yum.repos.d/dnf-ci-fedora.repo" with
+      """
+      [dnf-ci-fedora]
+      name=dnf-ci-fedora
+      baseurl={context.scenario.repos_location}/comps-upgrade-1
+      enabled=1
+      gpgcheck=0
+      """
+    # the following step runs createrepo on that repo
+    And I use repository "comps-upgrade-1"
+    And I create and substitute file "/etc/yum.repos.d/dnf-ci-fedora-updates.repo" with
+      """
+      [dnf-ci-fedora-updates]
+      name=dnf-ci-fedora-updates
+      baseurl={context.scenario.repos_location}/comps-upgrade-2
+      enabled=1
+      gpgcheck=0
+      """
+    # the following step runs createrepo on that repo
+    And I use repository "comps-upgrade-2"
+   When I execute dnf with args "group info a-group"
+   Then the exit code is 0
+    And stdout contains "Group: A-group - repo#2"
+    And stdout contains "Description: Testgroup for DNF CI testing - repo#2"
+
+
+Scenario: Comps merging and repoconf load order of dnf-ci-fedora and dnf-ci-fedora-updates repo files
+  Given I create and substitute file "/etc/yum.repos.d/dnf-ci-fedora.repo" with
+      """
+      [dnf-ci-fedora]
+      name=dnf-ci-fedora
+      baseurl={context.scenario.repos_location}/comps-upgrade-1
+      enabled=1
+      gpgcheck=0
+      """
+    # the following step runs createrepo on that repo
+    And I use repository "comps-upgrade-1"
+    And I create and substitute file "/etc/yum.repos.d/dnf-ci-abc.repo" with
+      """
+      [dnf-ci-fedora-updates]
+      name=dnf-ci-fedora-updates
+      baseurl={context.scenario.repos_location}/comps-upgrade-2
+      enabled=1
+      gpgcheck=0
+      """
+    # the following step runs createrepo on that repo
+    And I use repository "comps-upgrade-2"
+   When I execute dnf with args "group info a-group"
+   Then the exit code is 0
+    And stdout contains "Group: A-group - repo#1"
+    And stdout contains "Description: Testgroup for DNF CI testing - repo#1"

--- a/dnf-behave-tests/features/comps-upgrade.feature
+++ b/dnf-behave-tests/features/comps-upgrade.feature
@@ -39,18 +39,17 @@ Background: Enable comps-upgrade-1 nad install dummy
   Given I use repository "comps-upgrade-1"
     And I successfully execute dnf with args "install dummy"
 
-
 Scenario: Upgrade group when there are new package versions - upgrade packages
-  Given I successfully execute dnf with args "group install A-group"
+  Given I successfully execute dnf with args "group install 'A-group - repo#1'"
     And I use repository "comps-upgrade-2"
-   When I execute dnf with args "group upgrade A-group"
+   When I execute dnf with args "group upgrade 'A-group - repo#1'"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                            |
         | upgrade       | A-mandatory-0:2.0-1.x86_64         |
         | upgrade       | A-default-0:2.0-1.x86_64           |
         | upgrade       | A-conditional-true-0:2.0-1.x86_64  |
-        | group-upgrade | A-group                            |
+        | group-upgrade | A-group - repo#2                   |
 
 
 Scenario: Upgrade group when there are no new packages - nothing is installed
@@ -143,7 +142,7 @@ Scenario: Upgrade environment when there are no new groups/packages - nothing is
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                            |
-        | group-upgrade | A-group                            |
+        | group-upgrade | A-group - repo#1                   |
         | env-upgrade   | AB-environment                     |
 
 
@@ -173,7 +172,7 @@ Scenario: Upgrade environment when there are both old and new groups/packages - 
         | install-group | B-mandatory-0:1.0-1.x86_64         |
         | install-group | B-default-0:1.0-1.x86_64           |
         | install-group | B-conditional-true-0:1.0-1.x86_64  |
-        | group-upgrade | A-group                            |
+        | group-upgrade | A-group - repo#2                   |
         | group-install | B-group                            |
         | env-upgrade   | AB-environment                     |
 
@@ -200,7 +199,7 @@ Scenario: Upgrade environment to new metadata and back - always install new grou
         | install-group | A-mandatory-0:1.0-1.x86_64         |
         | install-group | A-default-0:1.0-1.x86_64           |
         | install-group | A-conditional-true-0:1.0-1.x86_64  |
-        | group-install | A-group                            |
+        | group-install | A-group - repo#1                   |
         | env-upgrade   | AB-environment                     |
 
 
@@ -210,13 +209,13 @@ Scenario: Upgrade environment when there were excluded packages during installat
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                            |
-        | group-install | A-group                            |
+        | group-install | A-group - repo#1                   |
         | env-install   | AB-environment                     |
    When I execute dnf with args "group upgrade AB-environment"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                            |
-        | group-upgrade | A-group                            |
+        | group-upgrade | A-group - repo#1                   |
         | env-upgrade   | AB-environment                     |
 
 
@@ -227,7 +226,7 @@ Scenario: Upgrade environment when there were removed packages since installatio
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                            |
-        | group-upgrade | A-group                            |
+        | group-upgrade | A-group - repo#1                   |
         | env-upgrade   | AB-environment                     |
 
 
@@ -250,11 +249,10 @@ Scenario: Upgrade empty environment
         | Action        | Package                            |
         | env-upgrade   | empty-environment                  |
 
-
 @bz1872586
 Scenario: Upgrade environment when all groups are removed
   Given I successfully execute dnf with args "group install AB-environment"
-    And I successfully execute dnf with args "group remove A-group"
+    And I successfully execute dnf with args "group remove 'A-group - repo#1'"
    When I execute dnf with args "group upgrade AB-environment"
    Then the exit code is 0
     And Transaction is following
@@ -264,12 +262,12 @@ Scenario: Upgrade environment when all groups are removed
 
 @bz1872586
 Scenario: Upgrade environment with installed optional groups
-  Given I successfully execute dnf with args "group mark install optional-environment A-group"
+  Given I successfully execute dnf with args "group mark install optional-environment a-group"
    When I execute dnf with args "group upgrade optional-environment"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                            |
-        | group-upgrade | A-group                            |
+        | group-upgrade | A-group - repo#1                   |
         | env-upgrade   | optional-environment               |
 
 

--- a/dnf-behave-tests/fixtures/specs/comps-upgrade-1/comps.xml
+++ b/dnf-behave-tests/fixtures/specs/comps-upgrade-1/comps.xml
@@ -3,12 +3,12 @@
 <comps>
 
   <group>
-   <id>A-group</id>
+   <id>a-group</id>
    <default>false</default>
    <uservisible>true</uservisible>
    <display_order>1024</display_order>
-   <name>A-group</name>
-   <description>Testgroup for DNF CI testing</description>
+   <name>A-group - repo#1</name>
+   <description>Testgroup for DNF CI testing - repo#1</description>
     <packagelist>
       <packagereq type="mandatory">A-mandatory</packagereq>
       <packagereq type="default">A-default</packagereq>
@@ -42,7 +42,7 @@
    <name>AB-environment</name>
    <description>Testenvironment for DNF CI testing</description>
     <grouplist>
-      <groupid>A-group</groupid>
+      <groupid>a-group</groupid>
     </grouplist>
   </environment>
 
@@ -76,7 +76,7 @@
    <name>optional-environment</name>
    <description>Testenvironment for DNF CI testing</description>
     <optionlist>
-      <groupid>A-group</groupid>
+      <groupid>a-group</groupid>
     </optionlist>
   </environment>
 

--- a/dnf-behave-tests/fixtures/specs/comps-upgrade-2/comps.xml
+++ b/dnf-behave-tests/fixtures/specs/comps-upgrade-2/comps.xml
@@ -3,12 +3,12 @@
 <comps>
 
   <group>
-   <id>A-group</id>
+   <id>a-group</id>
    <default>false</default>
    <uservisible>true</uservisible>
    <display_order>1024</display_order>
-   <name>A-group</name>
-   <description>Testgroup for DNF CI testing</description>
+   <name>A-group - repo#2</name>
+   <description>Testgroup for DNF CI testing - repo#2</description>
     <packagelist>
       <packagereq type="mandatory">A-mandatory</packagereq>
       <packagereq type="default">A-default</packagereq>


### PR DESCRIPTION
I renamed groupid A-group to a-group to distinguish it from the original group name.
The new group names are different so I also updated comps-upgrade.feature tests accordingly.