### PR TITLE
Steps for repodata generation

### DIFF
--- a/dnf-behave-tests/features/clean.feature
+++ b/dnf-behave-tests/features/clean.feature
@@ -39,7 +39,7 @@ Scenario: Expire dnf cache and run repoquery for a package that has been removed
 
         """
   Given I delete file "/{context.dnf.repos[dnf-ci-thirdparty-updates].path}/x86_64/SuperRipper-1.2-1.x86_64.rpm"
-    And I execute "createrepo_c --update ." in "/{context.dnf.repos[dnf-ci-thirdparty-updates].path}"
+    And I generate repodata for repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "repoquery --available SuperRipper"
    Then the exit code is 0
     And stdout is
@@ -78,7 +78,7 @@ Scenario: Expire dnf cache and run repoquery when a package has been removed mea
         SuperRipper-0:1.3-1.x86_64
         """
   Given I delete file "/{context.dnf.repos[dnf-ci-thirdparty-updates].path}/x86_64/SuperRipper-1.2-1.x86_64.rpm"
-    And I execute "createrepo_c --update ." in "/{context.dnf.repos[dnf-ci-thirdparty-updates].path}"
+    And I generate repodata for repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "repoquery"
    Then the exit code is 0
     And stdout is

--- a/dnf-behave-tests/features/config.feature
+++ b/dnf-behave-tests/features/config.feature
@@ -58,7 +58,7 @@ Scenario: Reposdir option in dnf.conf file in installroot
   Given I configure dnf with
         | key      | value      |
         | reposdir | /testrepos |
-    And I execute "createrepo_c {context.scenario.repos_location}/dnf-ci-fedora"
+    And I generate repodata for repository "dnf-ci-fedora"
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key     | value                                                   |
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora |
@@ -76,7 +76,7 @@ Scenario: Reposdir option in dnf.conf file with --config option in installroot
     [main]
     reposdir=/testrepos
     """
-    And I execute "createrepo_c {context.scenario.repos_location}/dnf-ci-fedora"
+    And I generate repodata for repository "dnf-ci-fedora"
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key     | value                                                   |
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora |
@@ -94,7 +94,7 @@ Scenario: Reposdir option in dnf.conf file with --config option in installroot i
     [main]
     reposdir={context.dnf.installroot}/testrepos,/othertestrepos
     """
-    And I execute "createrepo_c {context.scenario.repos_location}/dnf-ci-fedora"
+    And I generate repodata for repository "dnf-ci-fedora"
     And I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key     | value                                                   |
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora |
@@ -115,7 +115,7 @@ Scenario: Reposdir option set by --setopt
   Given I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key     | value                                                   |
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora |
-    And I execute "createrepo_c {context.scenario.repos_location}/dnf-ci-fedora"
+    And I generate repodata for repository "dnf-ci-fedora"
    # fail due to unavailable repository
    When I execute dnf with args "install filesystem"
    Then the exit code is 1
@@ -289,7 +289,7 @@ Scenario: Reposdir option in dnf.conf file in host
   Given I configure dnf with
         | key      | value      |
         | reposdir | /testrepos |
-    And I execute "createrepo_c {context.scenario.repos_location}/simple-base"
+    And I generate repodata for repository "simple-base"
     And I configure a new repository "testrepo" in "/testrepos" with
         | key     | value                                                   |
         | baseurl | {context.scenario.repos_location}/simple-base           |

--- a/dnf-behave-tests/features/download-source.feature
+++ b/dnf-behave-tests/features/download-source.feature
@@ -93,7 +93,7 @@ Given I create directory "/baseurlrepo"
 Scenario: Install from local repodata with locations pointing to remote packages
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --location-prefix http://localhost:{context.dnf.ports[dnf-ci-fedora]} {context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--location-prefix http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora"
   # delete packages from the repo copied for modification so they cannot be accidentally used
   And I delete directory "/{context.dnf.repos[dnf-ci-fedora].path}/noarch"
@@ -109,7 +109,7 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
 Scenario: Install from remote repodata with locations pointing to packages on different HTTP servers
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --location-prefix http://localhost:{context.dnf.ports[dnf-ci-fedora]} {context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--location-prefix http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora" as http
   # delete packages from the repo copied for modification so they cannot be accidentally used
   And I delete directory "/{context.dnf.repos[dnf-ci-fedora].path}/noarch"
@@ -140,7 +140,7 @@ Given I use repository "download-sources" as http
 Scenario: Download a package that contains special URL characters with full URL in location
 Given I make packages from repository "download-sources" accessible via http
   And I copy repository "download-sources" for modification
-  And I execute "createrepo_c --location-prefix http://localhost:{context.dnf.ports[download-sources]} {context.dnf.repos[download-sources].path}"
+  And I generate repodata for repository "download-sources" with extra arguments "--location-prefix http://localhost:{context.dnf.ports[download-sources]}"
   And I use repository "download-sources" as http
   # delete packages from the repo copied for modification so they cannot be accidentally used
   And I delete directory "/{context.dnf.repos[download-sources].path}/noarch"

--- a/dnf-behave-tests/features/install-xml-base.feature
+++ b/dnf-behave-tests/features/install-xml-base.feature
@@ -4,7 +4,7 @@ Feature: Install packages with base:xml set
 Scenario: Installed packages from local repository with local xml:base are not cached
 Given I copy repository "dnf-ci-fedora" for modification
   And I use repository "dnf-ci-fedora"
-  And I execute "createrepo_c --baseurl file://{context.dnf.installroot}/temp-repo/xml_base/dnf-ci-fedora /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl file://{context.dnf.installroot}/temp-repo/xml_base/dnf-ci-fedora"
   # setup data to which the base:xml (createrepo_c --baseurl argument) is pointing
   And I copy directory "{context.dnf.repos[dnf-ci-fedora].path}" to "/temp-repo/xml_base/dnf-ci-fedora"
  When I execute dnf with args "--setopt=keepcache=true install setup"
@@ -18,7 +18,7 @@ Given I copy repository "dnf-ci-fedora" for modification
 Scenario: Install from local repodata with xml:base pointing to remote packages
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora"
  When I execute dnf with args "--setopt=keepcache=true install setup"
  Then the exit code is 0
@@ -32,7 +32,7 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
 Scenario: Install from remote repodata with xml:base pointing to packages on different HTTP servers
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora" as http
  When I execute dnf with args "install setup"
  Then the exit code is 0
@@ -45,7 +45,7 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
 Scenario: Install from local repodata with xml:base pointing to remote packages doesn't delete unused local packages
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora"
   And file "/{context.dnf.repos[dnf-ci-fedora].path}/noarch/setup-2.12.1-1.fc29.noarch.rpm" exists
  When I execute dnf with args "install setup"
@@ -61,7 +61,7 @@ Scenario: Install from local repodata that have packages with xml:base pointing 
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
   And I copy repository "dnf-ci-thirdparty" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I execute "mergerepo_c --repo file://{context.dnf.repos[dnf-ci-fedora].path} --repo file://{context.dnf.repos[dnf-ci-thirdparty].path}" in "{context.dnf.installroot}"
   And I configure a new repository "merged-repo" with
       | key     | value                                        |

--- a/dnf-behave-tests/features/list-recent.feature
+++ b/dnf-behave-tests/features/list-recent.feature
@@ -9,8 +9,7 @@ Background: prepare repository with recent package labirinto
     And I execute "SOURCE_DATE_EPOCH=$(date +%s) rpmbuild -rb --define "_rpmdir ." --define "use_source_date_epoch_as_buildtime 1" /{context.dnf.repos[simple-base].path}/src/labirinto*.src.rpm" in "{context.dnf.repos[simple-base].path}"
     # remove source rpms not to interfere with list outputs
     And I execute "rm -rf src" in "{context.dnf.repos[simple-base].path}"
-    # rebuild repodata
-    And I execute "createrepo_c --simple-md-filenames --no-database /{context.dnf.repos[simple-base].path}"
+    And I generate repodata for repository "simple-base"
     And I use repository "simple-base"
 
 

--- a/dnf-behave-tests/features/microdnf/config.feature
+++ b/dnf-behave-tests/features/microdnf/config.feature
@@ -6,9 +6,9 @@ Feature: Respect main config options
 @not.with_os=rhel__eq__8
 Scenario: microdnf downloads zchunk metadata, enabled by default
 Given I copy repository "simple-base" for modification
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
   And I use repository "simple-base" as http
   And I start capturing outbound HTTP requests
-  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
  When I execute microdnf with args "install labirinto"
  Then the exit code is 0
   And HTTP log contains
@@ -22,9 +22,9 @@ Given I copy repository "simple-base" for modification
 @not.with_os=rhel__eq__8
 Scenario: microdnf ignores zchunk metadata if disabled
 Given I copy repository "simple-base" for modification
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
   And I use repository "simple-base" as http
   And I start capturing outbound HTTP requests
-  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
   And I configure dnf with
       | key    | value |
       | zchunk | False |

--- a/dnf-behave-tests/features/microdnf/install2.feature
+++ b/dnf-behave-tests/features/microdnf/install2.feature
@@ -6,8 +6,8 @@ Feature: microdnf install command on packages
 Scenario: Install package from local repodata with local xml:base
 #2. local repo with local packages (different package location specified using xml:base)
 Given I copy repository "dnf-ci-fedora" for modification
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl file://{context.dnf.installroot}/xml_base/dnf-ci-fedora"
   And I use repository "dnf-ci-fedora"
-  And I execute "createrepo_c --baseurl file://{context.dnf.installroot}/xml_base/dnf-ci-fedora /{context.dnf.repos[dnf-ci-fedora].path}"
   And I copy directory "{context.dnf.repos[dnf-ci-fedora].path}" to "/xml_base/dnf-ci-fedora"
  When I execute microdnf with args "install kernel"
  Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/install3.feature
+++ b/dnf-behave-tests/features/microdnf/install3.feature
@@ -7,7 +7,7 @@ Scenario: Install package from local repodata with xml:base pointing to remote p
 #3. local repo with remote packages (different package location specified using xml:base)
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora"
  When I execute microdnf with args "install kernel"
  Then the exit code is 0

--- a/dnf-behave-tests/features/microdnf/install4.feature
+++ b/dnf-behave-tests/features/microdnf/install4.feature
@@ -8,7 +8,7 @@ Scenario: Install packages from local repodata that have packages with xml:base 
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
   And I copy repository "dnf-ci-thirdparty" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I execute "mergerepo_c --repo file://{context.dnf.repos[dnf-ci-fedora].path} --repo file://{context.dnf.repos[dnf-ci-thirdparty].path}" in "{context.dnf.installroot}"
   And I configure a new repository "merged-repo" with
       | key     | value                                        |

--- a/dnf-behave-tests/features/microdnf/install6.feature
+++ b/dnf-behave-tests/features/microdnf/install6.feature
@@ -7,7 +7,7 @@ Scenario: Install packages from remote repodata with xml:base pointing to packag
 #6. remote repo with remote packages (different package location (different url) specified using xml:base)
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora" as http
   And I execute microdnf with args "install dwm"
  Then the exit code is 0

--- a/dnf-behave-tests/features/plugins-core/download-binary-xml-base.feature
+++ b/dnf-behave-tests/features/plugins-core/download-binary-xml-base.feature
@@ -8,7 +8,7 @@ Background:
 Scenario: Download packages from local repository with local xml:base
 Given I copy repository "dnf-ci-fedora" for modification
   And I use repository "dnf-ci-fedora"
-  And I execute "createrepo_c --baseurl file://{context.dnf.installroot}/xml_base/dnf-ci-fedora /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl file://{context.dnf.installroot}/xml_base/dnf-ci-fedora"
   # setup data to which the base:xml (createrepo_c --baseurl argument) is pointing
   And I copy directory "{context.dnf.repos[dnf-ci-fedora].path}" to "/xml_base/dnf-ci-fedora"
  When I execute dnf with args "download setup --destdir={context.dnf.tempdir}"
@@ -22,7 +22,7 @@ Given I copy repository "dnf-ci-fedora" for modification
 Scenario: Download from local repodata with xml:base pointing to remote packages
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora"
  When I execute dnf with args "download setup --destdir={context.dnf.tempdir}"
  Then stderr is empty
@@ -35,7 +35,7 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
 Scenario: Download from remote repodata with xml:base pointing to packages on different remote
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora" as http
  When I execute dnf with args "download setup --destdir={context.dnf.tempdir}"
  Then the exit code is 0
@@ -49,7 +49,7 @@ Scenario: Download to destdir from local repodata that have packages with xml:ba
 Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I copy repository "dnf-ci-fedora" for modification
   And I copy repository "dnf-ci-thirdparty" for modification
-  And I execute "createrepo_c --baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]} /{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I execute "mergerepo_c --repo file://{context.dnf.repos[dnf-ci-fedora].path} --repo file://{context.dnf.repos[dnf-ci-thirdparty].path}" in "{context.dnf.installroot}"
   And I configure a new repository "merged-repo" with
       | key     | value                                        |

--- a/dnf-behave-tests/features/plugins-core/repomanage.feature
+++ b/dnf-behave-tests/features/plugins-core/repomanage.feature
@@ -243,7 +243,7 @@ Scenario: multiple runs of repomanage don't use cached metadata
 Given I copy repository "dnf-ci-multicontext-hybrid-multiversion-modular" for modification
   And I execute dnf with args "repomanage --new --keep 100 {context.dnf.repos[dnf-ci-multicontext-hybrid-multiversion-modular].path}"
   And I delete file "//{context.dnf.tempdir}/repos/dnf-ci-multicontext-hybrid-multiversion-modular/*/nodejs*" with globs
-  And I execute "createrepo_c --update --keep-all-metadata {context.dnf.tempdir}/repos/dnf-ci-multicontext-hybrid-multiversion-modular/"
+  And I generate repodata for repository "dnf-ci-multicontext-hybrid-multiversion-modular"
   And I execute dnf with args "repomanage --new --keep 100 {context.dnf.repos[dnf-ci-multicontext-hybrid-multiversion-modular].path}"
  Then the exit code is 0
   And stdout is

--- a/dnf-behave-tests/features/repo-packages-info.feature
+++ b/dnf-behave-tests/features/repo-packages-info.feature
@@ -60,7 +60,7 @@ Given I delete file "/{context.dnf.repos[dnf-ci-fedora].path}/noarch/setup-2.12.
  Then the exit code is 0
 Given I delete file "/{context.dnf.repos[dnf-ci-fedora].path}/src/setup-2.12.1-1.fc29.src.rpm"
  Then the exit code is 0
-  And I execute "createrepo_c --update ." in "/{context.dnf.repos[dnf-ci-fedora].path}"
+  And I generate repodata for repository "dnf-ci-fedora"
  Then the exit code is 0
  When I execute dnf with args "clean expire-cache"
  Then the exit code is 0

--- a/dnf-behave-tests/features/repo-with-spaces.feature
+++ b/dnf-behave-tests/features/repo-with-spaces.feature
@@ -27,8 +27,7 @@ Given I create and substitute file "/etc/yum.repos.d/test-repo.repo" with
 @bz1853349
 Scenario: Install an rpm with spaces in its baseurl (the xml:base attribute of the package)
 Given I copy repository "repo with spaces" for modification
-  And I use repository "dnf-ci-fedora"
-  And I execute "createrepo_c --baseurl file://{context.scenario.repos_location}/repo%20with%20spaces '/{context.dnf.repos[repo with spaces].path}'"
+  And I generate repodata for repository "repo with spaces" with extra arguments "--baseurl file://{context.scenario.repos_location}/repo%20with%20spaces"
   And I create and substitute file "/etc/yum.repos.d/test-repo.repo" with
       """
       [test-repo]
@@ -47,8 +46,7 @@ Given I copy repository "repo with spaces" for modification
 @bz1853349
 Scenario: Download an rpm with spaces in its baseurl (the xml:base attribute of the package) to a destdir
 Given I copy repository "repo with spaces" for modification
-  And I use repository "dnf-ci-fedora"
-  And I execute "createrepo_c --baseurl file://{context.scenario.repos_location}/repo%20with%20spaces '/{context.dnf.repos[repo with spaces].path}'"
+  And I generate repodata for repository "repo with spaces" with extra arguments "--baseurl file://{context.scenario.repos_location}/repo%20with%20spaces"
   And I create and substitute file "/etc/yum.repos.d/test-repo.repo" with
       """
       [test-repo]

--- a/dnf-behave-tests/features/repodata-compression.feature
+++ b/dnf-behave-tests/features/repodata-compression.feature
@@ -3,7 +3,9 @@ Feature: Repodata compression
 
 @bz1914876
 Scenario: Read repodata compressed with zstd
-Given I use repository "zstd-compressed-repodata"
+Given I configure a new repository "zstd-compressed-repodata" with
+      | key    | value                                                           |
+      |baseurl | {context.dnf.fixturesdir}/repos-static/zstd-compressed-repodata |
  When I execute dnf with args "repoquery zstd"
  Then the exit code is 0
   And stdout contains "zstd-0:1.4.7-1.fc34.noarch"

--- a/dnf-behave-tests/features/repoquery/recent.feature
+++ b/dnf-behave-tests/features/repoquery/recent.feature
@@ -9,8 +9,7 @@ Background: prepare repository with recent package labirinto
     And I execute "SOURCE_DATE_EPOCH=$(date +%s) rpmbuild -rb --define "_rpmdir ." --define "use_source_date_epoch_as_buildtime 1" /{context.dnf.repos[simple-base].path}/src/labirinto*.src.rpm" in "{context.dnf.repos[simple-base].path}"
     # remove source rpms not to interfere with list outputs
     And I execute "rm -rf src" in "{context.dnf.repos[simple-base].path}"
-    # rebuild repodata
-    And I execute "createrepo_c --simple-md-filenames --no-database /{context.dnf.repos[simple-base].path}"
+    And I generate repodata for repository "simple-base"
     And I use repository "simple-base"
     And I successfully execute dnf with args "install labirinto vagare"
 

--- a/dnf-behave-tests/features/steps/repo.py
+++ b/dnf-behave-tests/features/steps/repo.py
@@ -76,12 +76,6 @@ def generate_repodata(context, repo):
     if not os.path.isdir(target_path):
         os.makedirs(target_path)
 
-    # skip creating repos that have repomd.xml created already
-    repomd_xml = os.path.join(target_path, "repodata", "repomd.xml")
-    if os.path.exists(repomd_xml):
-        context.repos[repo_replaced] = True
-        return
-
     run_in_context(context, "createrepo_c %s '%s'" % (args, target_path))
 
     repodata_path = os.path.join(target_path, "repodata")

--- a/dnf-behave-tests/features/zchunk.feature
+++ b/dnf-behave-tests/features/zchunk.feature
@@ -4,8 +4,8 @@ Feature: zchunk tests
 
 Scenario: I can install an RPM from local mirror with zchunk repo and enabled zchunk
 Given I copy repository "simple-base" for modification
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
   And I use repository "simple-base"
-  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
   And I configure dnf with
       | key    | value |
       | zchunk | True  |
@@ -19,8 +19,8 @@ Given I copy repository "simple-base" for modification
 @bz1886706
 Scenario: I can install an RPM from FTP mirror with zchunk repo and enabled zchunk
 Given I copy repository "simple-base" for modification
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
   And I use repository "simple-base" as ftp
-  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
   And I configure dnf with
       | key    | value |
       | zchunk | True  |
@@ -33,8 +33,8 @@ Given I copy repository "simple-base" for modification
 
 Scenario: I can install an RPM from FTP mirror with zchunk repo and disabled zchunk
 Given I copy repository "simple-base" for modification
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
   And I use repository "simple-base" as ftp
-  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
   And I configure dnf with
       | key    | value |
       | zchunk | False |
@@ -47,7 +47,7 @@ Given I copy repository "simple-base" for modification
 
 Scenario: when zchunk is enabled, prefer HTTP over FTP
 Given I copy repository "simple-base" for modification
-  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
   And I start http server "http_server" at "/{context.dnf.repos[simple-base].path}"
   And I start ftp server "ftp_server" at "/{context.dnf.repos[simple-base].path}"
   And I create and substitute file "/tmp/mirrorlist" with
@@ -77,7 +77,7 @@ Given I copy repository "simple-base" for modification
 
 Scenario: when zchunk is enabled, prefer HTTP over FTP (reversed)
 Given I copy repository "simple-base" for modification
-  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
   And I start http server "http_server" at "/{context.dnf.repos[simple-base].path}"
   And I start ftp server "ftp_server" at "/{context.dnf.repos[simple-base].path}"
   And I create and substitute file "/tmp/mirrorlist" with
@@ -107,8 +107,8 @@ Given I copy repository "simple-base" for modification
 
 Scenario: using mirror wihtout ranges supports and zchunk results in only two GET requests per file (the first try is with range specified)
 Given I copy repository "simple-base" for modification
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
   And I use repository "simple-base" as http
-  And I execute "createrepo_c --simple-md-filenames --zck /{context.dnf.repos[simple-base].path}"
   And I configure dnf with
       | key    | value |
       | zchunk | True |

--- a/dnf-behave-tests/fixtures/specs/build.sh
+++ b/dnf-behave-tests/fixtures/specs/build.sh
@@ -9,7 +9,6 @@ DIR="$(dirname "$(readlink -f "$0")")"
 ARCH="x86_64"
 DIST=".fc29"
 REPODIR="$DIR/../repos"
-STATIC_REPODIR="$DIR/../repos-static"
 GPGDIR="$DIR/../gpgkeys"
 CERTSDIR="$DIR/../certificates"
 GROUPS_FILENAME="comps.xml"
@@ -84,12 +83,6 @@ for path in "$DIR"/*/*.spec; do
         popd > /dev/null
     fi
 
-done
-
-
-# link static (manually created) repositories to the 'repos' directory
-for repo in $STATIC_REPODIR/*; do
-    ln -sf ../repos-static/$(basename $repo) $REPODIR/
 done
 
 


### PR DESCRIPTION
A refactor of the steps to not call createrepo_c directly, but use dedicated steps to do so.

Should also fix the weird filesystem error we are now getting with createrepo_c calls:
```
Cannot rename /opt/behave/fixtures/repos/dnf-ci-fedora/.repodata/ -> /opt/behave/fixtures/repos/dnf-ci-fedora/repodata/: Invalid cross-device link
```

FWIW here's a test run on my repos: https://github.com/lukash/dnf/runs/1968434664

The two failures are unrelated. And it is configured to use lukash/ci-dnf-stack (master branch) here:
https://github.com/lukash/dnf/blob/b57f2d7e192345caab202c7febf6cdeb7aa2f343/.github/workflows/ci.yaml#L16