### PR TITLE
CI: Add workflow to run CI on ci-dnf-stack PRs

### DIFF
--- a/.github/actions/copr-build/action.yml
+++ b/.github/actions/copr-build/action.yml
@@ -19,19 +19,24 @@ runs:
     - name: Rebase the pull request on target branch
       shell: bash
       run: |
-        pushd gits/${{github.event.pull_request.head.repo.name}}
+        REPO_NAME="${{github.event.pull_request.head.repo.name}}"
+        # if the triggering repo is ci-dnf-stack, the git we are rebasing is in the current directory
+        # otherwise, it's cloned into the gits directory for rpm-overlay to build from
+        if [ ${REPO_NAME} != "ci-dnf-stack" ]; then
+          cd gits/${REPO_NAME}
+        fi
+
         git config user.name github-actions
         git config user.email github-actions@github.com
         echo "Rebasing \"`git log --oneline -1`\" on ${{github.event.pull_request.base.ref}}: \"`git log --oneline -1 origin/${{github.event.pull_request.base.ref}}`\""
         git rebase origin/${{github.event.pull_request.base.ref}}
-        popd
 
     - name: Build packages in Copr
       id: copr-build
       shell: bash
       run: |
         PROJECT_NAME="CI-${{github.event.pull_request.head.repo.name}}-pr${{github.event.pull_request.number}}"
-        # if there's a git already checked out in the `gits` directory, rpm-gitoverlay will use it
+        # if there's a git already cloned in the `gits` directory, rpm-gitoverlay will use it
         rpm-gitoverlay -o rpmlist --gitdir=gits build-overlay -s "overlays/${{inputs.overlay}}" rpm copr --owner "${{inputs.copr-user}}" --project "$PROJECT_NAME" --chroot fedora-33-x86_64 --delete-project-after-days=7
 
         # delete the Copr secret just to be on the safe(er) side when running potentially untrusted PR code (albeit in a container, which should be secure)

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -3,6 +3,7 @@ name: Run DNF Integration Tests
 inputs:
   suite:
     description: The suite to run (default is "dnf", which is in the "features" directory)
+    default: "dnf"
   package-urls:
     description: The URLs of RPM packages to test
     required: true
@@ -24,8 +25,9 @@ runs:
           wget -P rpms ${RPM};
         done
 
-        SUITE=""
-        if [ -n "${{inputs.suite}}" ]; then SUITE="-s ${{inputs.suite}}"; fi
+        SUITE="${{inputs.suite}}"
+        if [ "${SUITE}" = "dnf" ]; then SUITE="features"; fi  # hack the wrong name of the dnf test suite
+        SUITE="-s ${SUITE}"
 
         CONTAINER=$(uuidgen)
         ./dnf-testing.sh -c $CONTAINER build jjb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+---
+name: DNF CI
+on: pull_request_target
+
+jobs:
+  permission-check:
+    name: Author Permission Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check author repository permissions
+        uses: octokit/request-action@v2.x
+        id: user-permission
+        with:
+          route: GET /repos/${{github.repository}}/collaborators/${{github.event.sender.login}}/permission
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Set write permission
+        if: contains('admin write', fromJson(steps.user-permission.outputs.data).permission)
+        id: set-write
+        run: |
+          echo "User '${{github.event.sender.login}}' has permission '${{fromJson(steps.user-permission.outputs.data).permission}}'. allowed values: 'admin', 'write'"
+          echo "::set-output name=has-write::true"
+
+    outputs:
+      has-write: ${{steps.set-write.outputs.has-write}}
+
+  integration-tests:
+    name: Integration Tests
+    needs: permission-check
+    if: needs.permission-check.outputs.has-write == 'true' # TODO test this doesn't run if unprivileged
+    strategy:
+      fail-fast: false  # don't fail all matrix jobs if one of them fails
+      matrix:
+        suite: [dnf, createrepo_c]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/rpm-software-management/dnf-ci-host
+      options: --privileged
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.sha}}  # check out the PR HEAD
+          fetch-depth: 0
+
+      - name: Setup CI
+        id: setup-ci
+        uses: ./.github/actions/setup-ci
+        with:
+          copr-user: ${{secrets.COPR_USER}}
+          copr-api-token: ${{secrets.COPR_API_TOKEN}}
+
+      - name: Run Copr Build
+        id: copr-build
+        uses: ./.github/actions/copr-build
+        with:
+          copr-user: ${{steps.setup-ci.outputs.copr-user}}
+          overlay: ${{matrix.suite}}-ci
+
+      - name: Run Integration Tests
+        uses: ./.github/actions/integration-tests
+        with:
+          package-urls: ${{steps.copr-build.outputs.package-urls}}
+          suite: ${{matrix.suite}}


### PR DESCRIPTION
This workflow will run the test suites from this repo against the stack, verifying the tests pass with the changes from the PR (in the simple case of an independent PR, in case the tests are for unmerged PRs in other repos, this is expected to fail).

Since we are checking out the (potentially untrusted) PR code to run the CI from, this workflow is guarded by requiring write permissions to the repo from the author, otherwise it will not run. Testing the "not having write permission" case is a bit hard since it requires a second user, I have done so here: https://github.com/lukash/ci-dnf-stack/pull/3 (submitting a PR to my repo from another user who doesn't have write permissions).

Since we have two test suites now (dnf in the `features` directory and createrepo_c), the workflow runs two jobs (using a matrix strategy), one builds and runs tests against the dnf stack and the other one builds createrepo_c and runs its tests.