### PR TITLE
Make tests pass on both Fedora and RHEL

### DIFF
--- a/dnf-behave-tests/features/comps-load-order.feature
+++ b/dnf-behave-tests/features/comps-load-order.feature
@@ -1,7 +1,9 @@
+@not.with_os=rhel__eq__8
+@bz1928181
 Feature: Comps are merged based on repoconf load order
 
 
-Scenario: Comps merging and repoconf load order of dnf-ci-asd and dnf-ci-fedora repo files
+Scenario: Comps merging and repoconf load order of dnf-ci-fedora and dnf-ci-fedora-updates repo files
   Given I create and substitute file "/etc/yum.repos.d/dnf-ci-fedora.repo" with
       """
       [dnf-ci-fedora]
@@ -28,7 +30,7 @@ Scenario: Comps merging and repoconf load order of dnf-ci-asd and dnf-ci-fedora 
     And stdout contains "Description: Testgroup for DNF CI testing - repo#2"
 
 
-Scenario: Comps merging and repoconf load order of dnf-ci-fedora and dnf-ci-fedora-updates repo files
+Scenario: Comps merging and repoconf load order of dnf-ci-abc and dnf-ci-fedora repo files
   Given I create and substitute file "/etc/yum.repos.d/dnf-ci-fedora.repo" with
       """
       [dnf-ci-fedora]

--- a/dnf-behave-tests/features/installonly.feature
+++ b/dnf-behave-tests/features/installonly.feature
@@ -115,6 +115,7 @@ Scenario: Remove all installonly packages but keep the latest and running kernel
         | remove          | kernel-core-0:4.19.15-300.fc29.x86_64    |
         | unchanged       | kernel-core-0:4.18.16-300.fc29.x86_64   |
 
+@not.with_os=rhel__eq__8
 @bz1934499
 @bz1921063
 Scenario: Do not autoremove kernel after upgrade with --best
@@ -138,6 +139,7 @@ Scenario: Do not autoremove kernel after upgrade with --best
    Then the exit code is 0
     And Transaction is empty
 
+@not.with_os=rhel__eq__8
 @bz1934499
 @bz1921063
 Scenario: Do not autoremove kernel after upgrade with --nobest
@@ -161,6 +163,7 @@ Scenario: Do not autoremove kernel after upgrade with --nobest
    Then the exit code is 0
     And Transaction is empty
 
+@not.with_os=rhel__eq__8
 @bz1934499
 @bz1921063
 Scenario: Do not remove or change reason after remove of one of installonly packages

--- a/dnf-behave-tests/features/logs.feature
+++ b/dnf-behave-tests/features/logs.feature
@@ -99,6 +99,7 @@ Given I use repository "dnf-ci-fedora-updates"
   And file "/var/log/hawkey.log" has mode "644"
 
 
+@not.with_os=rhel__eq__8
 @bz1910084
 Scenario: Created logfiles respect umask setting
 Given I use repository "dnf-ci-fedora-updates"
@@ -112,6 +113,7 @@ Given I use repository "dnf-ci-fedora-updates"
 Given I set umask to "0022"
 
 
+@not.with_os=rhel__eq__8
 @bz1910084
 Scenario: Log rotation keeps file permissions
 Given I use repository "dnf-ci-fedora-updates"

--- a/dnf-behave-tests/features/module/updateinfo.feature
+++ b/dnf-behave-tests/features/module/updateinfo.feature
@@ -49,6 +49,7 @@ Given I use repository "dnf-ci-fedora-modular-updates"
       """
 
 
+@not.with_os=rhel__eq__8
 @bz1804234
 Scenario: having installed packages from one collection and enabled all modules from another doesn't activate advisory
 Given I use repository "dnf-ci-fedora"
@@ -62,6 +63,7 @@ Given I use repository "dnf-ci-fedora"
       """
 
 
+@not.with_os=rhel__eq__8
 @bz1804234
 Scenario: having installed packages from all collections but enabled modules only for one shows just the one
 Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/features/plugins-removal.feature
+++ b/dnf-behave-tests/features/plugins-removal.feature
@@ -23,6 +23,7 @@ Scenario: Transaction callback of removed plugin is not executed
     And stdout does not contain "watermelon-dnf-plugin transaction()"
 
 
+@not.with_os=rhel__eq__8
 @bz1929163
 Scenario: Removal of plugin in splitted package is detected
   Given I successfully execute dnf with args "install watermelon-1.0"
@@ -36,6 +37,7 @@ Scenario: Removal of plugin in splitted package is detected
     And stdout does not contain "watermelon-dnf-plugin transaction()"
 
 
+@not.with_os=rhel__eq__8
 @bz1929163
 Scenario: Moving plugin between subpackages is not considered removal of plugin
   Given I execute dnf with args "install watermelon-dnf-plugin-2.0"

--- a/dnf-behave-tests/features/security-security.feature
+++ b/dnf-behave-tests/features/security-security.feature
@@ -26,6 +26,8 @@ Scenario: Security check-update when there are such updates
     And stdout contains "security_A.*1\.0-4\s+dnf-ci-security"
     And stdout does not contain "security_B"
 
+
+@not.with_os=rhel__eq__8
 @bz1918475
 Scenario: Security update
    When I execute dnf with args "update-minimal --security"
@@ -37,6 +39,7 @@ Scenario: Security update
   Then the exit code is 0
     And Transaction is empty
 
+@not.with_os=rhel__eq__8
 @bz1918475
 Scenario: Security update-minimal when exact version is not available
    When I execute dnf with args "update-minimal --security -x security_A-0:1.0-3.x86_64"
@@ -46,7 +49,7 @@ Scenario: Security update-minimal when exact version is not available
         | upgrade       | security_A-0:1.0-4.x86_64 |
 
 @bz1918475
-Scenario: Security update-minimal with priority setting
+Scenario: Security update with priority setting
   Given I use repository "dnf-ci-security-priority" with configuration
       | key           | value   |
       | priority      | 1       |
@@ -56,6 +59,7 @@ Scenario: Security update-minimal with priority setting
         | Action        | Package                     |
         | upgrade       | security_A-0:1.0-3.8.x86_64 |
 
+@not.with_os=rhel__eq__8
 @bz1918475
 Scenario: Security update-minimal with priority setting
   Given I use repository "dnf-ci-security-priority" with configuration

--- a/dnf-behave-tests/features/ssl.feature
+++ b/dnf-behave-tests/features/ssl.feature
@@ -82,7 +82,7 @@ Scenario: Installation with untrusted repository should fail
     And stderr matches line by line
     """
     Errors during downloading metadata for repository 'simple-base':
-      - Curl error \(60\): SSL peer certificate or SSH remote key was not OK for https://localhost:[0-9]+/repodata/repomd\.xml \[SSL certificate problem: self signed certificate in certificate chain\]
+      - Curl error \(60\): .* for https://localhost:[0-9]+/repodata/repomd\.xml \[SSL certificate problem: self signed certificate in certificate chain\]
     Error: Failed to download metadata for repo 'simple-base': Cannot download repomd\.xml: Cannot download repodata/repomd\.xml: All mirrors were tried
     """
 


### PR DESCRIPTION
Dear reviewer, if you refuse to merge this PR I would understand. This tests patching and workarounding the wording differences between Fedora and RHEL is gradually getting unsustainable.
We should branch the RHEL tests.