### PR TITLE
Test listing module with summary that contains empty line

### DIFF
--- a/dnf-behave-tests/features/module/info.feature
+++ b/dnf-behave-tests/features/module/info.feature
@@ -153,7 +153,8 @@ Scenario: Get info for a module, only module name specified
       Profiles         : default, development, minimal
       Default profiles : 
       Repo             : dnf-ci-fedora-modular
-      Summary          : Javascript runtime
+      Summary          : Javascript runtime module with quite a long
+                       : summary that contains an empty line.
       Description      : Node.js is a platform built on Chrome''s JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices.
       Requires         : platform:[f29]
       Artifacts        : nodejs-1:5.3.1-1.module_2011+41787af0.src
@@ -377,7 +378,8 @@ Scenario: Get info for an enabled stream, module name and stream specified
         Profiles         : default, development, minimal
         Default profiles : 
         Repo             : dnf-ci-fedora-modular
-        Summary          : Javascript runtime
+        Summary          : Javascript runtime module with quite a long
+                         : summary that contains an empty line.
         Description      : Node.js is a platform built on Chrome''s JavaScript runtime for easily building fast, scalable network applications. Node.js uses an event-driven, non-blocking I/O model that makes it lightweight and efficient, perfect for data-intensive real-time applications that run across distributed devices.
         Requires         : platform:[f29]
         Artifacts        : nodejs-1:5.3.1-1.module_2011+41787af0.src

--- a/dnf-behave-tests/features/module/list.feature
+++ b/dnf-behave-tests/features/module/list.feature
@@ -159,3 +159,9 @@ Scenario: Modules are ordered by repository then module name and stream name
     And stdout section "dnf-ci-fedora-modular test repository" contains "postgresql\s+6.*\n\s*postgresql\s+9.6"
     And stdout section "dnf-ci-fedora-modular-updates test repository" contains "nodejs\s+8.*\n\s*nodejs\s+10.*\n\s*nodejs\s+11.*\n\s*nodejs\s+12"
     And stdout section "dnf-ci-fedora-modular-updates test repository" contains "postgresql\s+9.6.*\n\s*postgresql\s+10.*\n\s*postgresql\s+11"
+
+
+Scenario: Correctly display module summary that contains empty lines
+   When I execute dnf with args "module list nodejs:5"
+   Then the exit code is 0
+    And stdout section "dnf-ci-fedora-modular test repository" contains "Javascript runtime module with quite a long summary that contains an empty line."

--- a/dnf-behave-tests/features/module/provides.feature
+++ b/dnf-behave-tests/features/module/provides.feature
@@ -29,7 +29,8 @@ Scenario: I can get list of all modules providing specific package
       Module   : nodejs:5:20150811143428:6c81f848:x86_64
       Profiles : development
       Repo     : dnf-ci-fedora-modular
-      Summary  : Javascript runtime
+      Summary  : Javascript runtime module with quite a long
+               : summary that contains an empty line.
 
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
       Module   : nodejs:8:20180801080000:6c81f848:x86_64
@@ -63,7 +64,8 @@ Given I successfully execute dnf with args "module enable nodejs:8"
       Module   : nodejs:5:20150811143428:6c81f848:x86_64
       Profiles : development
       Repo     : dnf-ci-fedora-modular
-      Summary  : Javascript runtime
+      Summary  : Javascript runtime module with quite a long
+               : summary that contains an empty line.
 
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
       Module   : nodejs:8:20180801080000:6c81f848:x86_64
@@ -97,7 +99,8 @@ Given I successfully execute dnf with args "module enable nodejs:8"
       Module   : nodejs:5:20150811143428:6c81f848:x86_64
       Profiles : development
       Repo     : dnf-ci-fedora-modular
-      Summary  : Javascript runtime
+      Summary  : Javascript runtime module with quite a long
+               : summary that contains an empty line.
 
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
       Module   : nodejs:8:20180801080000:6c81f848:x86_64
@@ -132,7 +135,8 @@ Given I successfully execute dnf with args "module enable nodejs:8"
       Module   : nodejs:5:20150811143428:6c81f848:x86_64
       Profiles : development
       Repo     : dnf-ci-fedora-modular
-      Summary  : Javascript runtime
+      Summary  : Javascript runtime module with quite a long
+               : summary that contains an empty line.
 
       nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
       Module   : nodejs:8:20180801080000:6c81f848:x86_64

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-modular/modules.yaml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-modular/modules.yaml
@@ -7,7 +7,10 @@ data:
   version: 20150811143428
   context: 6c81f848
   arch: x86_64
-  summary: Javascript runtime
+  summary: >-
+    Javascript runtime module with quite a long
+
+    summary that contains an empty line.
   description: >-
     Node.js is a platform built on Chrome''s JavaScript runtime for easily building
     fast, scalable network applications. Node.js uses an event-driven, non-blocking


### PR DESCRIPTION
Test for https://github.com/rpm-software-management/dnf/pull/1739

The only weird thing is that I could reproduce the issue only with additional new line in the module summary, not any multiline summary.