### PR TITLE
Test repo gets expired when package has incorrect checksum

### DIFF
--- a/dnf-behave-tests/features/gpg.feature
+++ b/dnf-behave-tests/features/gpg.feature
@@ -134,3 +134,25 @@ Scenario: Refuse to install a package with broken gpg signature
    Then the exit code is 1
    # dnf must not extract any files from the broken package
    Then file "/usr/share/doc/setup/README" does not exist
+
+
+@xfail
+@1941959
+Scenario: Expire repo when failed to install package with incorrect checksum
+  Given I drop repository "dnf-ci-gpg"
+    And I use repository "dnf-ci-gpg" as http
+    And I configure repository "dnf-ci-gpg" with
+        | key      | value |
+        | gpgcheck | 0     |
+        | gpgkey   |       |
+   When I execute dnf with args "install broken-package"
+   Then the exit code is 1
+    And DNF Transaction is following
+        | Action        | Package                               |
+        | install       | broken-package-0:0.2.4-1.fc29.noarch  |
+    And RPMDB Transaction is empty
+    And file "/var/cache/dnf/expired_repos.json" contents is
+        """
+        ["dnf-ci-gpg"]
+        """
+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1941959

I am not yet sure if this test is good enough to test the bug. I remember the issue was not reproducible with local repositories and it should work with the `dnf-ci-gpg repo` used as http, but I can't test it without the bug fix.