### PR TITLE
Replace SHA1 and MD5 which will no longer be supported by default

### DIFF
--- a/dnf-behave-tests/createrepo_c/empty-repository.feature
+++ b/dnf-behave-tests/createrepo_c/empty-repository.feature
@@ -84,19 +84,19 @@ Scenario: Repo with --groupfile
 
 
 Scenario: Repo with --groupfile and --checksum sha
- When I execute createrepo_c with args "--checksum sha1 --groupfile ../groupfile.xml ." in "/temp-repo"
+ When I execute createrepo_c with args "--checksum sha224 --groupfile ../groupfile.xml ." in "/temp-repo"
  Then the exit code is 0
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha1          | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha1          | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha1          | gz               |
-      | primary_db   | ${checksum}-primary.sqlite.bz2   | sha1          | bz2              |
-      | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha1          | bz2              |
-      | other_db     | ${checksum}-other.sqlite.bz2     | sha1          | bz2              |
-      | group        | ${checksum}-groupfile.xml        | sha1          | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha1          | gz               |
+      | primary      | ${checksum}-primary.xml.gz       | sha224        | gz               |
+      | filelists    | ${checksum}-filelists.xml.gz     | sha224        | gz               |
+      | other        | ${checksum}-other.xml.gz         | sha224        | gz               |
+      | primary_db   | ${checksum}-primary.sqlite.bz2   | sha224        | bz2              |
+      | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha224        | bz2              |
+      | other_db     | ${checksum}-other.sqlite.bz2     | sha224        | bz2              |
+      | group        | ${checksum}-groupfile.xml        | sha224        | -                |
+      | group_gz     | ${checksum}-groupfile.xml.gz     | sha224        | gz               |
 
 
 Scenario: Repo with --simple-md-filenames and --groupfile
@@ -196,35 +196,35 @@ Scenario: Repo with --compress-type xz
 
 
 Scenario: Repo with --repomd-checksum and --groupfile
- When I execute createrepo_c with args "--repomd-checksum sha1 --groupfile ../groupfile.xml ." in "/temp-repo"
+ When I execute createrepo_c with args "--repomd-checksum sha224 --groupfile ../groupfile.xml ." in "/temp-repo"
  Then the exit code is 0
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha1          | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha1          | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha1          | gz               |
-      | primary_db   | ${checksum}-primary.sqlite.bz2   | sha1          | bz2              |
-      | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha1          | bz2              |
-      | other_db     | ${checksum}-other.sqlite.bz2     | sha1          | bz2              |
-      | group        | ${checksum}-groupfile.xml        | sha1          | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha1          | gz               |
+      | primary      | ${checksum}-primary.xml.gz       | sha224        | gz               |
+      | filelists    | ${checksum}-filelists.xml.gz     | sha224        | gz               |
+      | other        | ${checksum}-other.xml.gz         | sha224        | gz               |
+      | primary_db   | ${checksum}-primary.sqlite.bz2   | sha224        | bz2              |
+      | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha224        | bz2              |
+      | other_db     | ${checksum}-other.sqlite.bz2     | sha224        | bz2              |
+      | group        | ${checksum}-groupfile.xml        | sha224        | -                |
+      | group_gz     | ${checksum}-groupfile.xml.gz     | sha224        | gz               |
 
 
 Scenario: Repo with --checksum --repomd-checksum and --groupfile
- When I execute createrepo_c with args "--checksum md5 --repomd-checksum sha1 --groupfile ../groupfile.xml ." in "/temp-repo"
+ When I execute createrepo_c with args "--checksum sha256 --repomd-checksum sha512 --groupfile ../groupfile.xml ." in "/temp-repo"
  Then the exit code is 0
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha1          | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha1          | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha1          | gz               |
-      | primary_db   | ${checksum}-primary.sqlite.bz2   | sha1          | bz2              |
-      | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha1          | bz2              |
-      | other_db     | ${checksum}-other.sqlite.bz2     | sha1          | bz2              |
-      | group        | ${checksum}-groupfile.xml        | sha1          | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha1          | gz               |
+      | primary      | ${checksum}-primary.xml.gz       | sha512        | gz               |
+      | filelists    | ${checksum}-filelists.xml.gz     | sha512        | gz               |
+      | other        | ${checksum}-other.xml.gz         | sha512        | gz               |
+      | primary_db   | ${checksum}-primary.sqlite.bz2   | sha512        | bz2              |
+      | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha512        | bz2              |
+      | other_db     | ${checksum}-other.sqlite.bz2     | sha512        | bz2              |
+      | group        | ${checksum}-groupfile.xml        | sha512        | -                |
+      | group_gz     | ${checksum}-groupfile.xml.gz     | sha512        | gz               |
 
 
 Scenario: Repo with --general-compress-type and --groupfile

--- a/dnf-behave-tests/createrepo_c/sqliterepo_c-miscellaneous.feature
+++ b/dnf-behave-tests/createrepo_c/sqliterepo_c-miscellaneous.feature
@@ -144,7 +144,7 @@ Given I execute createrepo_c with args "." in "/"
 
 Scenario: Sqlitedbs should be created using --force with different checksum
 Given I execute createrepo_c with args "." in "/"
- When I execute sqliterepo_c with args "--force --checksum md5 ." in "/"
+ When I execute sqliterepo_c with args "--force --checksum sha512 ." in "/"
  Then the exit code is 0
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
@@ -152,6 +152,6 @@ Given I execute createrepo_c with args "." in "/"
       | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
       | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
       | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | primary_db   | ${checksum}-primary.sqlite.bz2   | md5           | bz2              |
-      | filelists_db | ${checksum}-filelists.sqlite.bz2 | md5           | bz2              |
-      | other_db     | ${checksum}-other.sqlite.bz2     | md5           | bz2              |
+      | primary_db   | ${checksum}-primary.sqlite.bz2   | sha512        | bz2              |
+      | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha512        | bz2              |
+      | other_db     | ${checksum}-other.sqlite.bz2     | sha512        | bz2              |

--- a/dnf-behave-tests/createrepo_c/steps/lib/file.py
+++ b/dnf-behave-tests/createrepo_c/steps/lib/file.py
@@ -17,10 +17,10 @@ except ImportError:
 def get_checksum_regex(type_str):
     if type_str == "sha256":
         return "[a-z0-9]{64}"
-    if type_str == "sha1":
-        return "[a-z0-9]{40}"
-    if type_str == "md5":
-        return "[a-z0-9]{32}"
+    if type_str == "sha224":
+        return "[a-z0-9]{56}"
+    if type_str == "sha512":
+        return "[a-z0-9]{128}"
     if type_str == "-":
         return ""
     raise ValueError("Unknown checksum type: " + type_str)
@@ -43,10 +43,10 @@ def decompression_iter(filepath, compression_type, blocksize=65536):
 def checksum_of_file(filepath, checksum_type="sha256"):
     if checksum_type == "sha256":
         return hash_bytestr_iter(file_as_blockiter(open(filepath, 'rb')), hashlib.sha256())
-    if checksum_type == "sha1":
-        return hash_bytestr_iter(file_as_blockiter(open(filepath, 'rb')), hashlib.sha1())
-    if checksum_type == "md5":
-        return hash_bytestr_iter(file_as_blockiter(open(filepath, 'rb')), hashlib.md5())
+    if checksum_type == "sha224":
+        return hash_bytestr_iter(file_as_blockiter(open(filepath, 'rb')), hashlib.sha224())
+    if checksum_type == "sha512":
+        return hash_bytestr_iter(file_as_blockiter(open(filepath, 'rb')), hashlib.sha512())
     raise ValueError("Unknown checksum type: " + checksum_type)
 
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1935486

Requires: https://github.com/rpm-software-management/createrepo_c/pull/264