### PR TITLE
Update the path of the -d/--devel argument for correct mount

### DIFF
--- a/container-test
+++ b/container-test
@@ -191,7 +191,7 @@ class BehaveRunner(object):
                 self._volumes.extend(['--volume', '{}:{}:Z'.format(
                     os.path.join(PROGPATH, 'dnf-behave-tests',
                                  self.command_line_args.suite),
-                    os.path.join('/opt/behave', self.command_line_args.suite))])
+                    os.path.join('/opt/ci/dnf-behave-tests', self.command_line_args.suite))])
             if hasattr(self.command_line_args, 'junit_directory') \
                 and self.command_line_args.junit_directory:
                 self._volumes.extend(['--volume', '{}:/junit:z'.format(


### PR DESCRIPTION
This was updated in Dockerfile: https://github.com/rpm-software-management/ci-dnf-stack/pull/984