### PR TITLE
Test groups without packagelist and merging environments

### DIFF
--- a/dnf-behave-tests/fixtures/specs/comps-group-merging/comps.xml
+++ b/dnf-behave-tests/fixtures/specs/comps-group-merging/comps.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
+<comps>
+  <group>
+   <id>test-group</id>
+   <name>Test Group</name>
+   <description>Test Group description updated.</description>
+  </group>
+
+  <environment>
+    <id>no-name-env</id>
+    <name></name>
+    <description></description>
+    <grouplist>
+      <groupid>no-name-group</groupid>
+    </grouplist>
+    <optionlist>
+    </optionlist>
+  </environment>
+
+</comps>


### PR DESCRIPTION
Test that we can handle groups without `<packagelist>` element.

Also tests some changes from: https://github.com/rpm-software-management/dnf/pull/1764