### PR TITLE
Add basic distro-sync tests and tests with signed/broken pkgs

### DIFF
--- a/dnf-behave-tests/dnf/distro-sync.feature
+++ b/dnf-behave-tests/dnf/distro-sync.feature
@@ -1,0 +1,69 @@
+Feature: distro-sync
+
+
+Scenario: when there is noting to do
+Given I use repository "simple-base"
+ When I execute dnf with args "distro-sync"
+ Then the exit code is 0
+  And Transaction is empty
+
+
+Scenario: updating a pkg
+Given I use repository "simple-base"
+  And I execute dnf with args "install labirinto"
+  And I use repository "simple-updates"
+ When I execute dnf with args "distro-sync"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                               |
+      | upgrade       | labirinto-2.0-1.fc29.x86_64           |
+
+
+Scenario: updating a signed pkg
+Given I use repository "simple-base"
+  And I execute dnf with args "install dedalo-signed"
+  And I use repository "simple-updates" with configuration
+      | key      | value      |
+      | gpgcheck | 1          |
+      | gpgkey   | file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg/dnf-ci-gpg-public |
+ When I execute dnf with args "distro-sync"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                               |
+      | upgrade       | dedalo-signed-2.0-1.fc29.x86_64       |
+
+
+Scenario: updating a signed pkg without key specified
+Given I use repository "simple-base"
+  And I execute dnf with args "install dedalo-signed"
+  And I use repository "simple-updates" with configuration
+      | key      | value      |
+      | gpgcheck | 1          |
+ When I execute dnf with args "distro-sync"
+ Then the exit code is 1
+
+
+Scenario: updating a broken signed pkg whose key is not imported
+Given I use repository "dnf-ci-gpg"
+  And I execute dnf with args "install wget"
+  And I use repository "dnf-ci-gpg-updates" with configuration
+      | key      | value      |
+      | gpgcheck | 1          |
+      | gpgkey   | file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg-updates/dnf-ci-gpg-updates-public |
+ When I execute dnf with args "distro-sync wget"
+ Then the exit code is 1
+  And stderr contains "Error: GPG check FAILED"
+
+
+@bz1963732
+Scenario: updating a broken signed pkg whose key is imported
+Given I use repository "dnf-ci-gpg"
+  And I execute dnf with args "install wget"
+  And I use repository "dnf-ci-gpg-updates" with configuration
+      | key      | value      |
+      | gpgcheck | 1          |
+      | gpgkey   | file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg-updates/dnf-ci-gpg-updates-public |
+  And I execute rpm with args "--import {context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg-updates/dnf-ci-gpg-updates-public"
+ When I execute dnf with args "distro-sync wget"
+ Then the exit code is 1
+  And stderr contains "Error: GPG check FAILED"

--- a/dnf-behave-tests/fixtures/gpgkeys/keyspecs/dnf-ci-gpg-updates/packages
+++ b/dnf-behave-tests/fixtures/gpgkeys/keyspecs/dnf-ci-gpg-updates/packages
@@ -1,1 +1,2 @@
 dnf-ci-gpg/noarch/basesystem-11-6.fc29.noarch.rpm
+dnf-ci-gpg-updates/x86_64/wget-2.0.0-1.fc29.x86_64.rpm

--- a/dnf-behave-tests/fixtures/specs/break-packages.sh
+++ b/dnf-behave-tests/fixtures/specs/break-packages.sh
@@ -6,4 +6,5 @@ REPODIR="${DIR}/../repos"
 
 # broken-package in dnf-ci-gpg must have incorrect checksum (appending at the end is enough)
 echo "broken-package" >> "${REPODIR}/dnf-ci-gpg/noarch/broken-package-0.2.4-1.fc29.noarch.rpm"
+echo "broken-package" >> "${REPODIR}/dnf-ci-gpg-updates/x86_64/wget-2.0.0-1.fc29.x86_64.rpm"
 

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-gpg-updates/wget-broken-update-2.0.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-gpg-updates/wget-broken-update-2.0.0-1.fc29.spec
@@ -1,0 +1,18 @@
+Name: wget
+Version: 2.0.0
+Release: 1%{?dist}
+Summary: Broken update package for wget
+
+License: GPLv3+
+Group: Applications/Internet
+Url: http://www.gnu.org/software/wget/
+
+Provides: webclient
+Provides: bundled(gnulib)
+
+%description
+Broken update package for wget
+
+%files
+
+%changelog


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1963732

https://github.com/rpm-software-management/dnf/pull/1753 is required because it fixes a traceback in the last test.