### PR TITLE
Do no hardcode user for ghcr.io use secret instead

### DIFF
--- a/.github/workflows/ci-host.yml
+++ b/.github/workflows/ci-host.yml
@@ -11,10 +11,19 @@ jobs:
     steps:
       - name: Build the container
         run: |
-          DATE=`date "+%F"`
-          IMAGE="ghcr.io/rpm-software-management/dnf-ci-host"
+          # hack: Github replaces secrets with *** in the whole output.
+          # If there's a comment (#) at the end of the secret
+          # (e.g. "rpm-sofware-management #"), this will clean it up and
+          # since it is no longer the whole secret being printed, Github
+          # won't hide it anymore.
+          GHCR_USER=${{secrets.GHCR_USER}}
 
-          echo ${{secrets.GITHUB_TOKEN}} | docker login ghcr.io -u rpm-software-management --password-stdin
+          if [ -z "$GHCR_USER" ]; then exit 0; fi
+
+          DATE=`date "+%F"`
+          IMAGE="ghcr.io/${GHCR_USER}/dnf-ci-host"
+
+          echo ${{secrets.GITHUB_TOKEN}} | docker login ghcr.io -u ${GHCR_USER} --password-stdin
 
           docker build -t ${IMAGE}:${DATE} -t ${IMAGE}:latest -<<EOF
           FROM fedora:latest


### PR DESCRIPTION
When the user was hardcoded to rpm-software-management everytime someone
had this workflow in master branch (of their ci-dnf-stack fork) this
workflow ran as scheduled and failed when pushing to
ghcr.io/rpm-software-management/dnf-ci-host.

Now if you define your own secret GHCR_USER the image gets pushed to
ghcr.io/${GHCR_USER}/dnf-ci-host and if no user is defined the workflow
does nothing.

This also means we need to have the user secret defined for
https://github.com/rpm-software-management/ci-dnf-stack