### PR TITLE
CI: Add manual workflow dispatch to the cron workflows

### DIFF
--- a/.github/workflows/ci-host.yml
+++ b/.github/workflows/ci-host.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron:  '0 2 * * *'  # at 2am UTC
 
+  # allow to run the workflow manually from GitHub web interface
+  workflow_dispatch:
+
 jobs:
   container-build:
     name: Container build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron:  '0 0 * * *'  # at midnight UTC
 
+  # allow to run the workflow manually from GitHub web interface
+  workflow_dispatch:
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
This adds a button in the web interface to run the workflows manually on
demand.