### PR TITLE
Add repository and tests for "installonlypkgs" configuration option

### DIFF
--- a/dnf-behave-tests/dnf/installonlypkgs.feature
+++ b/dnf-behave-tests/dnf/installonlypkgs.feature
@@ -1,0 +1,60 @@
+Feature: Test upgrading installonly packages - "installonlypkgs" configuration option
+
+
+Background: Install one version of each test package
+  Given I use repository "installonly"
+   When I execute dnf with args "install installonlyA-1.0 installonlyB-1.0 kernel-core-4.18.16"
+   Then the exit code is 0
+     And Transaction is following
+        | Action        | Package                               |
+        | install       | installonlyA-0:1.0-1.x86_64           |
+        | install       | installonlyB-0:1.0-1.x86_64           |
+        | install       | kernel-core-0:4.18.16-300.fc29.x86_64 |
+
+
+Scenario: kernel-core is installonly package by default, and installonlyA is not
+   When I execute dnf with args "install installonlyA-2.0 kernel-core"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | upgrade       | installonlyA-0:2.0-1.x86_64           |
+        | install       | kernel-core-0:4.20.6-300.fc29.x86_64  |
+
+
+Scenario: Add package installonlyA to the installonly packages, kernel-core is installonly by default
+   Given I configure dnf with
+        | key                          | value         |
+        | installonlypkgs              | installonlyA  |
+   When I execute dnf with args "install installonlyA-2.0 kernel-core"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | install       | installonlyA-0:2.0-1.x86_64           |
+        | install       | kernel-core-0:4.20.6-300.fc29.x86_64  |
+
+
+Scenario: Add package installonlyA to the installonly packages, install multiple versions of installonlyA with a single command
+   Given I configure dnf with
+        | key                          | value         |
+        | installonlypkgs              | installonlyA  |
+   When I execute dnf with args "install installonlyA-2.0 installonlyA-2.2 installonlyB kernel-core"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | install       | installonlyA-0:2.0-1.x86_64           |
+        | install       | installonlyA-0:2.2-1.x86_64           |
+        | upgrade       | installonlyB-0:2.2-1.x86_64           |
+        | install       | kernel-core-0:4.20.6-300.fc29.x86_64  |
+
+
+Scenario: Clear the list of installonly packages and set the package installonlyA to it
+   Given I configure dnf with
+        | key                          | value         |
+        | installonlypkgs              | ,installonlyA |
+   When I execute dnf with args "install installonlyA-2.0 installonlyB-2.0 kernel-core"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | install       | installonlyA-0:2.0-1.x86_64           |
+        | upgrade       | installonlyB-0:2.0-1.x86_64           |
+        | upgrade       | kernel-core-0:4.20.6-300.fc29.x86_64  |

--- a/dnf-behave-tests/dnf/microdnf/installonlypkgs.feature
+++ b/dnf-behave-tests/dnf/microdnf/installonlypkgs.feature
@@ -1,0 +1,66 @@
+Feature: Test upgrading installonly packages - "installonlypkgs" configuration option
+
+
+Background: Install one version of each test package
+  Given I use repository "installonly"
+    # "/usr" directory is needed to load rpm database (to overcome bad heuristics in libdnf created by Colin Walters)
+    And I create directory "/usr"
+   When I execute microdnf with args "install installonlyA-1.0 installonlyB-1.0 kernel-core-4.18.16"
+   Then the exit code is 0
+     And microdnf transaction is
+        | Action        | Package                               |
+        | install       | installonlyA-0:1.0-1.x86_64           |
+        | install       | installonlyB-0:1.0-1.x86_64           |
+        | install       | kernel-core-0:4.18.16-300.fc29.x86_64 |
+
+
+Scenario: kernel-core is installonly package by default, and installonlyA is not
+   When I execute microdnf with args "install installonlyA-2.0 kernel-core"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                               |
+        | upgrade       | installonlyA-0:2.0-1.x86_64           |
+        | upgraded      | installonlyA-0:1.0-1.x86_64           |
+        | install       | kernel-core-0:4.20.6-300.fc29.x86_64  |
+
+
+Scenario: Add package installonlyA to the installonly packages, kernel-core is installonly by default
+   Given I configure dnf with
+        | key                          | value         |
+        | installonlypkgs              | installonlyA  |
+   When I execute microdnf with args "install installonlyA-2.0 kernel-core"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                               |
+        | install       | installonlyA-0:2.0-1.x86_64           |
+        | install       | kernel-core-0:4.20.6-300.fc29.x86_64  |
+
+
+Scenario: Add package installonlyA to the installonly packages, install multiple versions of installonlyA with a single command
+   Given I configure dnf with
+        | key                          | value         |
+        | installonlypkgs              | installonlyA  |
+   When I execute microdnf with args "install installonlyA-2.0 installonlyA-2.2 installonlyB kernel-core"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                               |
+        | install       | installonlyA-0:2.0-1.x86_64           |
+        | install       | installonlyA-0:2.2-1.x86_64           |
+        | upgrade       | installonlyB-0:2.2-1.x86_64           |
+        | upgraded      | installonlyB-0:1.0-1.x86_64           |
+        | install       | kernel-core-0:4.20.6-300.fc29.x86_64  |
+
+
+Scenario: Clear the list of installonly packages and set the package installonlyA to it
+   Given I configure dnf with
+        | key                          | value         |
+        | installonlypkgs              | ,installonlyA |
+   When I execute microdnf with args "install installonlyA-2.0 installonlyB-2.0 kernel-core"
+   Then the exit code is 0
+    And microdnf transaction is
+        | Action        | Package                               |
+        | install       | installonlyA-0:2.0-1.x86_64           |
+        | upgrade       | installonlyB-0:2.0-1.x86_64           |
+        | upgraded      | installonlyB-0:1.0-1.x86_64           |
+        | upgrade       | kernel-core-0:4.20.6-300.fc29.x86_64  |
+        | upgraded      | kernel-core-0:4.18.16-300.fc29.x86_64 |

--- a/dnf-behave-tests/dnf/steps/lib/rpm.py
+++ b/dnf-behave-tests/dnf/steps/lib/rpm.py
@@ -9,11 +9,6 @@ import rpm
 
 
 NEVRA_RE = re.compile(r"^(.+)-(?:([0-9]+):)?(.+)-(.+)\.(.+)$")
-INSTALLONLY_PROVIDES = {b'kernel', b'kernel-PAE', b'installonlypkg(kernel)',
-                        b'installonlypkg(kernel-module)', b'installonlypkg(vm)',
-                        b'multiversion(kernel)'}
-# newer rpm now returns unicode strings instead of bytes in headers
-INSTALLONLY_PROVIDES.update([p.decode() for p in INSTALLONLY_PROVIDES])
 
 
 class RPM(object):
@@ -65,13 +60,6 @@ class RPM(object):
         one = (str(self.epoch), self.version, self.release)
         two = (str(other.epoch), other.version, other.release)
         return rpm.labelCompare(one, two) <= -1
-
-    def is_installonly(self):
-        if not self.rpmheader:
-            raise ValueError("rpm header not available: %s" % str(self))
-        if INSTALLONLY_PROVIDES.intersection(self.rpmheader.provides):
-            return True
-        return False
 
     @property
     def na(self):

--- a/dnf-behave-tests/dnf/steps/lib/rpm.py
+++ b/dnf-behave-tests/dnf/steps/lib/rpm.py
@@ -58,6 +58,10 @@ class RPM(object):
         return True
 
     def __lt__(self, other):
+        if (self.na < other.na):
+            return True
+        if (self.na > other.na):
+            return False
         one = (str(self.epoch), self.version, self.release)
         two = (str(other.epoch), other.version, other.release)
         return rpm.labelCompare(one, two) <= -1

--- a/dnf-behave-tests/dnf/steps/transaction.py
+++ b/dnf-behave-tests/dnf/steps/transaction.py
@@ -55,6 +55,16 @@ def check_rpmdb_transaction(context, mode):
             if action.startswith('group-') or action.startswith('env-') or action.startswith('module-'):
                 continue
             rpm = RPM(nevra)
+            if action == "install" and rpm not in rpmdb_transaction["install"]:
+                if rpm in rpmdb_transaction["upgrade"]:
+                    action = "upgrade"
+                elif rpm in rpmdb_transaction["downgrade"]:
+                    action = "downgrade"
+            if action == "remove" and rpm not in rpmdb_transaction["remove"]:
+                if rpm in rpmdb_transaction["upgraded"]:
+                    action = "upgraded"
+                elif rpm in rpmdb_transaction["downgraded"]:
+                    action = "downgraded"
             if action == "reinstall" and rpm not in rpmdb_transaction["reinstall"]:
                 action = "unchanged"
             if (action == "remove" and rpm not in rpmdb_transaction["remove"]
@@ -88,6 +98,11 @@ def check_rpmdb_transaction(context, mode):
                     rpmdb_transaction[action].remove(nevra)
                 elif action == "remove" and nevra in rpmdb_transaction["obsoleted"]:
                     rpmdb_transaction["obsoleted"].remove(nevra)
+                elif action == "install":
+                    if nevra in rpmdb_transaction["upgrade"]:
+                        rpmdb_transaction["upgrade"].remove(nevra)
+                    elif nevra in rpmdb_transaction["downgrade"]:
+                        rpmdb_transaction["downgrade"].remove(nevra)
 
         for action in ["install", "remove", "upgrade", "downgrade", "obsoleted"]:
             if rpmdb_transaction[action]:

--- a/dnf-behave-tests/fixtures/specs/installonly/installonlyA-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/installonlyA-1.0-1.spec
@@ -1,0 +1,16 @@
+Name:           installonlyA
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+Provides:       installonlypkg(A)
+
+Summary:        Installonly package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/installonly/installonlyA-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/installonlyA-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           installonlyA
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+Provides:       installonlypkg(A)
+
+Summary:        Installonly package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/installonly/installonlyA-2.2-1.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/installonlyA-2.2-1.spec
@@ -1,0 +1,16 @@
+Name:           installonlyA
+Version:        2.2
+Release:        1
+
+License:        Public Domain
+URL:            None
+Provides:       installonlypkg(A)
+
+Summary:        Installonly package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/installonly/installonlyB-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/installonlyB-1.0-1.spec
@@ -1,0 +1,16 @@
+Name:           installonlyB
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+Provides:       installonlypkg(B)
+
+Summary:        Installonly package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/installonly/installonlyB-2.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/installonlyB-2.0-1.spec
@@ -1,0 +1,16 @@
+Name:           installonlyB
+Version:        2.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+Provides:       installonlypkg(B)
+
+Summary:        Installonly package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/installonly/installonlyB-2.2-1.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/installonlyB-2.2-1.spec
@@ -1,0 +1,16 @@
+Name:           installonlyB
+Version:        2.2
+Release:        1
+
+License:        Public Domain
+URL:            None
+Provides:       installonlypkg(B)
+
+Summary:        Installonly package.
+
+%description
+Dummy.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/installonly/kernel-4.18.16-300.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/kernel-4.18.16-300.fc29.spec
@@ -1,0 +1,39 @@
+Name:           kernel
+Epoch:          0
+Version:        4.18.16
+Release:        300.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       kernel = 4.18.16-300.fc29
+Provides:       kernel(x86-64) = 4.18.16-300.fc29
+
+Requires:       kernel-core-uname-r = 4.18.16-300.fc29.x86_64
+
+%description
+The kernel meta package
+
+%package core
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+Provides:       kernel = 4.18.16-300.fc29
+Provides:       kernel-core-uname-r = 4.18.16-300.fc29.x86_64
+Provides:       kernel-core = 4.18.16-300.fc29
+Provides:       kernel-core(x86-64) = 4.18.16-300.fc29
+Provides:       kernel-x86_64 = 4.18.16-300.fc29
+
+%description core
+The kernel package contains the Linux kernel (vmlinuz), the core of any
+Linux operating system.  The kernel handles the basic functions
+of the operating system: memory allocation, process allocation, device
+input and output, etc.
+
+%files
+
+%files core
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/installonly/kernel-4.19.15-300.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/kernel-4.19.15-300.fc29.spec
@@ -1,0 +1,39 @@
+Name:           kernel
+Epoch:          0
+Version:        4.19.15
+Release:        300.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       kernel = 4.19.15-300.fc29
+Provides:       kernel(x86-64) = 4.19.15-300.fc29
+
+Requires:       kernel-core-uname-r = 4.19.15-300.fc29.x86_64
+
+%description
+The kernel meta package
+
+%package core
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+Provides:       kernel = 4.19.15-300.fc29
+Provides:       kernel-core-uname-r = 4.19.15-300.fc29.x86_64
+Provides:       kernel-core = 4.19.15-300.fc29
+Provides:       kernel-core(x86-64) = 4.19.15-300.fc29
+Provides:       kernel-x86_64 = 4.19.15-300.fc29
+
+%description core
+The kernel package contains the Linux kernel (vmlinuz), the core of any
+Linux operating system.  The kernel handles the basic functions
+of the operating system: memory allocation, process allocation, device
+input and output, etc.
+
+%files
+
+%files core
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/installonly/kernel-4.20.6-300.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/installonly/kernel-4.20.6-300.fc29.spec
@@ -1,0 +1,39 @@
+Name:           kernel
+Epoch:          0
+Version:        4.20.6
+Release:        300.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       kernel = 4.20.6-300.fc29
+Provides:       kernel(x86-64) = 4.20.6-300.fc29
+
+Requires:       kernel-core-uname-r = 4.20.6-300.fc29.x86_64
+
+%description
+The kernel meta package
+
+%package core
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+Provides:       kernel = 4.20.6-300.fc29
+Provides:       kernel-core-uname-r = 4.20.6-300.fc29.x86_64
+Provides:       kernel-core = 4.20.6-300.fc29
+Provides:       kernel-core(x86-64) = 4.20.6-300.fc29
+Provides:       kernel-x86_64 = 4.20.6-300.fc29
+
+%description core
+The kernel package contains the Linux kernel (vmlinuz), the core of any
+Linux operating system.  The kernel handles the basic functions
+of the operating system: memory allocation, process allocation, device
+input and output, etc.
+
+%files
+
+%files core
+
+%changelog


### PR DESCRIPTION
PR also changes the `diff_rpm_lists` and `check_rpmdb_transaction` functions.

The previous version of `diff_rpm_lists` function used `RPM.is_installonly`method, which contained hardcoded list of "installonly" packages. This aproach was unusable for testing the "installonlypkgs" option, because the same package is used as both "installonly" and as "not-installony" (depending on the value of the "installonlypkgs" option tested).
The new version of `diff_rpm_lists` function still uses information about "installonly" packages, but "installonly" packages are automaticaly detected. Detection uses the assumption that multiple versions of a package with the same name and architecture on the system mean an "installonly" package.

There is a special case when "installonly" package is removed and another version is installed. In this case, it is not an "installonly" package for automatic detection, and the `diff_rpm_lists` function returns upgrade or downgrade. So, the check_rpmdb_transaction` function was extended to deal with this.