### PR TITLE
Temporarily freeze libsolv at 0.7.19 until new version gets into centos

### DIFF
--- a/overlays/dnf-nightly/overlay.yml
+++ b/overlays/dnf-nightly/overlay.yml
@@ -11,6 +11,7 @@ components:
   - name: libsolv
     git:
       src: github:openSUSE/libsolv.git
+      freeze: c773294be6b0a2425f344a8999f173fb00cfd16f
     distgit:
       src: fedorapkgs:libsolv.git
       patches: drop


### PR DESCRIPTION
This overlay uses patches for centos 8 stream build from:
https://git.centos.org/rpms/libsolv/blob/c8s/f/SOURCES however patch
0002-Fix-Memory-leaks-in-SWIG-generated-code-for-Python.patch is
already merged upstream, this causes problems because it tries to apply
the patch again which fails. This is responsible for our dnf-nightly
failures.

To resolve this freeze libsolv at the last commit before the merged patch.

This can be removed once the patch is removed from the centos distgit.

----

Another option would be to configure dropping the patches but this would 
also drop 0001-Add-support-for-computing-hashes-using-OpenSSL.patch.

I am not sure which option is better.
