### PR TITLE
Add dedicated overlay for dnf5-ci testing

### DIFF
--- a/overlays/dnf5-ci/overlay.yml
+++ b/overlays/dnf5-ci/overlay.yml
@@ -1,0 +1,16 @@
+---
+aliases:
+  - name: github
+    url: https://github.com/
+
+components:
+  - name: librepo
+    git:
+      src: github:rpm-software-management/librepo.git
+
+  - name: libdnf
+    git:
+      src: github:rpm-software-management/libdnf.git
+      branch: origin/dnf-5-devel
+    requires:
+      - librepo


### PR DESCRIPTION
Integration tests for dnf5 require only librepo and libdnf.
There is no need to build dnf, plugins or libcomps.

We could also possibly reuse dnf5-unstable overlay (which currently doesn't build librepo) but this seems like the more correct approach to me.