### PR TITLE
GHA: enable dnf-nightly for l10n-update-pot

### DIFF
--- a/.github/actions/l10n-update-pot/action.yml
+++ b/.github/actions/l10n-update-pot/action.yml
@@ -15,6 +15,8 @@ runs:
     - name: Generate *.pot files
       shell: bash
       run: |
+        dnf -y copr enable rpmsoftwaremanagement/dnf-nightly
+
         # generate fresh *.pot file from source
         pushd source > /dev/null
           dnf --assumeyes build-dep *.spec


### PR DESCRIPTION
The action builds the component and sometimes there are dependencies on
unreleased versions of the stack, we need nightlies to satisfy those.

@mblaha