### PR TITLE
Lock CI host image to f34 due to broken deps

### DIFF
--- a/.github/workflows/ci-host.yml
+++ b/.github/workflows/ci-host.yml
@@ -29,7 +29,8 @@ jobs:
           echo ${{secrets.GITHUB_TOKEN}} | docker login ghcr.io -u ${GHCR_USER} --password-stdin
 
           docker build -t ${IMAGE}:${DATE} -t ${IMAGE}:latest -<<EOF
-          FROM fedora:latest
+          # temporarily lock to f34, f35 has an issue with Copr deps
+          FROM fedora:34
           RUN dnf -y update
           RUN dnf -y install dnf-plugins-core
           RUN dnf -y copr enable rpmsoftwaremanagement/rpm-gitoverlay

--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -26,8 +26,6 @@ BuildRequires:  openssl
 BuildRequires:  python3
 BuildRequires:  python3-distro
 BuildRequires:  python3-pip
-# a missing dep of python3-pip on f35 beta, remove when unneeded
-BuildRequires:  python3-setuptools
 BuildRequires:  rpm-build
 BuildRequires:  rpm-sign
 BuildRequires:  sqlite


### PR DESCRIPTION
Also drops the setuptools dependency from requirements.txt, as that one (looks like a similar issue) has already been fixed.