### PR TITLE
dnf-behave-tests: Re-introduce dependency on python3-setuptools

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -26,6 +26,8 @@ BuildRequires:  openssl
 BuildRequires:  python3
 BuildRequires:  python3-distro
 BuildRequires:  python3-pip
+# a missing dep of python3-pip on f35 beta, remove when unneeded
+BuildRequires:  python3-setuptools
 BuildRequires:  rpm-build
 BuildRequires:  rpm-sign
 BuildRequires:  sqlite


### PR DESCRIPTION
The dependency is still needed, it is a weak dep in python3-pip.

This reverts commit 8e743f8a7fd6d3d7a3cf1cd33e110a85c3599d0b.

related: https://bugzilla.redhat.com/show_bug.cgi?id=2020635