### PR TITLE
createrepo_c: add a test with an ampersand in a provide

### DIFF
--- a/dnf-behave-tests/createrepo_c/bad-packages.feature
+++ b/dnf-behave-tests/createrepo_c/bad-packages.feature
@@ -32,3 +32,18 @@ Given I create directory "/temp-repo/"
       C_CREATEREPOLIB: Warning: read_header: rpmReadPackageFile() error
       C_CREATEREPOLIB: Warning: Cannot read package: ./emptyfilethatlookslike.rpm: rpmReadPackageFile() error
       """
+
+
+Scenario: Don't re-escape ampersand when running with --update
+Given I create symlink "/createrepo_c-ci-packages" to file "/{context.scenario.repos_location}/createrepo_c-ci-packages"
+  And I execute createrepo_c with args "." in "/"
+ When I execute createrepo_c with args "--update ." in "/"
+ Then the exit code is 0
+  And repodata "/repodata" are consistent
+  And I execute "dnf --repofrompath=test,{context.scenario.default_tmp_dir}/ --repo test repoquery --provides ampersand-provide-package"
+  And stdout is
+  """
+  ampersand-provide-package = 0.2.1-1.fc29
+  ampersand-provide-package(x86-64) = 0.2.1-1.fc29
+  font(bpgalgetigpl&gnu)
+  """

--- a/dnf-behave-tests/fixtures/specs/createrepo_c-ci-packages/ampersand-provide-package-0.2.1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/createrepo_c-ci-packages/ampersand-provide-package-0.2.1-1.spec
@@ -1,0 +1,15 @@
+Summary:        Test package for createrepo_c with and ampersand provide
+Name:           ampersand-provide-package
+Version:        0.2.1
+Release:        1%{?dist}
+License:        GPLv2+
+URL:            https://github.com/rpm-software-management/package
+
+Provides:       font(bpgalgetigpl&gnu)
+
+%description
+Test package with ampersand in a provide
+
+%files
+
+%changelog


### PR DESCRIPTION
Test we don't re-escape `&` on a second run with `--update`.

For: https://github.com/rpm-software-management/createrepo_c/pull/289