### PR TITLE
system-upgrade doesn't delete user files when cleaning up caches (RhBug:2024430)

### DIFF
--- a/dnf-behave-tests/dnf/plugins-extras/system-upgrade.feature
+++ b/dnf-behave-tests/dnf/plugins-extras/system-upgrade.feature
@@ -197,3 +197,40 @@ Given I successfully execute dnf with args "distro-sync"
       """
       Error: system is not ready for upgrade
       """
+
+
+@bz2024430
+Scenario Outline: Test system-upgrade with <option> doesn't delete user files
+Given I create directory "/downloaddir"
+  And I create file "/downloaddir/precious_file1" with
+      """
+      precious content1
+      """
+  And I create directory "/downloaddir/precious_dir"
+  And I create file "/downloaddir/precious_dir/precious_file2" with
+      """
+      precious content2
+      """
+  And I execute dnf with args "system-upgrade download <option>={context.dnf.installroot}/downloaddir"
+  And I successfully execute dnf with args "system-upgrade reboot"
+  And I stop http server for repository "system-upgrade-f$releasever"
+  And I stop http server for repository "system-upgrade-2-f$releasever"
+ When I execute dnf with args "system-upgrade upgrade"
+ Then the exit code is 0
+  And transaction is following
+      | Action        | Package               |
+      | upgrade       | pkg-a-2.0-1.noarch    |
+      | upgrade       | pkg-both-2.0-1.noarch |
+      | downgrade     | pkg-b-1.0-1.noarch    |
+  And file "/downloaddir/precious_file1" exists
+  And file "/downloaddir/precious_dir/precious_file2" exists
+  And file "/downloaddir/pkg-a-2.0-1.noarch.rpm" does not exist
+  And file "/downloaddir/pkg-b-1.0-1.noarch.rpm" does not exist
+  And file "/downloaddir/pkg-both-2.0-1.noarch.rpm" does not exist
+
+Examples:
+      | option            |
+      | --destdir         |
+      | --downloaddir     |
+      | --setopt=cachedir |
+      # cachedir cannot be overwritten by user in system-upgrade, but test it to make sure


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf-plugins-extras/pull/201

https://bugzilla.redhat.com/show_bug.cgi?id=2024430