### PR TITLE
Fix random fail needs-restarting boot time detect

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/needs-restarting-conf-files.feature
+++ b/dnf-behave-tests/dnf/plugins-core/needs-restarting-conf-files.feature
@@ -5,7 +5,7 @@ Given I enable plugin "needs_restarting"
   And I use repository "needs-restarting"
   And I move the clock backward to "before boot-up"
   And I execute dnf with args "install wget abcde"
-  And I move the clock forward to "the present"
+  And I move the clock forward to "2 hours"
   And I use repository "needs-restarting-updates"
   And I create directory "/etc/dnf/plugins/needs-restarting.d"
   And I create and substitute file "/etc/dnf/plugins/needs-restarting.d/wget.conf" with


### PR DESCRIPTION
Apparently the steps
- I move the clock forward to "the present"
- I execute dnf with args "upgrade wget"
may happen at the exact integer time and the first
scenario that checks for boot time may fail
causing a false negative warning.

Many thanks to @m-blaha who found it.