### PR TITLE
Behavior of the rpmdb version is changed, each transaction causes change

### DIFF
--- a/dnf-behave-tests/dnf/history-rpmdb.feature
+++ b/dnf-behave-tests/dnf/history-rpmdb.feature
@@ -10,4 +10,4 @@ Scenario: Compute rpmdb version in repeatable manner
     And the exit code is 0
    Then I execute dnf with args "reinstall setup"
     And the exit code is 0
-   Then history info rpmdb version did not change
+   Then history info rpmdb version changed

--- a/dnf-behave-tests/dnf/plugins-core/debug-dump.feature
+++ b/dnf-behave-tests/dnf/plugins-core/debug-dump.feature
@@ -47,7 +47,7 @@ Scenario: dnf debug-dump dumps file with configuration
       test-replace-0:3-fc29.src
       test-replace-0:3-fc29.x86_64
     %%%%RPMDB VERSIONS
-      all: 2:[0-9abcdef]{40}
+      all: [^ ]+
     """
 
 
@@ -76,5 +76,5 @@ Scenario: dnf debug-dump with --norepos skips dumping repositories contents
       kernel-0:4\.19\.1-fc29\.x86_64
       kernel-0:4\.20\.1-fc29\.x86_64
     %%%%RPMDB VERSIONS
-      all: 2:[0-9abcdef]{40}
+      all: [^ ]+
     """

--- a/dnf-behave-tests/dnf/steps/history.py
+++ b/dnf-behave-tests/dnf/steps/history.py
@@ -131,12 +131,12 @@ def step_impl(context, spec=None):
         print_lines_diff(expected_actions, found_actions)
         raise AssertionError("History actions mismatch")
 
-@behave.then('History info rpmdb version did not change')
+@behave.then('History info rpmdb version changed')
 def step_impl(context, spec=""):
     h_info = parsed_history_info(context, spec)
     assert (h_info['Begin rpmdb']), "End rpmdb version not found"
     assert (h_info['End rpmdb']), "End rpmdb version not found"
-    assert (h_info['End rpmdb'] == h_info['Begin rpmdb']), "Begin and end rpmdb versions are different"
+    assert (h_info['End rpmdb'] != h_info['Begin rpmdb']), "Begin and end rpmdb versions are the same"
 
 
 @behave.then('package reasons are')


### PR DESCRIPTION
* Each rpm transaction, including reinstalling the same package, will change the version of the rpm database.

* Format of the rpmdb version is changed, depends on librpm - The rpmdb version is now obtained from librpm. Format not defined. And can be changed in the future. E.g. now it's SHA1, but switch to SHA256 is ready. In fact, every non-empty string is valid.

It is related to the transition to the use of cookies from librpm.
https://github.com/rpm-software-management/dnf/pull/1811
https://github.com/rpm-software-management/libdnf/pull/1434