### PR TITLE
Add step for generating repository that fails

### DIFF
--- a/dnf-behave-tests/common/lib/cmd.py
+++ b/dnf-behave-tests/common/lib/cmd.py
@@ -29,7 +29,7 @@ def run(cmd, shell=True, cwd=None):
     return proc.returncode, stdout, stderr
 
 
-def run_in_context(context, cmd, can_fail=False, **run_args):
+def run_in_context(context, cmd, can_fail=False, expected_exit_code=None, **run_args):
     if getattr(context, "faketime", None) is not None:
         cmd = context.faketime + cmd
 
@@ -48,6 +48,10 @@ def run_in_context(context, cmd, can_fail=False, **run_args):
 
     if not can_fail and context.cmd_exitcode != 0:
         raise AssertionError('Running command "%s" failed: %s' % (cmd, context.cmd_exitcode))
+    elif expected_exit_code is not None and int(expected_exit_code) != context.cmd_exitcode:
+        raise AssertionError(
+            'Running command "%s" had unexpected exit code: %s' % (cmd, context.cmd_exitcode)
+        )
 
 
 def assert_exitcode(context, exitcode):

--- a/dnf-behave-tests/dnf/gpg.feature
+++ b/dnf-behave-tests/dnf/gpg.feature
@@ -126,7 +126,8 @@ Scenario: Fail to install package with incorrect checksum when gpgcheck=0
 @bz1932090
 Scenario: Refuse to install a package with broken gpg signature
   Given I drop repository "dnf-ci-gpg"
-    And I use repository "dnf-ci-broken-rpm-signature" with configuration
+    And I use repository "dnf-ci-broken-rpm-signature" generated with exit code "2"
+    And I configure repository "dnf-ci-broken-rpm-signature" with
         | key      | value                                                                                                                                                               |
         | gpgcheck | 1                                                                                                                                                                   |
         | gpgkey   | file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg/dnf-ci-gpg-public,file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg-subkey/dnf-ci-gpg-subkey-public |

--- a/dnf-behave-tests/dnf/microdnf/gpg.feature
+++ b/dnf-behave-tests/dnf/microdnf/gpg.feature
@@ -6,7 +6,8 @@ Feature: GPG signatures
 @bz1932089
 @bz1932090
 Scenario: Refuse to install a package with broken gpg signature
-  Given I use repository "dnf-ci-broken-rpm-signature" with configuration
+  Given I use repository "dnf-ci-broken-rpm-signature" generated with exit code "2"
+    And I configure repository "dnf-ci-broken-rpm-signature" with
         | key      | value                                                                                                                                                               |
         | gpgcheck | 1                                                                                                                                                                   |
         | gpgkey   | file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg/dnf-ci-gpg-public,file://{context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg-subkey/dnf-ci-gpg-subkey-public |


### PR DESCRIPTION
The gpg.feature requires repository with package with broken gpg
signature and createrepo_c started to return exit code 2 when
generating such repostiory.