### PR TITLE
dnf-behave-tests/dnf/steps/repo: Convert expected_exit_code to int in…

### DIFF
--- a/dnf-behave-tests/common/lib/cmd.py
+++ b/dnf-behave-tests/common/lib/cmd.py
@@ -48,7 +48,7 @@ def run_in_context(context, cmd, can_fail=False, expected_exit_code=None, **run_
 
     if not can_fail and context.cmd_exitcode != 0:
         raise AssertionError('Running command "%s" failed: %s' % (cmd, context.cmd_exitcode))
-    elif expected_exit_code is not None and int(expected_exit_code) != context.cmd_exitcode:
+    elif expected_exit_code is not None and expected_exit_code != context.cmd_exitcode:
         raise AssertionError(
             'Running command "%s" had unexpected exit code: %s' % (cmd, context.cmd_exitcode)
         )

--- a/dnf-behave-tests/dnf/steps/repo.py
+++ b/dnf-behave-tests/dnf/steps/repo.py
@@ -168,7 +168,7 @@ def step_use_repository_generated_with_exit_code(context, repo, exitcode):
     installroot).
     Createrepo_c can fail during generating the repodata, with given exit code.
     """
-    generate_repodata(context, repo, can_fail=True, expected_exit_code=exitcode)
+    generate_repodata(context, repo, can_fail=True, expected_exit_code=int(exitcode))
     create_repo_conf(context, repo)
 
 


### PR DESCRIPTION
… the step

The run_in_context() should be accepting ints, the conversion should
happen on the step input.