### PR TITLE
Fix random fail needs-restarting boot time detect

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
+++ b/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
@@ -6,7 +6,7 @@ Background:
       And I use repository "dnf-ci-fedora"
       And I move the clock backward to "before boot-up"
       And I execute dnf with args "install lame kernel basesystem glibc wget"
-      And I move the clock forward to "the present"
+      And I move the clock forward to "2 hours"
       And I use repository "dnf-ci-fedora-updates"
 
 @bz1913962


### PR DESCRIPTION
The same as for needs-restarting-conf-files.feature.

Apparently the steps
- I move the clock forward to "the present"
- I execute dnf with args "upgrade wget"
may happen at the exact integer time and the first
scenario that checks for boot time may fail
causing a false negative warning.