### PR TITLE
CI: Switch to Fedora 35 and Switch CI host image back to latest

### DIFF
--- a/.github/workflows/ci-host.yml
+++ b/.github/workflows/ci-host.yml
@@ -29,8 +29,7 @@ jobs:
           echo ${{secrets.GITHUB_TOKEN}} | docker login ghcr.io -u ${GHCR_USER} --password-stdin
 
           docker build -t ${IMAGE}:${DATE} -t ${IMAGE}:latest -<<EOF
-          # temporarily lock to f34, f35 has an issue with Copr deps
-          FROM fedora:34
+          FROM fedora:latest
           RUN dnf -y update
           RUN dnf -y install dnf-plugins-core
           RUN dnf -y copr enable rpmsoftwaremanagement/rpm-gitoverlay

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # $ podman build --build-arg TYPE=distro -t ci-dnf-stack -f Dockerfile
 # $ podman run --net none -it ci-dnf-stack behave dnf
 
-ARG BASE=fedora:34
+ARG BASE=fedora:35
 FROM $BASE
 
 ENV LANG C.UTF-8

--- a/dnf-behave-tests/dnf/download-source.feature
+++ b/dnf-behave-tests/dnf/download-source.feature
@@ -64,7 +64,7 @@ Given I create directory "/baseurlrepo"
  Then the exit code is 1
   And stderr contains "Errors during downloading metadata for repository 'testrepo':"
   And stderr contains "- Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
-  And stderr contains "- Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000: Connection refused\]"
+  And stderr contains "- Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Connection refused\]"
   And stderr contains "- Curl error \(37\): Couldn't read a file:// file for file:///tmp/dnf_ci_installroot_.*/I_dont_exist/repodata/repomd.xml \[Couldn't open file /tmp/dnf_ci_installroot_.*/I_dont_exist/repodata/repomd.xml\]"
   And stderr contains "Error: Failed to download metadata for repo 'testrepo': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
 

--- a/dnf-behave-tests/dnf/repo-sync.feature
+++ b/dnf-behave-tests/dnf/repo-sync.feature
@@ -159,14 +159,14 @@ Scenario: Mirrorlist with invalid mirrors
    Then the exit code is 1
     And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
     And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
-    And stderr contains "  - Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000: Connection refused\]"
+    And stderr contains "  - Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Connection refused\]"
     And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
     And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
    When I execute dnf with args "makecache --setopt=*.skip_if_unavailable=1"
    Then the exit code is 0
     And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
     And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
-    And stderr contains "  - Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000: Connection refused\]"
+    And stderr contains "  - Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Connection refused\]"
     And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
     And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
     And stderr contains "Ignoring repositories: dnf-ci-fedora"


### PR DESCRIPTION
I have tried building the host image with latest and it works now: https://github.com/kontura/ci-dnf-stack/actions/runs/1955798776