### PR TITLE
Switch ansible dockerfile to f35 together with the rest of CI

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -2,7 +2,7 @@
 # $ podman build --build-arg TYPE=distro -t ansible -f Dockerfile.ansible
 # $ podman run --net none -it ansible ./ansible
 
-FROM fedora:34
+FROM fedora:35
 ARG TYPE=nightly
 
 # enable nightlies if requested


### PR DESCRIPTION
I have noticed the Ansible test are failing due to mismatching python versions, this should fix it.