### PR TITLE
createrepo_c: libmodulemd added some double-quotes in modulemd-defaults

### DIFF
--- a/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
+++ b/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
@@ -22,7 +22,7 @@ Given I create directory "/modular_repo1/"
         summary: Test module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile1:
             rpms:
@@ -32,7 +32,7 @@ Given I create directory "/modular_repo1/"
             modular-package1: {rationale: 'rationale for modular-package1'}
         artifacts:
           rpms:
-          - modular-package1-0:0.1-1.x86_64.rpm
+          - "modular-package1-0:0.1-1.x86_64.rpm"
       ...
       ---
       document: modulemd-defaults
@@ -41,7 +41,7 @@ Given I create directory "/modular_repo1/"
         module: test-module
         stream: "modular-package1"
         profiles:
-          test-profile1: [default]
+          "test-profile1": [default]
       ...
       """
   And I create file "/modules2.yaml" with
@@ -58,7 +58,7 @@ Given I create directory "/modular_repo1/"
         summary: Test module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile2:
             rpms:
@@ -68,7 +68,7 @@ Given I create directory "/modular_repo1/"
             modular-package2: {rationale: 'rationale for modular-package2'}
         artifacts:
           rpms:
-          - modular-package2-0:0.1-1.x86_64.rpm
+          - "modular-package2-0:0.1-1.x86_64.rpm"
       ...
       ---
       document: modulemd-defaults
@@ -77,7 +77,7 @@ Given I create directory "/modular_repo1/"
         module: test-module
         stream: "modular-package2"
         profiles:
-          test-profile2: [default]
+          "test-profile2": [default]
       ...
       """
   And I execute modifyrepo_c with args "--mdtype=modules ../../modules1.yaml ." in "/modular_repo1/repodata"
@@ -97,8 +97,8 @@ Scenario: merged repository contains streams from both source repositories
       data:
         module: test-module
         profiles:
-          test-profile1: [default]
-          test-profile2: [default]
+          "test-profile1": [default]
+          "test-profile2": [default]
       ...
       ---
       document: modulemd
@@ -113,7 +113,7 @@ Scenario: merged repository contains streams from both source repositories
           Made up module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile1:
             rpms:
@@ -124,7 +124,7 @@ Scenario: merged repository contains streams from both source repositories
               rationale: rationale for modular-package1
         artifacts:
           rpms:
-          - modular-package1-0:0.1-1.x86_64.rpm
+          - "modular-package1-0:0.1-1.x86_64.rpm"
       ...
       ---
       document: modulemd
@@ -139,7 +139,7 @@ Scenario: merged repository contains streams from both source repositories
           Made up module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile2:
             rpms:
@@ -150,6 +150,6 @@ Scenario: merged repository contains streams from both source repositories
               rationale: rationale for modular-package2
         artifacts:
           rpms:
-          - modular-package2-0:0.1-1.x86_64.rpm
+          - "modular-package2-0:0.1-1.x86_64.rpm"
       ...
       """

--- a/dnf-behave-tests/createrepo_c/modular.feature
+++ b/dnf-behave-tests/createrepo_c/modular.feature
@@ -35,7 +35,7 @@ Given I create file "/modules.yaml" with
         module: test-module
         stream: "modular-package1"
         profiles:
-          test-profile1: [default]
+          "test-profile1": [default]
       ...
       """
   And I create file "/stream.modulemd.yaml" with
@@ -52,7 +52,7 @@ Given I create file "/modules.yaml" with
         summary: Test module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile2:
             rpms:
@@ -71,7 +71,7 @@ Given I create file "/modules.yaml" with
         module: test-module
         stream: "modular-package2"
         profiles:
-          test-profile2: [default]
+          "test-profile2": [default]
       ...
       """
   And I create file "/some.modulemd-defaults.yaml" with
@@ -83,7 +83,7 @@ Given I create file "/modules.yaml" with
         module: stratis
         stream: "1"
         profiles:
-          1: [default]
+          "1": [default]
       ...
       ---
       document: modulemd-defaults
@@ -92,7 +92,7 @@ Given I create file "/modules.yaml" with
         module: scala
         stream: "2.10"
         profiles:
-          2.10: [default]
+          "2.10": [default]
       ...
       """
  And I create file "/modular-result.yaml" with
@@ -104,7 +104,7 @@ Given I create file "/modules.yaml" with
         module: scala
         stream: "2.10"
         profiles:
-          2.10: [default]
+          "2.10": [default]
       ...
       ---
       document: modulemd-defaults
@@ -113,7 +113,7 @@ Given I create file "/modules.yaml" with
         module: stratis
         stream: "1"
         profiles:
-          1: [default]
+          "1": [default]
       ...
       ---
       document: modulemd-defaults
@@ -121,8 +121,8 @@ Given I create file "/modules.yaml" with
       data:
         module: test-module
         profiles:
-          test-profile1: [default]
-          test-profile2: [default]
+          "test-profile1": [default]
+          "test-profile2": [default]
       ...
       ---
       document: modulemd
@@ -137,7 +137,7 @@ Given I create file "/modules.yaml" with
           Made up module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile1:
             rpms:
@@ -148,7 +148,7 @@ Given I create file "/modules.yaml" with
               rationale: rationale for modular-package1
         artifacts:
           rpms:
-          - modular-package1-0:0.1-1.x86_64.rpm
+          - "modular-package1-0:0.1-1.x86_64.rpm"
       ...
       ---
       document: modulemd
@@ -163,7 +163,7 @@ Given I create file "/modules.yaml" with
           Made up module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile2:
             rpms:
@@ -174,7 +174,7 @@ Given I create file "/modules.yaml" with
               rationale: rationale for modular-package2
         artifacts:
           rpms:
-          - modular-package2-0:0.1-1.x86_64.rpm
+          - "modular-package2-0:0.1-1.x86_64.rpm"
       ...
       """
 
@@ -383,7 +383,7 @@ Given I create directory "/repo/"
         module: scala
         stream: "2.10"
         profiles:
-          2.10: [default]
+          "2.10": [default]
       ...
       ---
       document: modulemd-defaults
@@ -392,7 +392,7 @@ Given I create directory "/repo/"
         module: stratis
         stream: "1"
         profiles:
-          1: [default]
+          "1": [default]
       ...
       """
 

--- a/dnf-behave-tests/createrepo_c/update-keep-all-metadata.feature
+++ b/dnf-behave-tests/createrepo_c/update-keep-all-metadata.feature
@@ -38,7 +38,7 @@ Given I create directory "/temp-repo/"
         summary: Test module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile1:
             rpms:
@@ -48,7 +48,7 @@ Given I create directory "/temp-repo/"
             modular-package1: {rationale: 'rationale for modular-package1'}
         artifacts:
           rpms:
-          - modular-package1-0:0.1-1.x86_64.rpm
+          - "modular-package1-0:0.1-1.x86_64.rpm"
       ...
       """
   And I create file "/custom_metadata.txt" with
@@ -195,7 +195,7 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
         summary: Test module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile2:
             rpms:
@@ -205,7 +205,7 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
             modular-package2: {rationale: 'rationale for modular-package2'}
         artifacts:
           rpms:
-          - modular-package2-0:0.1-1.x86_64.rpm
+          - "modular-package2-0:0.1-1.x86_64.rpm"
       ...
       """
  When I execute createrepo_c with args "--update --keep-all-metadata ." in "/temp-repo"
@@ -239,7 +239,7 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
           Made up module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile1:
             rpms:
@@ -250,7 +250,7 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
               rationale: rationale for modular-package1
         artifacts:
           rpms:
-          - modular-package1-0:0.1-1.x86_64.rpm
+          - "modular-package1-0:0.1-1.x86_64.rpm"
       ...
       ---
       document: modulemd
@@ -265,7 +265,7 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
           Made up module
         license:
           module:
-          - MIT
+          - "MIT"
         profiles:
           test-profile2:
             rpms:
@@ -276,7 +276,7 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
               rationale: rationale for modular-package2
         artifacts:
           rpms:
-          - modular-package2-0:0.1-1.x86_64.rpm
+          - "modular-package2-0:0.1-1.x86_64.rpm"
       ...
       """
 


### PR DESCRIPTION
https://github.com/fedora-modularity/libmodulemd/pull/587