### PR TITLE
When running with nightly ensure nightly packages are used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ COPY ./repos.d/ /etc/yum.repos.d/
 
 # enable the test-utils repo
 RUN set -x && \
-    dnf -y upgrade; \
-    dnf clean all; \
+    dnf -y --refresh upgrade; \
     dnf -y install dnf-plugins-core; \
     dnf -y copr enable rpmsoftwaremanagement/test-utils;
 
@@ -27,11 +26,8 @@ RUN set -x && \
 RUN set -x && \
     if [ "$TYPE" == "nightly" ]; then \
         dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
+        dnf -y distro-sync --repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly; \
     fi
-
-# upgrade all packages
-RUN set -x && \
-    dnf -y --refresh upgrade
 
 # copy test suite
 COPY ./dnf-behave-tests/ /opt/ci/dnf-behave-tests


### PR DESCRIPTION
Nightlies can sometimes contain builds with the same nevras as in the
Fedora repo but the Fedora repo can contain additional downstream
patches. We are testing for unpatched behavior.
More details: https://github.com/rpm-software-management/rpm-gitoverlay/pull/35

Also cleans up dnf metadata refreshes and upgrades (we want to end up
with packages from nighly builds even if Fedora repo has newer nevras)

I don't know what was the purpose of the `dnf clean all;`, it seems redundant to me.