### PR TITLE
Test modulemd is accepted even with additional fields (RhBug:2004853,…

### DIFF
--- a/dnf-behave-tests/features/module/metadata-format.feature
+++ b/dnf-behave-tests/features/module/metadata-format.feature
@@ -1,0 +1,46 @@
+Feature: libmodulemd document format tests
+
+
+@bz2004853
+@bz2007166
+@bz2007167
+Scenario: Metadata containing additional uknown field can be read (the field is ignored)
+Given I use repository "additional-field-modulemd"
+ When I execute dnf with args "module info nodejs"
+ Then stdout is
+      """
+      <REPOSYNC>
+      Name             : nodejs
+      Stream           : 5
+      Version          : 20150811143428
+      Context          : 6c81f848
+      Architecture     : x86_64
+      Profiles         : default, development, minimal
+      Default profiles : 
+      Repo             : additional-field-modulemd
+      Summary          : Javascript runtime
+      Description      : Node.js is a platform built on Chrome
+      Requires         : platform:[f29]
+      Artifacts        : nodejs-1:5.3.1-1.module_2011+41787af0.src
+                       : nodejs-1:5.3.1-1.module_2011+41787af0.x86_64
+                       : nodejs-devel-1:5.3.1-1.module_2011+41787af0.x86_64
+                       : nodejs-docs-1:5.3.1-1.module_2011+41787af0.noarch
+                       : npm-1:5.3.1-1.module_2011+41787af0.x86_64
+
+      Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled, [a]ctive
+      """
+
+
+@bz2004853
+@bz2007166
+@bz2007167
+Scenario: Metadata containing additional uknown field can be used for modular filtering
+Given I use repository "additional-field-modulemd"
+  And I use repository "dnf-ci-fedora"
+  And I execute dnf with args "module enable nodejs:5"
+ When I execute dnf with args "repoquery nodejs"
+ Then stdout is
+      """
+      nodejs-1:5.3.1-1.module_2011+41787af0.src
+      nodejs-1:5.3.1-1.module_2011+41787af0.x86_64
+      """

--- a/dnf-behave-tests/fixtures/specs/additional-field-modulemd/modules.yaml
+++ b/dnf-behave-tests/fixtures/specs/additional-field-modulemd/modules.yaml
@@ -1,0 +1,62 @@
+---
+document: modulemd
+version: 2
+data:
+  unknown: field
+  name: nodejs
+  stream: 5
+  version: 20150811143428
+  context: 6c81f848
+  arch: x86_64
+  summary: >-
+    Javascript runtime
+  description: >-
+    Node.js is a platform built on Chrome
+  license:
+    module:
+    - MIT
+    content:
+    - MIT and ASL 2.0 and ISC and BSD
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  references:
+    community: http://nodejs.org
+    documentation: http://nodejs.org/en/docs
+    tracker: https://github.com/nodejs/node/issues
+  profiles:
+    default:
+      rpms:
+      - nodejs
+      - npm
+    development:
+      rpms:
+      - nodejs
+      - nodejs-devel
+      - npm
+    minimal:
+      rpms:
+      - nodejs
+  api:
+    rpms:
+    - nodejs
+    - nodejs-devel
+    - npm
+  components:
+    rpms:
+      nodejs:
+        rationale: Javascript runtime and npm package manager.
+        repository: git://pkgs.fedoraproject.org/rpms/nodejs
+        cache: http://pkgs.fedoraproject.org/repo/pkgs/nodejs
+        ref: 5
+        buildorder: 10
+  artifacts:
+    rpms:
+    - nodejs-1:5.3.1-1.module_2011+41787af0.x86_64
+    - nodejs-1:5.3.1-1.module_2011+41787af0.src
+    - nodejs-devel-1:5.3.1-1.module_2011+41787af0.x86_64
+    - nodejs-docs-1:5.3.1-1.module_2011+41787af0.noarch
+    - npm-1:5.3.1-1.module_2011+41787af0.x86_64
+...

--- a/dnf-behave-tests/fixtures/specs/additional-field-modulemd/nodejs-5.3.1-1.module_2011+41787af0.spec
+++ b/dnf-behave-tests/fixtures/specs/additional-field-modulemd/nodejs-5.3.1-1.module_2011+41787af0.spec
@@ -1,0 +1,87 @@
+%undefine _debuginfo_subpackages
+
+Name:           nodejs
+Epoch:          1
+Version:        5.3.1
+Release:        1.module_2011+41787af0
+
+License:        MIT and ASL 2.0 and ISC and BSD
+URL:            http://nodejs.org/
+
+Summary:        JavaScript runtime
+
+Provides:       nodejs = 1:5.3.1-1.module_2011+41787af0
+Provides:       nodejs(x86-64) = 1:5.3.1-1.module_2011+41787af0
+Provides:       bundled(c-ares) = 1.10.1
+Provides:       bundled(icu) = 60.1
+Provides:       bundled(v8) = 6.2.414.54
+Provides:       nodejs(abi) = 5.3
+Provides:       nodejs(abi8) = 5.3
+Provides:       nodejs(engine) = 5.3.1
+Provides:       nodejs(v8-abi) = 6.2
+Provides:       nodejs(v8-abi6) = 6.2
+Provides:       nodejs-punycode = 2.0.0
+Provides:       npm(punycode) = 2.0.0
+
+Requires:       rtld(GNU_HASH)
+
+Conflicts:      node <= 0.3.2-12
+
+Recommends:     npm = 1:5.6.0-1.5.3.1.1.module_2011+41787af0
+
+%description
+Node.js is a platform built on Chrome's JavaScript runtime
+for easily building fast, scalable network applications.
+Node.js uses an event-driven, non-blocking I/O model that
+makes it lightweight and efficient, perfect for data-intensive
+real-time applications that run across distributed devices.
+
+%package devel
+Summary:        JavaScript runtime - development headers
+
+Provides:       nodejs-devel = 1:5.3.1-1.module_2011+41787af0
+Provides:       nodejs-devel(x86-64) = 1:5.3.1-1.module_2011+41787af0
+
+Requires:       rtld(GNU_HASH)
+Requires:       nodejs(x86-64) = 1:5.3.1-1.module_2011+41787af0
+
+%description devel
+Development headers for the Node.js JavaScript runtime.
+
+%package docs
+Summary:        Node.js API documentation
+BuildArch:      noarch
+
+Provides:       nodejs-docs = 1:5.3.1-1.module_2011+41787af0
+
+Conflicts:      nodejs < 1:5.3.1-1.module_2011+41787af0
+Conflicts:      nodejs > 1:5.3.1-1.module_2011+41787af0
+
+%description docs
+The API documentation for the Node.js JavaScript runtime.
+
+%package -n npm
+Summary:        Node.js Package Manager
+
+Provides:       npm = 1:4.4.0-1.5.3.1.1.module_2011+41787af0
+Provides:       npm = 1:4.4.0
+Provides:       npm(npm) = 4.4.0
+Provides:       npm(x86-64) = 1:4.4.0-1.5.3.1.1.module_2011+41787af0
+
+Requires:       nodejs = 1:5.3.1-1.module_2011+41787af0
+
+Obsoletes:      npm < 2.5.4-6
+
+%description -n npm
+npm is a package manager for node.js. You can use it to install and publish
+your node programs. It manages dependencies and does other cool stuff.
+
+%files
+
+%files devel
+
+%files docs
+
+%files -n npm
+
+%changelog


### PR DESCRIPTION
…2007166,2007167)

The added nodejs module in `additional-filed-modulemd` repository contains unrecognized
`unknown: field` entry which creates an error in strict parsing mode of libmodulemd.

For: https://github.com/rpm-software-management/libdnf/pull/1346

https://bugzilla.redhat.com/show_bug.cgi?id=2004853
https://bugzilla.redhat.com/show_bug.cgi?id=2007166
https://bugzilla.redhat.com/show_bug.cgi?id=2007167