### PR TITLE
Use dnf5 instead of microdnf5 for running dnf5 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         include:
           - { component: dnf, suite: dnf, extra-run-args: '' }
-          - { component: dnf5, suite: dnf, extra-run-args: --tags dnf5 --command microdnf5 }
+          - { component: dnf5, suite: dnf, extra-run-args: --tags dnf5 --command dnf5 }
           - { component: dnf5, suite: dnf, extra-run-args: --tags dnfdaemon --command dnfdaemon-client }
           - { component: createrepo_c, suite: createrepo_c, extra-run-args: '' }
     runs-on: ubuntu-latest


### PR DESCRIPTION
For: https://github.com/rpm-software-management/libdnf/pull/1505