### PR TITLE
[dnf5] Make ready and enable advisory/updateinfo tests for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/repoquery/security-filters.feature
+++ b/dnf-behave-tests/dnf/repoquery/security-filters.feature
@@ -1,0 +1,229 @@
+@dnf5
+Feature: repoquery with security filters (--security, --bugfix, --newpackages, --enhancement)
+
+
+Scenario: --security, --available with available security fix
+Given I use repository "repoquery-security-filters"
+ When I execute dnf with args "repoquery --security --available A"
+ Then the exit code is 0
+  And dnf4 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  """
+  And dnf5 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  A-0:3-3.x86_64
+  """
+
+
+Scenario: --security, --available with available security fix for installed pkg
+Given I use repository "repoquery-security-filters"
+  And I execute dnf with args "install A-1-1"
+ When I execute dnf with args "repoquery --security --available A"
+ Then the exit code is 0
+  And dnf4 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  """
+  And dnf5 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  A-0:3-3.x86_64
+  """
+
+
+Scenario: --security, --installed with available security fix for installed pkg
+Given I use repository "repoquery-security-filters"
+  And I execute dnf with args "install A-1-1"
+ When I execute dnf with args "repoquery --security --installed A"
+ Then the exit code is 0
+  And stdout is empty
+
+
+Scenario: --security, --available with installed and available security fix
+Given I use repository "repoquery-security-filters"
+  And I execute dnf with args "install A-3-3"
+ When I execute dnf with args "repoquery --security --available A"
+ Then the exit code is 0
+  And dnf4 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  """
+  And dnf5 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  A-0:3-3.x86_64
+  """
+
+
+Scenario: --security, --available with installed exact version of security fix
+Given I use repository "repoquery-security-filters"
+  And I execute dnf with args "install A-2-2"
+ When I execute dnf with args "repoquery --security --available A"
+ Then the exit code is 0
+  And dnf4 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  """
+  And dnf5 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  A-0:3-3.x86_64
+  """
+
+
+# Because --installed is used dnf5 shows two A-2-2 packages one from
+# system repo and one from repoquery-security-filters.
+Scenario: --security with installed security fix
+Given I use repository "repoquery-security-filters"
+  And I execute dnf with args "install A-2-2"
+ When I execute dnf with args "repoquery --security --available --installed A --info"
+ Then the exit code is 0
+  And dnf4 stdout is
+  """
+  <REPOSYNC>
+  Name         : A
+  Version      : 2
+  Release      : 2
+  Architecture : x86_64
+  Size         : 0.0  
+  Source       : A-2-2.src.rpm
+  Repository   : @System
+  From repo    : repoquery-security-filters
+  Summary      : Testing advisory upgrade options
+  URL          : None
+  License      : Public Domain
+  Description  : This package is part of testing security options
+  """
+  And dnf5 stdout is
+  """
+  <REPOSYNC>
+  Name         : A
+  Epoch        : 0
+  Version      : 2
+  Release      : 2
+  Architecture : x86_64
+  Install size : 0
+  Source       : A-2-2.src.rpm
+  Repository   : @System
+  Summary      : Testing advisory upgrade options
+  URL          : None
+  License      : Public Domain
+  Description  : This package is part of testing security options
+
+  Name         : A
+  Epoch        : 0
+  Version      : 2
+  Release      : 2
+  Architecture : x86_64
+  Install size : 0
+  Package size : 6082
+  Source       : A-2-2.src.rpm
+  Repository   : repoquery-security-filters
+  Summary      : Testing advisory upgrade options
+  URL          : None
+  License      : Public Domain
+  Description  : This package is part of testing security options
+
+  Name         : A
+  Epoch        : 0
+  Version      : 3
+  Release      : 3
+  Architecture : x86_64
+  Install size : 0
+  Package size : 6082
+  Source       : A-3-3.src.rpm
+  Repository   : repoquery-security-filters
+  Summary      : Testing advisory upgrade options
+  URL          : None
+  License      : Public Domain
+  Description  : This package is part of testing security options
+  """
+
+
+Scenario: --security, --available with advisory for a missing pkg and newer version present
+Given I use repository "repoquery-security-filters"
+ When I execute dnf with args "repoquery --security --available B"
+ Then the exit code is 0
+  And stdout is
+  """
+  <REPOSYNC>
+  B-0:2-2.x86_64
+  """
+
+
+Scenario: list all --security fixes when no pkg name is specified
+Given I use repository "repoquery-security-filters"
+ When I execute dnf with args "repoquery --security --available"
+ Then the exit code is 0
+  And dnf4 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  B-0:2-2.x86_64
+  C-0:1-1.x86_64
+  C-0:2-2.x86_64
+  """
+  And dnf5 stdout is
+  """
+  <REPOSYNC>
+  A-0:2-2.x86_64
+  A-0:3-3.x86_64
+  B-0:2-2.x86_64
+  C-0:1-1.x86_64
+  C-0:2-2.x86_64
+  """
+
+
+Scenario: package C has two versions where each has advisory
+Given I use repository "repoquery-security-filters"
+ When I execute dnf with args "repoquery --security C"
+ Then the exit code is 0
+  And stdout is
+  """
+  <REPOSYNC>
+  C-0:1-1.x86_64
+  C-0:2-2.x86_64
+  """
+
+
+Scenario: repoquery shows a command line package when its present in an advisory
+  Given I use repository "dnf-ci-security"
+   When I execute dnf with args "install advisory_A-1.0-1 advisory_B-1.0-1"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                   |
+        | install       | advisory_A-0:1.0-1.x86_64 |
+        | install       | advisory_B-0:1.0-1.x86_64 |
+   When I execute dnf with args "repoquery --cve CVE-002 {context.scenario.repos_location}/dnf-ci-security/x86_64/advisory_B-1.0-4.x86_64.rpm"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    advisory_B-0:1.0-4.x86_64
+    """
+
+
+Scenario: repoquery filters out a command line package when its not present in an advisory
+  Given I use repository "dnf-ci-security"
+   When I execute dnf with args "install advisory_A-1.0-1 advisory_B-1.0-1"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                   |
+        | install       | advisory_A-0:1.0-1.x86_64 |
+        | install       | advisory_B-0:1.0-1.x86_64 |
+   When I execute dnf with args "repoquery --cve CVE-002 {context.scenario.repos_location}/dnf-ci-security/x86_64/advisory_A-1.0-1.x86_64.rpm"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    """

--- a/dnf-behave-tests/dnf/security-advisory.feature
+++ b/dnf-behave-tests/dnf/security-advisory.feature
@@ -22,6 +22,15 @@ Scenario: upgrade-minimal cve and advisory
         | upgrade       | advisory_B-0:1.0-2.x86_64 |
 
 
+Scenario: upgrade-minimal with pkgs specified cve and advisory
+   When I execute dnf with args "upgrade-minimal advisory_A advisory_B --cve CVE-001 --advisory DNF-BUGFIX-001"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                   |
+        | upgrade       | advisory_A-0:1.0-2.x86_64 |
+        | upgrade       | advisory_B-0:1.0-2.x86_64 |
+
+
 # @dnf5
 # TODO(nsella) Unknown argument "--advisories=DNF-BUGFIX-001" for command "upgrade"
 Scenario: upgrade advisories
@@ -46,7 +55,17 @@ Scenario: upgrade cves
 # @dnf5
 # TODO(nsella) Unknown argument "--sec-severity" for command "upgrade-minimal"
 Scenario: upgrade-minimal sec-severity
-   When I execute dnf with args "upgrade-minimal --sec-severity Moderate"
+   When I execute dnf4 with args "upgrade-minimal --sec-severity Moderate"
+   When I execute dnf5 with args "upgrade-minimal --advisory-severities=Moderate"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                   |
+        | upgrade       | advisory_B-0:1.0-2.x86_64 |
+
+
+Scenario: upgrade-minimal with pkgs specified sec-severity
+   When I execute dnf4 with args "upgrade-minimal advisory_B --sec-severity Moderate"
+   When I execute dnf5 with args "upgrade-minimal advisory_B --advisory-severities=Moderate"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                   |
@@ -56,7 +75,8 @@ Scenario: upgrade-minimal sec-severity
 # @dnf5
 # TODO(nsella) Unknown argument "--sec-severity" for command "upgrade"
 Scenario: upgrade secseverity
-   When I execute dnf with args "upgrade --sec-severity Critical"
+   When I execute dnf4 with args "upgrade --sec-severity Critical"
+   When I execute dnf5 with args "upgrade --advisory-severities Critical"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                   |

--- a/dnf-behave-tests/dnf/security-advisory.feature
+++ b/dnf-behave-tests/dnf/security-advisory.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Test upgrade-minimal with advisory, cve, secseverity
 
 
@@ -11,8 +12,6 @@ Background: Use repository with advisories
         | install       | advisory_B-0:1.0-1.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "--cve" for command "upgrade-minimal"
 Scenario: upgrade-minimal cve and advisory
    When I execute dnf with args "upgrade-minimal --cve CVE-001 --advisory DNF-BUGFIX-001"
    Then the exit code is 0
@@ -31,8 +30,6 @@ Scenario: upgrade-minimal with pkgs specified cve and advisory
         | upgrade       | advisory_B-0:1.0-2.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "--advisories=DNF-BUGFIX-001" for command "upgrade"
 Scenario: upgrade advisories
    When I execute dnf with args "upgrade --advisories=DNF-BUGFIX-001 --advisories=DNF-SECURITY-004"
    Then the exit code is 0
@@ -42,8 +39,6 @@ Scenario: upgrade advisories
         | upgrade       | advisory_B-0:1.0-4.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "--cve" for command "upgrade"
 Scenario: upgrade cves
    When I execute dnf with args "upgrade --cve CVE-001 --cve CVE-002"
    Then the exit code is 0
@@ -52,8 +47,6 @@ Scenario: upgrade cves
         | upgrade       | advisory_B-0:1.0-4.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "--sec-severity" for command "upgrade-minimal"
 Scenario: upgrade-minimal sec-severity
    When I execute dnf4 with args "upgrade-minimal --sec-severity Moderate"
    When I execute dnf5 with args "upgrade-minimal --advisory-severities=Moderate"
@@ -72,8 +65,6 @@ Scenario: upgrade-minimal with pkgs specified sec-severity
         | upgrade       | advisory_B-0:1.0-2.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "--sec-severity" for command "upgrade"
 Scenario: upgrade secseverity
    When I execute dnf4 with args "upgrade --sec-severity Critical"
    When I execute dnf5 with args "upgrade --advisory-severities Critical"
@@ -83,8 +74,6 @@ Scenario: upgrade secseverity
         | upgrade       | advisory_B-0:1.0-4.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "--security" for command "upgrade-minimal"
 Scenario: upgrade-minimal security plus bugfix
    When I execute dnf with args "upgrade-minimal --security --bugfix"
    Then the exit code is 0

--- a/dnf-behave-tests/dnf/security-bugfix.feature
+++ b/dnf-behave-tests/dnf/security-bugfix.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Test security options for update
 
 
@@ -12,8 +13,6 @@ Background: Use repository with advisories
         | install       | bugfix_C-0:1.0-1.x86_64   |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "update" for command "microdnf"
 Scenario: Test security option --bugfix for update
    When I execute dnf with args "upgrade --bugfix"
    Then the exit code is 0
@@ -23,8 +22,6 @@ Scenario: Test security option --bugfix for update
         | upgrade       | bugfix_C-0:1.0-4.x86_64   |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "update-minimal" for command "microdnf"
 Scenario: Test security option --bugfix for upgrade-minimal
    When I execute dnf with args "upgrade-minimal --bugfix"
    Then the exit code is 0

--- a/dnf-behave-tests/dnf/security-bugfix.feature
+++ b/dnf-behave-tests/dnf/security-bugfix.feature
@@ -15,7 +15,7 @@ Background: Use repository with advisories
 # @dnf5
 # TODO(nsella) Unknown argument "update" for command "microdnf"
 Scenario: Test security option --bugfix for update
-   When I execute dnf with args "update --bugfix"
+   When I execute dnf with args "upgrade --bugfix"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                   |
@@ -25,8 +25,8 @@ Scenario: Test security option --bugfix for update
 
 # @dnf5
 # TODO(nsella) Unknown argument "update-minimal" for command "microdnf"
-Scenario: Test security option --bugfix for update-minimal
-   When I execute dnf with args "update-minimal --bugfix"
+Scenario: Test security option --bugfix for upgrade-minimal
+   When I execute dnf with args "upgrade-minimal --bugfix"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                   |

--- a/dnf-behave-tests/dnf/security-security.feature
+++ b/dnf-behave-tests/dnf/security-security.feature
@@ -31,8 +31,7 @@ Scenario: Security check-update when there are such updates
     And stdout does not contain "security_B"
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "update-minimal" for command "microdnf"
+@dnf5
 @bz1918475
 Scenario: Security update
    When I execute dnf with args "upgrade-minimal --security"
@@ -45,8 +44,7 @@ Scenario: Security update
     And Transaction is empty
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "update-minimal" for command "microdnf"
+@dnf5
 @bz1918475
 Scenario: Security upgrade-minimal when exact version is not available
    When I execute dnf with args "upgrade-minimal --security -x security_A-0:1.0-3.x86_64"
@@ -56,8 +54,7 @@ Scenario: Security upgrade-minimal when exact version is not available
         | upgrade       | security_A-0:1.0-4.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "update" for command "microdnf"
+@dnf5
 @bz1918475
 Scenario: Security update with priority setting
   Given I use repository "dnf-ci-security-priority" with configuration
@@ -70,8 +67,7 @@ Scenario: Security update with priority setting
         | upgrade       | security_A-0:1.0-3.8.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "update-minimal" for command "microdnf"
+@dnf5
 @bz1918475
 Scenario Outline: Security upgrade-minimal with priority setting and args: <Args>
   Given I use repository "dnf-ci-security-priority" with configuration
@@ -89,8 +85,7 @@ Examples:
     | security_A |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "update" for command "microdnf"
+@dnf5
 Scenario Outline: Security <command>
    When I execute dnf with args "<command> --security"
    Then the exit code is 0
@@ -119,9 +114,7 @@ Examples:
     | update-minimal    | security_A-0:1.0-3.x86_64 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "--security" for command "upgrade"
-# depends on backporting of https://github.com/rpm-software-management/dnf/commit/6c45861ad7f5e6a6d586025a05c39b4b7a180aa0
+@dnf5
 Scenario Outline: Security <command> with bzs explicitly mentioned
    When I execute dnf with args "<command> --security --bz 123 --bzs=234,345"
    Then the exit code is 0

--- a/dnf-behave-tests/dnf/security-security.feature
+++ b/dnf-behave-tests/dnf/security-security.feature
@@ -35,12 +35,12 @@ Scenario: Security check-update when there are such updates
 # TODO(nsella) Unknown argument "update-minimal" for command "microdnf"
 @bz1918475
 Scenario: Security update
-   When I execute dnf with args "update-minimal --security"
+   When I execute dnf with args "upgrade-minimal --security"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                   |
         | upgrade       | security_A-0:1.0-3.x86_64 |
-  When I execute dnf with args "update --security"
+  When I execute dnf with args "upgrade --security"
   Then the exit code is 0
     And Transaction is empty
 
@@ -48,8 +48,8 @@ Scenario: Security update
 # @dnf5
 # TODO(nsella) Unknown argument "update-minimal" for command "microdnf"
 @bz1918475
-Scenario: Security update-minimal when exact version is not available
-   When I execute dnf with args "update-minimal --security -x security_A-0:1.0-3.x86_64"
+Scenario: Security upgrade-minimal when exact version is not available
+   When I execute dnf with args "upgrade-minimal --security -x security_A-0:1.0-3.x86_64"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                   |
@@ -63,7 +63,7 @@ Scenario: Security update with priority setting
   Given I use repository "dnf-ci-security-priority" with configuration
       | key           | value   |
       | priority      | 1       |
-   When I execute dnf with args "update --security "
+   When I execute dnf with args "upgrade --security "
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                     |
@@ -73,15 +73,21 @@ Scenario: Security update with priority setting
 # @dnf5
 # TODO(nsella) Unknown argument "update-minimal" for command "microdnf"
 @bz1918475
-Scenario: Security update-minimal with priority setting
+Scenario Outline: Security upgrade-minimal with priority setting and args: <Args>
   Given I use repository "dnf-ci-security-priority" with configuration
       | key           | value   |
       | priority      | 1       |
-   When I execute dnf with args "update-minimal --security "
+   When I execute dnf with args "upgrade-minimal <Args> --security "
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                     |
         | upgrade       | security_A-0:1.0-3.1.x86_64 |
+
+Examples:
+    | Args       |
+    |            |
+    | security_A |
+
 
 # @dnf5
 # TODO(nsella) Unknown argument "update" for command "microdnf"
@@ -93,11 +99,24 @@ Scenario Outline: Security <command>
         | upgrade       | <package>                 |
 
 Examples:
+    | command                    | package                   |
+    | upgrade                    | security_A-0:1.0-4.x86_64 |
+    | upgrade-minimal            | security_A-0:1.0-3.x86_64 |
+    | upgrade-minimal security_A | security_A-0:1.0-3.x86_64 |
+
+
+@not.with_dnf=5
+Scenario Outline: Security <command> (dnf4 syntax compat)
+   When I execute dnf with args "<command> --security"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                   |
+        | upgrade       | <package>                 |
+
+Examples:
     | command           | package                   |
     | update            | security_A-0:1.0-4.x86_64 |
-    | upgrade           | security_A-0:1.0-4.x86_64 |
     | update-minimal    | security_A-0:1.0-3.x86_64 |
-    | upgrade-minimal   | security_A-0:1.0-3.x86_64 |
 
 
 # @dnf5
@@ -112,5 +131,5 @@ Scenario Outline: Security <command> with bzs explicitly mentioned
 
 Examples:
     | command           | package                   |
-    | update            | security_A-0:1.0-4.x86_64 |
-    | update-minimal    | security_A-0:1.0-4.x86_64 |
+    | upgrade           | security_A-0:1.0-4.x86_64 |
+    | upgrade-minimal   | security_A-0:1.0-4.x86_64 |

--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: --security upgrades
 
 

--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -111,8 +111,17 @@ def when_I_execute_dnf_with_args(context, args):
     run_in_context(context, cmd, can_fail=True)
 
 
+@behave.step("I execute {dnf_version:dnf_version} with args \"{args}\"")
+def when_I_execute_dnf_variant_with_args(context, dnf_version, args):
+    dnf5_mode = hasattr(context, "dnf5_mode") and context.dnf5_mode
+    if dnf_version == "dnf5" and dnf5_mode:
+        when_I_execute_dnf_with_args(context, args)
+    if dnf_version == "dnf4" and not dnf5_mode:
+        when_I_execute_dnf_with_args(context, args)
+
+
 @behave.step("I execute dnf with args \"{args}\" as an unprivileged user")
-def when_I_execute_dnf_with_args(context, args):
+def when_I_execute_dnf_with_args_unprivileged(context, args):
     """
     Creates an unpriviged user if it doesn't exist (therefore the test is
     destructive!). Runs the dnf command under this user.

--- a/dnf-behave-tests/dnf/updateinfo.feature
+++ b/dnf-behave-tests/dnf/updateinfo.feature
@@ -21,41 +21,100 @@ Scenario: Listing available updates
   Given I use repository "dnf-ci-fedora-updates"
    Then I execute dnf with args "updateinfo list"
     And the exit code is 0
-    And stdout is
+    And dnf4 stdout is
     """
     <REPOSYNC>
     FEDORA-2999:002-02     enhancement flac-1.3.3-8.fc29.x86_64
     FEDORA-2018-318f184000 bugfix      glibc-2.28-26.fc29.x86_64
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type        Severity                   Package              Issued
+    FEDORA-2018-318f184000 bugfix      none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+    FEDORA-2999:002-02     enhancement Moderate  flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
     """
 
 
 # @dnf5
 # TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
 Scenario Outline: updateinfo <summary alias> (when there's nothing to report)
+Scenario: updateinfo summary (when there's nothing to report)
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
    When I execute dnf with args "updateinfo summary"
    Then the exit code is 0
-    And stdout is
+    And dnf4 stdout is
+    """
+    <REPOSYNC>
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Available advisory information summary:
+    Security    : 0
+      Critical  : 0
+      Important : 0
+      Moderate  : 0
+      Low       : 0
+      Other     : 0
+    Bugfix      : 0
+    Enhancement : 0
+    Other       : 0
+    """
+
+
+# @dnf5
+# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@not.with_dnf=5
+Scenario: updateinfo --summary when there's nothing to report (dnf4 compat)
+   When I execute dnf with args "install glibc flac"
+   Then the exit code is 0
+   When I execute dnf with args "updateinfo --summary"
+   Then the exit code is 0
+    And dnf4 stdout is
     """
     <REPOSYNC>
     """
 
-Examples: 
-        | summary alias |
-        | summary       |
-        | --summary     |
- 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
-Scenario Outline: updateinfo <summary alias> available (when there is an available update)
+Scenario: updateinfo summary --available (when there is an available update)
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo <summary alias> available"
+   When I execute dnf with args "updateinfo summary --available"
    Then the exit code is 0
-    And stdout is
+    And dnf4 stdout is
+    """
+    <REPOSYNC>
+    Updates Information Summary: available
+        1 Bugfix notice(s)
+        1 Enhancement notice(s)
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Available advisory information summary:
+    Security    : 0
+      Critical  : 0
+      Important : 0
+      Moderate  : 0
+      Low       : 0
+      Other     : 0
+    Bugfix      : 1
+    Enhancement : 1
+    Other       : 0
+    """
+
+
+@not.with_dnf=5
+Scenario: updateinfo --summary available when there is an available update (dnf4 compat)
+   When I execute dnf with args "install glibc flac"
+   Then the exit code is 0
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "updateinfo --summary available"
+   Then the exit code is 0
+    And dnf4 stdout is
     """
     <REPOSYNC>
     Updates Information Summary: available
@@ -63,21 +122,97 @@ Scenario Outline: updateinfo <summary alias> available (when there is an availab
         1 Enhancement notice(s)
     """
 
-Examples: 
-        | summary alias |
-        | summary       |
-        | --summary     |
-
-
 # @dnf5
 # TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
-Scenario Outline: updateinfo info
+Scenario: updateinfo info
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo <info alias> available"
+   When I execute dnf with args "updateinfo info --available"
    Then the exit code is 0
-    And stdout matches line by line
+    And dnf4 stdout matches line by line
+    """
+    <REPOSYNC>
+    ===============================================================================
+      flac enhacements
+    ===============================================================================
+      Update ID: FEDORA-2999:002-02
+           Type: enhancement
+        Updated: 2019-01-1\d \d\d:00:00
+    Description: Enhance some stuff
+       Severity: Moderate
+
+    ===============================================================================
+      glibc bug fix
+    ===============================================================================
+      Update ID: FEDORA-2018-318f184000
+           Type: bugfix
+        Updated: 2019-01-1\d \d\d:00:00
+           Bugs: 222 - 222
+           CVEs: 2999
+               : CVE-2999
+    Description: Fix some stuff
+       Severity: none
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name        : FEDORA-2018-318f184000
+    Title       : glibc bug fix
+    Severity    : none
+    Type        : bugfix
+    Status      : final
+    Vendor      : secresponseteam@foo.bar
+    Issued      : 2019-01-17 00:00:00
+    Description : Fix some stuff
+    Message     : 
+    Rights      : 
+    Reference   : 
+      Title     : 222
+      Id        : 222
+      Type      : bugzilla
+      Url       : https://foobar/foobarupdate_1
+    Reference   : 
+      Title     : CVE-2999
+      Id        : 2999
+      Type      : cve
+      Url       : https://foobar/foobarupdate_1
+    Reference   : 
+      Title     : CVE-2999
+      Id        : CVE-2999
+      Type      : cve
+      Url       : https://foobar/foobarupdate_1
+    Collection  : 
+      Pacakges  : glibc-2.28-26.fc29.x86_64
+
+    Name        : FEDORA-2999:002-02
+    Title       : flac enhacements
+    Severity    : Moderate
+    Type        : enhancement
+    Status      : final
+    Vendor      : secresponseteam@foo.bar
+    Issued      : 2019-01-17 00:00:00
+    Description : Enhance some stuff
+    Message     : 
+    Rights      : 
+    Reference   : 
+      Title     : update_1
+      Id        : 1
+      Type      : self
+      Url       : https://foobar/foobarupdate_1
+    Collection  : 
+      Pacakges  : flac-1.3.3-8.fc29.x86_64
+    """
+
+
+@not.with_dnf=5
+Scenario: updateinfo --info (dnf4 compat)
+   When I execute dnf with args "install glibc flac"
+   Then the exit code is 0
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "updateinfo --info --available"
+   Then the exit code is 0
+    And dnf4 stdout matches line by line
     """
     <REPOSYNC>
     ===============================================================================
@@ -102,15 +237,9 @@ Scenario Outline: updateinfo info
        Severity: none
     """
 
-Examples: 
-        | info alias |
-        | info       |
-        | --info     |
-         
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
-Scenario: updateinfo info security (when there's nothing to report)
+@not.with_dnf=5
+Scenario: updateinfo info security (when there's nothing to report) (dnf4 compat)
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
@@ -124,24 +253,52 @@ Scenario: updateinfo info security (when there's nothing to report)
 
 # @dnf5
 # TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
-Scenario Outline: updateinfo <list alias>
+Scenario: updateinfo info security (when there's nothing to report)
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo <list alias>"
+   When I execute dnf with args "updateinfo info --security"
    Then the exit code is 0
-    And stdout is
+   And stdout is
+   """
+   <REPOSYNC>
+   """
+
+
+Scenario: updateinfo list
+   When I execute dnf with args "install glibc flac"
+   Then the exit code is 0
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "updateinfo list"
+   Then the exit code is 0
+    And dnf4 stdout is
     """
     <REPOSYNC>
     FEDORA-2999:002-02     enhancement flac-1.3.3-8.fc29.x86_64
     FEDORA-2018-318f184000 bugfix      glibc-2.28-26.fc29.x86_64
     """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type        Severity                   Package              Issued
+    FEDORA-2018-318f184000 bugfix      none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+    FEDORA-2999:002-02     enhancement Moderate  flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
+    """
 
-Examples:
-        | list alias |
-        | list       |
-        | --list     |
 
+@not.with_dnf=5
+Scenario: updateinfo --list (dnf4 compat)
+   When I execute dnf with args "install glibc flac"
+   Then the exit code is 0
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "updateinfo --list"
+   Then the exit code is 0
+    And dnf4 stdout is
+    """
+    <REPOSYNC>
+    FEDORA-2999:002-02     enhancement flac-1.3.3-8.fc29.x86_64
+    FEDORA-2018-318f184000 bugfix      glibc-2.28-26.fc29.x86_64
+    """
 
 # @dnf5
 # TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
@@ -150,14 +307,19 @@ Scenario: updateinfo list all security
    When I execute dnf with args "install glibc flac CQRlib"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo list all security"
+   When I execute dnf with args "updateinfo list --all --security"
    Then the exit code is 0
-    And stdout is
+    And dnf4 stdout is
     """
     <REPOSYNC>
     i FEDORA-2018-318f184113 Moderate/Sec. CQRlib-1.1.2-16.fc29.x86_64
     """
-                 
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type     Severity                     Package              Issued
+    FEDORA-2018-318f184113 security Moderate CQRlib-1.1.2-16.fc29.x86_64 2019-01-20 00:00:00
+    """
 
 # @dnf5
 # TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
@@ -165,16 +327,23 @@ Scenario: updateinfo list updates
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
-   Then I execute dnf with args "update glibc flac"
+   Then I execute dnf with args "upgrade glibc flac"
     And the exit code is 0
   Given I use repository "dnf-ci-fedora-updates-testing"
-   When I execute dnf with args "updateinfo list updates"
+   When I execute dnf with args "updateinfo list --updates"
    Then the exit code is 0
-    And stdout is
+    And dnf4 stdout is
     """
     <REPOSYNC>
     FEDORA-2999:002-02     enhancement flac-1.3.3-8.fc29.x86_64
     FEDORA-2018-318f184112 enhancement flac-1.4.0-1.fc29.x86_64
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type        Severity                  Package              Issued
+    FEDORA-2018-318f184112 enhancement Moderate flac-1.4.0-1.fc29.x86_64 2019-01-19 00:00:00
+    FEDORA-2999:002-02     enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
     """
 
 
@@ -184,15 +353,21 @@ Scenario: updateinfo list installed
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
-   Then I execute dnf with args "update glibc flac"
+   Then I execute dnf with args "upgrade glibc flac"
     And the exit code is 0
   Given I use repository "dnf-ci-fedora-updates-testing"
-   When I execute dnf with args "updateinfo list installed"
+   When I execute dnf with args "updateinfo list --installed"
    Then the exit code is 0
-    And stdout is
+    And dnf4 stdout is
     """
     <REPOSYNC>
     FEDORA-2018-318f184000 bugfix glibc-2.28-26.fc29.x86_64
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type   Severity                   Package              Issued
+    FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
     """
 
 
@@ -203,13 +378,20 @@ Scenario: updateinfo list available enhancement
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
   Given I use repository "dnf-ci-fedora-updates-testing"
-   When I execute dnf with args "updateinfo list available enhancement"
+   When I execute dnf with args "updateinfo list --available --enhancement"
    Then the exit code is 0
-    And stdout is
+    And dnf4 stdout is
     """
     <REPOSYNC>
     FEDORA-2999:002-02     enhancement flac-1.3.3-8.fc29.x86_64
     FEDORA-2018-318f184112 enhancement flac-1.4.0-1.fc29.x86_64
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type        Severity                  Package              Issued
+    FEDORA-2018-318f184112 enhancement Moderate flac-1.4.0-1.fc29.x86_64 2019-01-19 00:00:00
+    FEDORA-2999:002-02     enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
     """
 
 
@@ -219,12 +401,18 @@ Scenario: updateinfo list all bugfix
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo list all bugfix"
+   When I execute dnf with args "updateinfo list --all --bugfix"
    Then the exit code is 0
-    And stdout is
+    And dnf4 stdout is
     """
     <REPOSYNC>
       FEDORA-2018-318f184000 bugfix glibc-2.28-26.fc29.x86_64
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type   Severity                   Package              Issued
+    FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
     """
 
 
@@ -237,7 +425,36 @@ Scenario Outline: updateinfo list updates plus <option>
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "<option> <value> updateinfo list updates"
+   When I execute dnf with args "updateinfo list --updates <option> <value>"
+   Then the exit code is 0
+    And dnf4 stdout is
+    """
+    <REPOSYNC>
+    FEDORA-2018-318f184000 bugfix glibc-2.28-26.fc29.x86_64
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type   Severity                   Package              Issued
+    FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+    """
+
+Examples:
+        | option | value                  |
+        | --bz   | 222                    |
+        | --cve  | 2999                   |
+        | --cve  | CVE-2999               |
+        |        | FEDORA-2018-318f184000 |
+
+
+# @dnf5
+# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@not.with_dnf=5
+Scenario: updateinfo list updates plus --advisory (dnf4 compat)
+   When I execute dnf with args "install glibc flac"
+   Then the exit code is 0
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "--advisory FEDORA-2018-318f184000 updateinfo list updates"
    Then the exit code is 0
     And stdout is
     """
@@ -245,23 +462,13 @@ Scenario Outline: updateinfo list updates plus <option>
     FEDORA-2018-318f184000 bugfix glibc-2.28-26.fc29.x86_64
     """
 
-Examples:
-        | option      | value                  |
-        | --bz        | 222                    |
-        | --cve       | 2999                   |
-        | --cve       | CVE-2999               |
-        | --advisory  | FEDORA-2018-318f184000 |
-
-
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
 Scenario: updateinfo info <advisory>
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo info FEDORA-2018-318f184000"
    Then the exit code is 0
-    And stdout matches line by line
+    And dnf4 stdout matches line by line
     """
     <REPOSYNC>
     ===============================================================================
@@ -276,7 +483,37 @@ Scenario: updateinfo info <advisory>
     Description: Fix some stuff
        Severity: none
     """
-        
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name        : FEDORA-2018-318f184000
+    Title       : glibc bug fix
+    Severity    : none
+    Type        : bugfix
+    Status      : final
+    Vendor      : secresponseteam@foo.bar
+    Issued      : 2019-01-17 00:00:00
+    Description : Fix some stuff
+    Message     : 
+    Rights      : 
+    Reference   : 
+      Title     : 222
+      Id        : 222
+      Type      : bugzilla
+      Url       : https://foobar/foobarupdate_1
+    Reference   : 
+      Title     : CVE-2999
+      Id        : 2999
+      Type      : cve
+      Url       : https://foobar/foobarupdate_1
+    Reference   : 
+      Title     : CVE-2999
+      Id        : CVE-2999
+      Type      : cve
+      Url       : https://foobar/foobarupdate_1
+    Collection  : 
+      Pacakges  : glibc-2.28-26.fc29.x86_64
+    """
 
 # @dnf5
 # TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
@@ -286,7 +523,7 @@ Scenario: updateinfo info <advisory-with-respin-suffix>
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo info FEDORA-2999:002-02"
    Then the exit code is 0
-    And stdout matches line by line
+    And dnf4 stdout matches line by line
     """
     <REPOSYNC>
     ===============================================================================
@@ -298,15 +535,34 @@ Scenario: updateinfo info <advisory-with-respin-suffix>
     Description: Enhance some stuff
        Severity: Moderate
     """
-   Then stdout contains "Update\s+ID:\s+FEDORA-2999:002-02"
-    And stdout contains "Type:\s+enhancement"
-    And stdout does not contain "glibc"
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name        : FEDORA-2999:002-02
+    Title       : flac enhacements
+    Severity    : Moderate
+    Type        : enhancement
+    Status      : final
+    Vendor      : secresponseteam@foo.bar
+    Issued      : 2019-01-17 00:00:00
+    Description : Enhance some stuff
+    Message     : 
+    Rights      : 
+    Reference   : 
+      Title     : update_1
+      Id        : 1
+      Type      : self
+      Url       : https://foobar/foobarupdate_1
+    Collection  : 
+      Pacakges  : flac-1.3.3-8.fc29.x86_64
+    """
 
 
 # @dnf5
 # TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@not.with_dnf=5
 @bz1750528
-Scenario Outline: updateinfo lists advisories referencing CVE
+Scenario Outline: updateinfo lists advisories referencing CVE (dnf4 compat)
   Given I successfully execute dnf with args "install glibc flac"
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo <options>"
@@ -329,7 +585,8 @@ Examples:
 
 # @dnf5
 # TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
-Scenario Outline: updateinfo lists advisories referencing bugzilla
+@not.with_dnf=5
+Scenario Outline: updateinfo lists advisories referencing bugzilla (dnf4 compat)
   Given I successfully execute dnf with args "install glibc flac"
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "updateinfo <options>"
@@ -359,20 +616,28 @@ Scenario: updateinfo show <advisory> of the running kernel after a kernel update
         | install-dep   | kernel-core-0:4.18.16-300.fc29.x86_64    |
         | install-dep   | kernel-modules-0:4.18.16-300.fc29.x86_64 |
   Given I use repository "dnf-ci-fedora-updates"
-    And I execute dnf with args "updateinfo list kernel"
+    And I execute dnf4 with args "updateinfo list kernel"
+    And I execute dnf5 with args "updateinfo list --contains-pkgs=kernel"
    Then the exit code is 0
-    And stdout is
+    And dnf4 stdout is
     """
     <REPOSYNC>
     FEDORA-2019-348e185000 bugfix kernel-4.19.15-300.fc29.x86_64
     """
-   When I execute dnf with args "update kernel"
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type   Severity                        Package              Issued
+    FEDORA-2019-348e185000 bugfix Moderate kernel-4.19.15-300.fc29.x86_64 2019-01-17 00:00:00
+    """
+   When I execute dnf with args "upgrade kernel"
    Then Transaction is following
         | Action        | Package                                  |
         | install       | kernel-0:4.19.15-300.fc29.x86_64         |
         | install-dep   | kernel-core-0:4.19.15-300.fc29.x86_64    |
         | install-dep   | kernel-modules-0:4.19.15-300.fc29.x86_64 |
-   When I execute dnf with args "updateinfo list kernel"
+   When I execute dnf4 with args "updateinfo list kernel"
+   When I execute dnf5 with args "updateinfo list --contains-pkgs=kernel"
    Then the exit code is 0
     And stdout is
     """
@@ -380,10 +645,7 @@ Scenario: updateinfo show <advisory> of the running kernel after a kernel update
     """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "list-sec" for command "microdnf"
-# TODO(nsella) Unknown argument "list-security" for command "microdnf"
-# TODO(nsella) Unknown argument "list-updateinfo" for command "microdnf"
+@not.with_dnf=5
 Scenario Outline: updateinfo lists advisories using direct commands (yum compat)
   Given I successfully execute dnf with args "install glibc flac"
     And I use repository "dnf-ci-fedora-updates"
@@ -403,10 +665,7 @@ Examples:
     | list-updateinfo |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "list-sec" for command "microdnf"
-# TODO(nsella) Unknown argument "list-security" for command "microdnf"
-# TODO(nsella) Unknown argument "list-updateinfo" for command "microdnf"
+@not.with_dnf=5
 Scenario Outline: updateinfo shows info for advisories using direct commands (yum compat)
   Given I successfully execute dnf with args "install glibc flac"
     And I use repository "dnf-ci-fedora-updates"
@@ -444,8 +703,7 @@ Examples:
     | info-updateinfo |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "summary-updateinfo" for command "microdnf"
+@not.with_dnf=5
 Scenario: updateinfo shows summary for advisories using direct commands (yum compat)
   Given I successfully execute dnf with args "install glibc flac"
     And I use repository "dnf-ci-fedora-updates"
@@ -460,8 +718,7 @@ Scenario: updateinfo shows summary for advisories using direct commands (yum com
     """
 
 
-# @dnf5
-# TODO(nsella) different stdout
+@not.with_dnf=5
 @bz1801092
 Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode (DNF version)
   Given I set dnf command to "dnf"
@@ -485,8 +742,7 @@ Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode
     """
 
 
-# @dnf5
-# TODO(nsella) different stdout
+@not.with_dnf=5
 @bz1801092
 Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode (YUM version)
   Given I set dnf command to "yum"

--- a/dnf-behave-tests/dnf/updateinfo.feature
+++ b/dnf-behave-tests/dnf/updateinfo.feature
@@ -4,8 +4,8 @@ Feature: Listing available updates using the dnf updateinfo command
 Background:
   Given I use repository "dnf-ci-fedora"
 
-# @dnf5
-# TODO(nsella) different stderr
+
+@dnf5
 Scenario: Listing available updates
    When I execute dnf with args "install glibc flac"
    Then Transaction is following
@@ -36,9 +36,7 @@ Scenario: Listing available updates
     """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
-Scenario Outline: updateinfo <summary alias> (when there's nothing to report)
+@dnf5
 Scenario: updateinfo summary (when there's nothing to report)
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -64,8 +62,6 @@ Scenario: updateinfo summary (when there's nothing to report)
     """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
 @not.with_dnf=5
 Scenario: updateinfo --summary when there's nothing to report (dnf4 compat)
    When I execute dnf with args "install glibc flac"
@@ -78,6 +74,7 @@ Scenario: updateinfo --summary when there's nothing to report (dnf4 compat)
     """
 
 
+@dnf5
 Scenario: updateinfo summary --available (when there is an available update)
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -122,8 +119,8 @@ Scenario: updateinfo --summary available when there is an available update (dnf4
         1 Enhancement notice(s)
     """
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+
+@dnf5
 Scenario: updateinfo info
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -251,8 +248,7 @@ Scenario: updateinfo info security (when there's nothing to report) (dnf4 compat
    """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@dnf5
 Scenario: updateinfo info security (when there's nothing to report)
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -265,6 +261,7 @@ Scenario: updateinfo info security (when there's nothing to report)
    """
 
 
+@dnf5
 Scenario: updateinfo list
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -300,8 +297,8 @@ Scenario: updateinfo --list (dnf4 compat)
     FEDORA-2018-318f184000 bugfix      glibc-2.28-26.fc29.x86_64
     """
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+
+@dnf5
 Scenario: updateinfo list all security
   Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "install glibc flac CQRlib"
@@ -321,8 +318,8 @@ Scenario: updateinfo list all security
     FEDORA-2018-318f184113 security Moderate CQRlib-1.1.2-16.fc29.x86_64 2019-01-20 00:00:00
     """
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+
+@dnf5
 Scenario: updateinfo list updates
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -347,8 +344,7 @@ Scenario: updateinfo list updates
     """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "update" for command "microdnf"
+@dnf5
 Scenario: updateinfo list installed
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -371,8 +367,7 @@ Scenario: updateinfo list installed
     """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@dnf5
 Scenario: updateinfo list available enhancement
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -395,8 +390,7 @@ Scenario: updateinfo list available enhancement
     """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@dnf5
 Scenario: updateinfo list all bugfix
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -416,11 +410,7 @@ Scenario: updateinfo list all bugfix
     """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
-# TODO(nsella) Unknown argument "--bz" for command "microdnf"
-# TODO(nsella) Unknown argument "--cve" for command "microdnf"
-# TODO(nsella) Unknown argument "--advisory" for command "microdnf"
+@dnf5
 Scenario Outline: updateinfo list updates plus <option>
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -447,8 +437,6 @@ Examples:
         |        | FEDORA-2018-318f184000 |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
 @not.with_dnf=5
 Scenario: updateinfo list updates plus --advisory (dnf4 compat)
    When I execute dnf with args "install glibc flac"
@@ -462,6 +450,8 @@ Scenario: updateinfo list updates plus --advisory (dnf4 compat)
     FEDORA-2018-318f184000 bugfix glibc-2.28-26.fc29.x86_64
     """
 
+
+@dnf5
 Scenario: updateinfo info <advisory>
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -515,8 +505,8 @@ Scenario: updateinfo info <advisory>
       Pacakges  : glibc-2.28-26.fc29.x86_64
     """
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+
+@dnf5
 Scenario: updateinfo info <advisory-with-respin-suffix>
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -558,8 +548,28 @@ Scenario: updateinfo info <advisory-with-respin-suffix>
     """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@dnf5
+@bz1750528
+Scenario: updateinfo lists advisories referencing CVE
+  Given I successfully execute dnf with args "install glibc flac"
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "updateinfo list --with-cve"
+   Then the exit code is 0
+    And dnf4 stdout is
+    """
+    <REPOSYNC>
+    2999     bugfix glibc-2.28-26.fc29.x86_64
+    CVE-2999 bugfix glibc-2.28-26.fc29.x86_64
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    CVE      Type   Severity                   Package              Issued
+    2999     bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+    CVE-2999 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+    """
+
+
 @not.with_dnf=5
 @bz1750528
 Scenario Outline: updateinfo lists advisories referencing CVE (dnf4 compat)
@@ -583,8 +593,25 @@ Examples:
     | --list cves         |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@dnf5
+Scenario: updateinfo lists advisories referencing bugzilla
+  Given I successfully execute dnf with args "install glibc flac"
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "updateinfo list --with-bz"
+   Then the exit code is 0
+    And dnf4 stdout is
+    """
+    <REPOSYNC>
+    222 bugfix glibc-2.28-26.fc29.x86_64
+    """
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Bugzilla Type   Severity                   Package              Issued
+    222      bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+    """
+
+
 @not.with_dnf=5
 Scenario Outline: updateinfo lists advisories referencing bugzilla (dnf4 compat)
   Given I successfully execute dnf with args "install glibc flac"
@@ -605,8 +632,7 @@ Examples:
     | list bzs            |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "updateinfo" for command "microdnf"
+@dnf5
 @bz1728004
 Scenario: updateinfo show <advisory> of the running kernel after a kernel update
    When I execute dnf with args "install kernel"
@@ -763,4 +789,26 @@ Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode
     <REPOSYNC>
     2999     bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
     CVE-2999 bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
+    """
+
+
+@dnf5
+@bz1801092
+Scenario: updateinfo lists advisories referencing CVE with dates
+  Given I successfully execute dnf with args "install glibc flac"
+    And I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "updateinfo list --with-cve"
+   Then the exit code is 0
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    CVE      Type   Severity                   Package              Issued
+    2999     bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+    CVE-2999 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+    """
+    And dnf4 stdout is
+    """
+    <REPOSYNC>
+    2999     bugfix glibc-2.28-26.fc29.x86_64
+    CVE-2999 bugfix glibc-2.28-26.fc29.x86_64
     """

--- a/dnf-behave-tests/dnf/updateinfo.feature
+++ b/dnf-behave-tests/dnf/updateinfo.feature
@@ -812,3 +812,137 @@ Scenario: updateinfo lists advisories referencing CVE with dates
     2999     bugfix glibc-2.28-26.fc29.x86_64
     CVE-2999 bugfix glibc-2.28-26.fc29.x86_64
     """
+
+
+@dnf5
+Scenario: updateinfo lists advisories with custom type and severity
+  Given I use repository "advisories-base"
+    And I execute dnf with args "install labirinto"
+    And I use repository "advisories-updates"
+   When I execute dnf with args "updateinfo list"
+   Then the exit code is 0
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name                   Type        Severity                               Package              Issued
+    FEDORA-2019-57b5902ed1 security    Critical        labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
+    FEDORA-2019-f4eb34cf4c security    Moderate        labirinto-1.56.2-1.fc30.x86_64 2019-05-12 01:21:43
+    FEDORA-2022-2222222222 custom_type custom_severity labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
+    FEDORA-2022-2222222223 security    custom_severity labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
+    FEDORA-2022-2222222224 custom_type Critical        labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
+    """
+
+
+@dnf5
+Scenario: updateinfo prints info for advisories with custom type and severity
+  Given I use repository "advisories-base"
+    And I execute dnf with args "install labirinto"
+    And I use repository "advisories-updates"
+   When I execute dnf with args "updateinfo info"
+   Then the exit code is 0
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Name        : FEDORA-2019-f4eb34cf4c
+    Title       : labirinto-1.56.2-1.fc30
+    Severity    : Moderate
+    Type        : security
+    Status      : stable
+    Vendor      : updates@fedoraproject.org
+    Issued      : 2019-05-12 01:21:43
+    Description : GNOME 3.32.2
+    Message     : 
+    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+    Reference   : 
+      Title     : [abrt] epiphany: ephy_suggestion_get_unescaped_title(): epiphany-search-provider killed by SIGABRT
+      Id        : 1696529
+      Type      : bugzilla
+      Url       : https://bugzilla.redhat.com/show_bug.cgi?id=1696529
+    Collection  : 
+      Pacakges  : labirinto-1.56.2-1.fc30.i686
+                : labirinto-1.56.2-1.fc30.x86_64
+                : labirinto-1.56.2-1.fc30.src
+
+    Name        : FEDORA-2019-57b5902ed1
+    Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
+    Severity    : Critical
+    Type        : security
+    Status      : stable
+    Vendor      : updates@fedoraproject.org
+    Issued      : 2019-09-15 01:34:29
+    Description : mozjs60 60.9.0, including various security, stability and regression fixes from Firefox 60.9.0 ESR. For details, see https://www.mozilla.org/en-US/firefox/60.9.0/releasenotes/
+    Message     : 
+    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+    Collection  : 
+      Pacakges  : labirinto-1.56.2-6.fc30.i686
+                : labirinto-1.56.2-6.fc30.src
+                : labirinto-1.56.2-6.fc30.x86_64
+
+    Name        : FEDORA-2022-2222222222
+    Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
+    Severity    : custom_severity
+    Type        : custom_type
+    Status      : stable
+    Vendor      : updates@fedoraproject.org
+    Issued      : 2019-09-15 01:34:29
+    Description : advisory with custom type and seveirity
+    Message     : 
+    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+    Collection  : 
+      Pacakges  : labirinto-1.56.2-6.fc30.i686
+                : labirinto-1.56.2-6.fc30.src
+                : labirinto-1.56.2-6.fc30.x86_64
+
+    Name        : FEDORA-2022-2222222223
+    Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
+    Severity    : custom_severity
+    Type        : security
+    Status      : stable
+    Vendor      : updates@fedoraproject.org
+    Issued      : 2019-09-15 01:34:29
+    Description : advisory with custom seveirity
+    Message     : 
+    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+    Collection  : 
+      Pacakges  : labirinto-1.56.2-6.fc30.i686
+                : labirinto-1.56.2-6.fc30.src
+                : labirinto-1.56.2-6.fc30.x86_64
+
+    Name        : FEDORA-2022-2222222224
+    Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
+    Severity    : Critical
+    Type        : custom_type
+    Status      : stable
+    Vendor      : updates@fedoraproject.org
+    Issued      : 2019-09-15 01:34:29
+    Description : advisory with custom type
+    Message     : 
+    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+    Collection  : 
+      Pacakges  : labirinto-1.56.2-6.fc30.i686
+                : labirinto-1.56.2-6.fc30.src
+                : labirinto-1.56.2-6.fc30.x86_64
+    """
+
+
+@dnf5
+Scenario: updateinfo prints summary of advisories with custom type and severity
+  Given I use repository "advisories-base"
+    And I execute dnf with args "install labirinto"
+    And I use repository "advisories-updates"
+   When I execute dnf with args "updateinfo summary"
+   Then the exit code is 0
+    And dnf5 stdout is
+    """
+    <REPOSYNC>
+    Available advisory information summary:
+    Security    : 3
+      Critical  : 1
+      Important : 0
+      Moderate  : 1
+      Low       : 0
+      Other     : 1
+    Bugfix      : 0
+    Enhancement : 0
+    Other       : 2
+    """

--- a/dnf-behave-tests/dnf/upgrade-advisories.feature
+++ b/dnf-behave-tests/dnf/upgrade-advisories.feature
@@ -13,14 +13,14 @@ Scenario: Upgrade packages with security issues
         | Action        | Package                                   |
         | install       | labirinto-0:1.56.1-1.fc30.x86_64          |
   Given I use repository "advisories-updates"
-   When I execute dnf with args "update --security"
+   When I execute dnf with args "upgrade --security"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |
         | upgrade       | labirinto-0:1.56.2-6.fc30.x86_64          |
    When I execute dnf with args "downgrade labirinto"
    Then the exit code is 0
-   When I execute dnf with args "update labirinto"
+   When I execute dnf with args "upgrade labirinto"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |

--- a/dnf-behave-tests/dnf/upgrade-advisories.feature
+++ b/dnf-behave-tests/dnf/upgrade-advisories.feature
@@ -1,5 +1,4 @@
-# @dnf5
-# TODO(nsella) Unknown argument "update" for command "microdnf"
+@dnf5
 Feature: Upgrade using security advisories
 
 

--- a/dnf-behave-tests/fixtures/specs/advisories-updates/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/advisories-updates/updateinfo.xml
@@ -55,4 +55,85 @@
             </collection>
         </pkglist>
     </update>
+
+    <update from="updates@fedoraproject.org" status="stable" type="custom_type" version="2.0">
+        <id>FEDORA-2022-2222222222</id>
+        <title>labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30</title>
+        <issued date="2019-09-15 01:34:29"/>
+        <updated date="2019-09-08 11:57:09"/>
+        <rights>Copyright (C) 2020 Red Hat, Inc. and others.</rights>
+        <release>Fedora 30</release>
+        <severity>custom_severity</severity>
+        <summary>labirinto-1.56.2-6.fc30 custom_type_severity update</summary>
+        <description>advisory with custom type and seveirity</description>
+        <references/>
+        <pkglist>
+            <collection short="F30">
+                <name>Fedora 30</name>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="i686" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/i386/g/labirinto-1.56.2-6.fc30.i686.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.i686.rpm</filename>
+                </package>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="src" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/SRPMS/g/labirinto-1.56.2-6.fc30.src.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.src.rpm</filename>
+                </package>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="x86_64" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/x86_64/g/labirinto-1.56.2-6.fc30.x86_64.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+
+    <update from="updates@fedoraproject.org" status="stable" type="security" version="2.0">
+        <id>FEDORA-2022-2222222223</id>
+        <title>labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30</title>
+        <issued date="2019-09-15 01:34:29"/>
+        <updated date="2019-09-08 11:57:09"/>
+        <rights>Copyright (C) 2020 Red Hat, Inc. and others.</rights>
+        <release>Fedora 30</release>
+        <severity>custom_severity</severity>
+        <summary>labirinto-1.56.2-6.fc30 custom_severity update</summary>
+        <description>advisory with custom seveirity</description>
+        <references/>
+        <pkglist>
+            <collection short="F30">
+                <name>Fedora 30</name>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="i686" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/i386/g/labirinto-1.56.2-6.fc30.i686.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.i686.rpm</filename>
+                </package>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="src" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/SRPMS/g/labirinto-1.56.2-6.fc30.src.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.src.rpm</filename>
+                </package>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="x86_64" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/x86_64/g/labirinto-1.56.2-6.fc30.x86_64.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+
+    <update from="updates@fedoraproject.org" status="stable" type="custom_type" version="2.0">
+        <id>FEDORA-2022-2222222224</id>
+        <title>labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30</title>
+        <issued date="2019-09-15 01:34:29"/>
+        <updated date="2019-09-08 11:57:09"/>
+        <rights>Copyright (C) 2020 Red Hat, Inc. and others.</rights>
+        <release>Fedora 30</release>
+        <severity>Critical</severity>
+        <summary>labirinto-1.56.2-6.fc30 custom_type update</summary>
+        <description>advisory with custom type</description>
+        <references/>
+        <pkglist>
+            <collection short="F30">
+                <name>Fedora 30</name>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="i686" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/i386/g/labirinto-1.56.2-6.fc30.i686.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.i686.rpm</filename>
+                </package>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="src" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/SRPMS/g/labirinto-1.56.2-6.fc30.src.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.src.rpm</filename>
+                </package>
+                <package name="labirinto" version="1.56.2" release="6.fc30" epoch="0" arch="x86_64" src="https://download.fedoraproject.org/pub/fedora/linux/updates/30/x86_64/g/labirinto-1.56.2-6.fc30.x86_64.rpm">
+                    <filename>labirinto-1.56.2-6.fc30.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
 </updates>

--- a/dnf-behave-tests/fixtures/specs/repoquery-security-filters/A-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-security-filters/A-1-1.spec
@@ -1,0 +1,16 @@
+Name:           A
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-security-filters/A-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-security-filters/A-2-2.spec
@@ -1,0 +1,16 @@
+Name:           A
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-security-filters/A-3-3.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-security-filters/A-3-3.spec
@@ -1,0 +1,16 @@
+Name:           A
+Epoch:          0
+Version:        3
+Release:        3
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-security-filters/B-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-security-filters/B-2-2.spec
@@ -1,0 +1,16 @@
+Name:           B
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-security-filters/C-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-security-filters/C-1-1.spec
@@ -1,0 +1,16 @@
+Name:           C
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-security-filters/C-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-security-filters/C-2-2.spec
@@ -1,0 +1,16 @@
+Name:           C
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/repoquery-security-filters/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/repoquery-security-filters/updateinfo.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing security filters during repoquery</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="A" version="2" release="2" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>A-2-2.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing security filters during repoquery, advisory for not present pkg to check if newer pkg are shown as a fix</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="B" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>B-1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing security filters during repoquery, advisory for not present pkg to check if newer pkg are shown as a fix</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="C" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>C-1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing security filters during repoquery, advisory for not present pkg to check if newer pkg are shown as a fix</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="C" version="2" release="2" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>C-2-2.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>


### PR DESCRIPTION
For: https://github.com/rpm-software-management/libdnf/pull/1534