### PR TITLE
Enable dnf5 failing scenarios with reason `different exit code`

### DIFF
--- a/dnf-behave-tests/dnf/encoding.feature
+++ b/dnf-behave-tests/dnf/encoding.feature
@@ -41,7 +41,7 @@ Scenario: non-UTF-8 characters in .repo filename
 
 
 # @dnf5
-# TODO(nsella) different exit code
+# TODO(nsella) different stdout
 Scenario: non-UTF-8 character in pkgspec
   Given I use repository "miscellaneous"
    When I execute dnf with args "install {context.invalid_utf8_char}ummy"

--- a/dnf-behave-tests/dnf/excludes-includes.feature
+++ b/dnf-behave-tests/dnf/excludes-includes.feature
@@ -22,7 +22,7 @@ Scenario: Install RPMs that are in includepkgs in repo conf
         | install       | flac-libs-0:1.3.2-8.fc29.x86_64  |
 
 
-# @dnf5
+@dnf5
 # TODO(nsella) different exit code
 Scenario: Fail to install RPMs when some RPM is NOT in includepkgs in main conf
   Given I use repository "dnf-ci-fedora"
@@ -61,7 +61,7 @@ Scenario: Install RPMs that are NOT in excludepkgs in repo conf
        | install       | flac-libs-0:1.3.2-8.fc29.x86_64  |
 
 
-# @dnf5
+@dnf5
 # TODO(nsella) different exit code
 Scenario: Fail to install RPMs when some RPM is in excludepkgs in main conf
   Given I use repository "dnf-ci-fedora"
@@ -99,7 +99,7 @@ Scenario: Install RPMs that are in includepkgs and NOT in excludepkgs in repo co
         | install       | flac-libs-0:1.3.2-8.fc29.x86_64  |
 
 
-# @dnf5
+@dnf5
 # TODO(nsella) different exit code
 Scenario: Fail to install RPMs when there is a non-existent RPM in includedpkgs in main conf
   Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/dnf/install-exclude.feature
+++ b/dnf-behave-tests/dnf/install-exclude.feature
@@ -1,8 +1,7 @@
 Feature: Install RPMs with --exclude
 
 
-# @dnf5
-# TODO(nsella) different exit code 0
+@dnf5
 Scenario: Install an RPM that is excluded
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem --exclude filesystem"
@@ -26,8 +25,7 @@ Scenario: Install an RPM that requires excluded RPM
     """
 
 
-# @dnf5
-# TODO(nsella) different exit code 0
+@dnf5
 Scenario: Install RPMs while excluding part of them
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup filesystem --exclude filesystem"

--- a/dnf-behave-tests/dnf/install-exclude.feature
+++ b/dnf-behave-tests/dnf/install-exclude.feature
@@ -10,7 +10,7 @@ Scenario: Install an RPM that is excluded
     And Transaction is empty
 
 # @dnf5
-# TODO(nsella) different exit code 0
+# TODO(nsella) different stderr
 @bz1756473
 Scenario: Install an RPM that requires excluded RPM
   Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/dnf/install-fails.feature
+++ b/dnf-behave-tests/dnf/install-fails.feature
@@ -1,7 +1,7 @@
-# @dnf5
-# TODO(nsella) different exit code 0
 Feature: Installing attemps fail
 
+# @dnf5
+# TODO(nsella) different stderr
 @bz1568965
 Scenario: Report all missing dependencies
   Given I use repository "dnf-ci-thirdparty"

--- a/dnf-behave-tests/dnf/install-fails.feature
+++ b/dnf-behave-tests/dnf/install-fails.feature
@@ -9,6 +9,8 @@ Scenario: Report all missing dependencies
     Then stderr contains "nothing provides abcde needed by SuperRipper-1.0-1.x86_64"
     Then stderr contains "nothing provides nodejs needed by anitras-dance-1.0-1.x86_64"
 
+# @dnf5
+# TODO(nsella) different exit code
 @bz1599774
 Scenario: Report error when installing empty file
    Given I execute "touch empty.rpm" in "{context.dnf.installroot}/"
@@ -20,6 +22,8 @@ Scenario: Report error when installing empty file
      Could not open: empty.rpm
      """
 
+# @dnf5
+# TODO(nsella) different exit code
 @bz1616321
 Scenario: Report error when installing text file
    Given I create file "invalid.rpm" with

--- a/dnf-behave-tests/dnf/install-fails.feature
+++ b/dnf-behave-tests/dnf/install-fails.feature
@@ -34,6 +34,8 @@ Scenario: Report error when installing text file
      Could not open: invalid.rpm
      """
 
+# @dnf5
+# TODO(nsella) different stdout
 @bz1599774
 Scenario: Report error when installing non-existing RPM file
     When I execute dnf with args "install no_such_file.rpm"

--- a/dnf-behave-tests/dnf/install-non-existent.feature
+++ b/dnf-behave-tests/dnf/install-non-existent.feature
@@ -2,7 +2,7 @@ Feature: Test for installation of non-existent rpm or package
 
 
 # @dnf5
-# TODO(nsella) different exit code 0
+# TODO(nsella) different stdout
 @bz1578369
 Scenario: Try to install a non-existent rpm
   Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/dnf/install-non-existent.feature
+++ b/dnf-behave-tests/dnf/install-non-existent.feature
@@ -13,7 +13,7 @@ Scenario: Try to install a non-existent rpm
 
 
 # @dnf5
-# TODO(nsella) different exit code 0
+# TODO(nsella) different stderr
 Scenario: Try to install a non-existent package
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install non-existent-package"
@@ -23,7 +23,7 @@ Scenario: Try to install a non-existent package
 
 
 # @dnf5
-# TODO(nsella) different exit code 0
+# TODO(nsella) different stderr
 @bz1717429
 Scenario: Install an existent and an non-existent package
   Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/dnf/installroot.feature
+++ b/dnf-behave-tests/dnf/installroot.feature
@@ -110,7 +110,7 @@ Scenario: Upgrade package in installroot
 
 
 # @dnf5
-# TODO(nsella) different exit code
+# TODO(nsella) different stderr
 @bz1658579
 Scenario: Installroot directory is listed when there are no repos
    When I execute dnf with args "install sugar"

--- a/dnf-behave-tests/dnf/protect-running-kernel.feature
+++ b/dnf-behave-tests/dnf/protect-running-kernel.feature
@@ -9,7 +9,7 @@ Background: Install fake kernel
 
 
 # @dnf5
-# TODO(nsella) different exit code
+# TODO(nsella) different stdout
 @bz1698145
 Scenario: Running kernel is protected
    When I execute dnf with args "remove dnf-ci-kernel"
@@ -33,7 +33,7 @@ Scenario: Running kernel is not protected with config protect_running_kernel=Fal
 
 
 # @dnf5
-# TODO(nsella) different exit code
+# TODO(nsella) different stdout
 @bz1698145
 Scenario: Running kernel is protected when in protected_packages even with config protect_running_kernel=False
    When I execute dnf with args "remove dnf-ci-kernel --setopt=protect_running_kernel=False --setopt=protected_packages=dnf-ci-kernel"
@@ -46,7 +46,7 @@ Scenario: Running kernel is protected when in protected_packages even with confi
 
 
 # @dnf5
-# TODO(nsella) different exit code
+# TODO(nsella) different stdout
 @bz1698145
 Scenario: Running kernel is protected against obsoleting
    When I execute dnf with args "install dnf-ci-obsolete"

--- a/dnf-behave-tests/dnf/protected-packages.feature
+++ b/dnf-behave-tests/dnf/protected-packages.feature
@@ -2,7 +2,7 @@ Feature: Protected packages
 
 
 # @dnf5
-# TODO(nsella) different exit code
+# TODO(nsella) different stderr
 @tier1
 Scenario: Package protected via setopt cannot be removed
   Given I use repository "dnf-ci-fedora"
@@ -19,7 +19,7 @@ Scenario: Package protected via setopt cannot be removed
 
 
 # @dnf5
-# TODO(nsella) different exit code
+# TODO(nsella) different stderr
 Scenario: Package with protected dependency via setopt cannot be removed
   Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "install filesystem"

--- a/dnf-behave-tests/dnf/provides-alternatives.feature
+++ b/dnf-behave-tests/dnf/provides-alternatives.feature
@@ -1,5 +1,5 @@
 # @dnf5
-# TODO(nsella) different exit code
+# TODO(nsella) different stdout
 Feature: Alternative packages are suggested when package is not available
 
 @bz1625586

--- a/dnf-behave-tests/dnf/reinstall.feature
+++ b/dnf-behave-tests/dnf/reinstall.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Reinstall
 
 
@@ -12,7 +13,6 @@ Background: Install CQRlib-devel and CQRlib
         | install-dep   | CQRlib-0:1.1.2-16.fc29.x86_64             |
 
 
-@dnf5
 Scenario: Reinstall an RPM from the same repository
    When I execute dnf with args "reinstall CQRlib"
    Then the exit code is 0
@@ -21,7 +21,6 @@ Scenario: Reinstall an RPM from the same repository
         | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |
 
 
-@dnf5
 Scenario: Reinstall an RPM from different repository
   Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "reinstall CQRlib"
@@ -31,8 +30,6 @@ Scenario: Reinstall an RPM from different repository
         | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |
 
 
-# @dnf5
-# TODO(nsella) different exit code 0
 Scenario: Reinstall an RPM that is not available
   Given I drop repository "dnf-ci-fedora-updates"
    When I execute dnf with args "reinstall CQRlib"

--- a/dnf-behave-tests/dnf/remove-exclude.feature
+++ b/dnf-behave-tests/dnf/remove-exclude.feature
@@ -1,7 +1,7 @@
+@dnf5
 Feature: Remove RPMs with --exclude
 
 
-@dnf5
 Scenario: Remove RPMs while excluding another RPM
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install basesystem"
@@ -19,8 +19,6 @@ Scenario: Remove RPMs while excluding another RPM
         | remove        | basesystem-0:11-6.fc29.noarch         |
 
 
-# @dnf5
-# TODO(nsella) different exit code
 Scenario: Remove RPM which is required by excluded RPM
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem"

--- a/dnf-behave-tests/dnf/repo-priorities.feature
+++ b/dnf-behave-tests/dnf/repo-priorities.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Repositories with priorities
 
 
@@ -13,7 +14,6 @@ Background: Use repositories with priorities 1, 2, and 3
         | priority | 3     |
 
 
-@dnf5
 Scenario: Install an RPM from the highest-priority repository and ensure that upgrade will not install update from the lower priority repository
    When I execute dnf with args "install flac"
    Then the exit code is 0
@@ -25,7 +25,6 @@ Scenario: Install an RPM from the highest-priority repository and ensure that up
     And Transaction is empty
 
 
-@dnf5
 Scenario: Install an RPM of specific version from lower-priority repository
    When I execute dnf with args "install flac-1.3.3-3.fc29"
    Then the exit code is 0
@@ -34,7 +33,6 @@ Scenario: Install an RPM of specific version from lower-priority repository
         | install       | flac-0:1.3.3-3.fc29.x86_64                |
 
 
-@dnf5
 Scenario: Install RPMs from different highest-priority repositories
    When I execute dnf with args "install flac *system"
    Then the exit code is 0
@@ -46,7 +44,6 @@ Scenario: Install RPMs from different highest-priority repositories
         | install-dep   | setup-0:2.12.1-1.fc29.noarch              |
 
 
-@dnf5
 Scenario: Install an RPM and its dependencies from the proper highest-priority repositories
    When I execute dnf with args "install glibc"
    Then the exit code is 0
@@ -60,7 +57,6 @@ Scenario: Install an RPM and its dependencies from the proper highest-priority r
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
-@dnf5
 Scenario: Upgrade an RPM from the highest-priority repository
    When I execute dnf with args "install flac-1.3.3-1.fc29"
    Then the exit code is 0
@@ -74,8 +70,6 @@ Scenario: Upgrade an RPM from the highest-priority repository
         | upgrade       | flac-0:1.3.3-2.fc29.x86_64                |
 
 
-# @dnf5
-# TODO(nsella) different exit code
 @bz1733582
 Scenario: Do not upgrade installonly package from lower-priority repository
    When I execute dnf with args "install kernel-core"
@@ -83,12 +77,11 @@ Scenario: Do not upgrade installonly package from lower-priority repository
     And Transaction is following
         | Action        | Package                               |
         | install       | kernel-core-0:4.18.16-300.fc29.x86_64 |
-   When I execute dnf with args "update"
+   When I execute dnf with args "upgrade"
    Then the exit code is 0
     And Transaction is empty
 
 
-@dnf5
 Scenario: Upgrade an RPM to specific version from lower-priority repository
    When I execute dnf with args "install flac"
    Then the exit code is 0
@@ -102,7 +95,6 @@ Scenario: Upgrade an RPM to specific version from lower-priority repository
         | upgrade       | flac-0:1.3.3-3.fc29.x86_64                |
 
 
-@dnf5
 Scenario: Upgrade RPMs from different highest-priority repositories
    When I execute dnf with args "install setup glibc"
    Then the exit code is 0
@@ -125,7 +117,6 @@ Scenario: Upgrade RPMs from different highest-priority repositories
         | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64  |
 
 
-@dnf5
 Scenario: Downgrade an RPM from the highest-priority repository
    When I execute dnf with args "install glibc-2.28-27.fc29"
    Then the exit code is 0
@@ -146,7 +137,6 @@ Scenario: Downgrade an RPM from the highest-priority repository
         | downgrade     | glibc-all-langpacks-0:2.28-9.fc29.x86_64   |
 
 
-@dnf5
 Scenario: Downgrade an RPM to specific version from lower-priority repository
    When I execute dnf with args "install flac"
    Then the exit code is 0
@@ -160,7 +150,6 @@ Scenario: Downgrade an RPM to specific version from lower-priority repository
         | downgrade     | flac-0:1.3.3-1.fc29.x86_64                |
 
 
-@dnf5
 Scenario: Downgrade RPMs from different highest-priority repositories
    When I execute dnf with args "install setup-2.12.1-2.fc29 flac-1.3.3-3.fc29"
    Then the exit code is 0


### PR DESCRIPTION
More scenarios can be enabled by setting the correct exit code in microdnf
- builddep
- distro-sync
- downgrade