### PR TITLE
CI: Lock host image to f35 due to bugged clang-format

### DIFF
--- a/.github/workflows/ci-host.yml
+++ b/.github/workflows/ci-host.yml
@@ -29,7 +29,11 @@ jobs:
           echo ${{secrets.GITHUB_TOKEN}} | docker login ghcr.io -u ${GHCR_USER} --password-stdin
 
           docker build -t ${IMAGE}:${DATE} -t ${IMAGE}:latest -<<EOF
-          FROM fedora:latest
+          # TODO(lukash) temporarily lock fedora to 35 due to bugged
+          # clang-format (clang-tools-extra-0:14.0.0-1.fc36):
+          # https://github.com/llvm/llvm-project/issues/55260
+          # change back to fedora:latest when fixed
+          FROM fedora:35
           RUN dnf -y update
           RUN dnf -y install dnf-plugins-core
           RUN dnf -y copr enable rpmsoftwaremanagement/rpm-gitoverlay


### PR DESCRIPTION
clang-format in clang-tools-extra-0:14.0.0-1.fc36 is bugged:
https://github.com/llvm/llvm-project/issues/55260

And there's no other version in f36, meaning we have to fall back to f35
for a working version of clang-format for libdnf 5 CI to work.