### PR TITLE
Test for upgrade --security with advisories with different arches

### DIFF
--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -1,0 +1,13 @@
+Feature: --security upgrades
+
+
+Scenario: --security upgrade with advisories with pkgs of different arches
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install json-c-1-1 bind-libs-lite-1-1"
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                     |
+      | upgrade       | bind-libs-lite-0:2-2.x86_64 |
+      | upgrade       | json-c-0:2-2.x86_64         |
+

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/bind-libs-lite-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/bind-libs-lite-1-1.spec
@@ -1,0 +1,16 @@
+Name:           bind-libs-lite
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/bind-libs-lite-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/bind-libs-lite-2-2.spec
@@ -1,0 +1,18 @@
+Name:           bind-libs-lite
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+Requires:       libjson-c.so.4()(64bit)
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/json-c-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/json-c-1-1.spec
@@ -1,0 +1,16 @@
+Name:           json-c
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/json-c-2-2.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/json-c-2-2.i686.spec
@@ -1,0 +1,18 @@
+Name:           json-c
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+Provides:       libjson-c.so.4()
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/json-c-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/json-c-2-2.spec
@@ -1,0 +1,18 @@
+Name:           json-c
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+Provides:       libjson-c.so.4()(64bit)
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-1</id>
+        <title>json-c security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisory</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="json-c" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>json-c-1-1.x86_64.rpm</filename>
+                </package>
+                <package name="json-c" version="1" release="1" epoch="0" arch="i686" src="https://the.url/the.package.rpm">
+                    <filename>json-c-1-1.i686.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-1</id>
+        <title>bind-libs-lite security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisory</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="bind-libs-lite" version="2" release="2" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>bind-libs-lite-2-2.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2088149

For: https://github.com/rpm-software-management/libdnf/pull/1526