### PR TITLE
Mark persistdir creation check as dnf4 only

### DIFF
--- a/dnf-behave-tests/dnf/persistdir.feature
+++ b/dnf-behave-tests/dnf/persistdir.feature
@@ -1,7 +1,7 @@
-@dnf5
 Feature: Track information in persistdir
 
 
+@use.with_dnf=4
 Scenario: Persistdir is created during transaction
   Given I use repository "dnf-ci-fedora"
    Then file "/var/lib/dnf" does not exist


### PR DESCRIPTION
Marking it explicitly with the @use.with_dnf=4 because it is known the
test won't work with dnf5.

(@m-blaha, @inknos) I've added the tag even though it's redundant, shall we do that for tests we know we don't want to run on dnf5?