### PR TITLE
Store `dnf5_mode` and `dnfdaemon_mode` directly in behave context

### DIFF
--- a/dnf-behave-tests/common/output.py
+++ b/dnf-behave-tests/common/output.py
@@ -80,7 +80,7 @@ def then_stdout_is(context):
     if found == [""]:
         found = []
 
-    dnf5_mode = hasattr(context, "dnf") and context.dnf.dnf5_mode
+    dnf5_mode = hasattr(context, "dnf") and context.dnf5_mode
     clean_expected, clean_found = handle_reposync(expected, found, dnf5_mode)
 
     if clean_expected == clean_found:
@@ -118,7 +118,7 @@ def then_dnf_exit_code_is(context, dnf_version):
     Check for the test's exit code only if running in the
     appropriate mode otherwise the step is skipped
     """
-    dnf5_mode = hasattr(context, "dnf") and context.dnf.dnf5_mode
+    dnf5_mode = hasattr(context, "dnf") and context.dnf5_mode
     if dnf_version == "dnf5" and dnf5_mode:
         then_the_exit_code_is(context)
     if dnf_version == "dnf4" and not dnf5_mode:
@@ -131,7 +131,7 @@ def then_dnf_stdout_is(context, dnf_version):
     Check for exact match of the test's stdout only if running in the
     appropriate mode otherwise the step is skipped.
     """
-    dnf5_mode = hasattr(context, "dnf") and context.dnf.dnf5_mode
+    dnf5_mode = hasattr(context, "dnf") and context.dnf5_mode
     if dnf_version == "dnf5" and dnf5_mode:
         then_stdout_is(context)
     if dnf_version == "dnf4" and not dnf5_mode:
@@ -144,7 +144,7 @@ def then_dnf_stderr_is(context, dnf_version):
     Check for exact match of the test's stderr only if running in the
     appropriate mode otherwise the step is skipped.
     """
-    dnf5_mode = hasattr(context, "dnf") and context.dnf.dnf5_mode
+    dnf5_mode = hasattr(context, "dnf") and context.dnf5_mode
     if dnf_version == "dnf5" and dnf5_mode:
         then_stderr_is(context)
     if dnf_version == "dnf4" and not dnf5_mode:
@@ -158,7 +158,7 @@ def then_dnf_stdout_matches_line_by_line(context, dnf_version):
     Supports the <REPOSYNC> in the same way as the step "stdout is"
     Works only if running in the appropriate mode otherwise the step is skipped.
     """
-    dnf5_mode = hasattr(context, "dnf") and context.dnf.dnf5_mode
+    dnf5_mode = hasattr(context, "dnf") and context.dnf5_mode
     if dnf_version == "dnf5" and dnf5_mode:
         then_stdout_matches_line_by_line(context)
     if dnf_version == "dnf4" and not dnf5_mode:
@@ -172,7 +172,7 @@ def then_dnf_stderr_matches_line_by_line(context, dnf_version):
     Supports the <REPOSYNC> in the same way as the step "stderr is"
     Works only if running in the appropriate mode otherwise the step is skipped.
     """
-    dnf5_mode = hasattr(context, "dnf") and context.dnf.dnf5_mode
+    dnf5_mode = hasattr(context, "dnf") and context.dnf5_mode
     if dnf_version == "dnf5" and dnf5_mode:
         then_stderr_matches_line_by_line(context)
     if dnf_version == "dnf4" and not dnf5_mode:
@@ -188,7 +188,7 @@ def then_stdout_matches_line_by_line(context):
     found = context.cmd_stdout.split('\n')
     expected = context.text.split('\n')
 
-    dnf5_mode = hasattr(context, "dnf") and context.dnf.dnf5_mode
+    dnf5_mode = hasattr(context, "dnf") and context.dnf5_mode
     clean_expected, clean_found = handle_reposync(expected, found, dnf5_mode)
 
     lines_match_to_regexps_line_by_line(clean_found, clean_expected)

--- a/dnf-behave-tests/dnf/steps/lib/dnf.py
+++ b/dnf-behave-tests/dnf/steps/lib/dnf.py
@@ -69,7 +69,7 @@ def find_transaction_table_begin(context, lines):
     """
 
     # DNF 5
-    if context.dnf.dnf5_mode:
+    if context.dnf5_mode:
         trans_start_re = re.compile(r"Package +Arch +Version +Repository +Size")
         for i in range(0, len(lines) - 1):
             if trans_start_re.match(lines[i]):
@@ -116,7 +116,7 @@ def find_transaction_table_end(context, lines):
     """
 
     # DNF 5
-    if context.dnf.dnf5_mode:
+    if context.dnf5_mode:
         for i in range(0, len(lines)):
             if not lines[i].strip():
                 # empty line indicates the end of the transaction table

--- a/dnf-behave-tests/dnf/steps/transaction.py
+++ b/dnf-behave-tests/dnf/steps/transaction.py
@@ -111,7 +111,7 @@ def check_rpmdb_transaction(context, mode):
                     action, ", ".join([str(rpm) for rpm in sorted(rpmdb_transaction[action])])))
 
 def check_dnf_transaction(context, mode):
-    dnf5_mode = hasattr(context, "dnf") and context.dnf.dnf5_mode
+    dnf5_mode = hasattr(context, "dnf") and context.dnf5_mode
     if dnf5_mode:
         print("=== WARNING ===")
         print("stdout checking is disabled for transaction table with @dnf5")


### PR DESCRIPTION
We need to know status of `dnf5_mode` in `before_all` for active tag
matching, this is before `DNFContext` is created in `before_scenario`.

We usually don't specify `dnf5_mode` manually, we use just `dnf5` tag.

Logic for inferring `dnf5_mode` from `dnf5` tag was present only in
`before_scenario` but was missing in `before_all`. Since we don't want
to duplicate it move it to `before_all` and store `dnf5_mode` directly
in behave `context` (`dnfdaemon_mode` as well).

I noticed PR: https://github.com/rpm-software-management/ci-dnf-stack/pull/1118 passed CI even though it shouldn't. It is because we don't specify `dnf5_mode` manually when running the CI and the new tests weren't run.
Another solution would be to run CI with define `dnf5_mode=1` but I think that would need to be added to `container-test` script.
