### PR TITLE
dnf5: Enable tests for remote cmdline packages (URL path), add tests for case insensitivity of URL scheme

### DIFF
--- a/dnf-behave-tests/dnf/install-path.feature
+++ b/dnf-behave-tests/dnf/install-path.feature
@@ -11,11 +11,12 @@ Scenario Outline: I can install an RPM from path, where path is <path type>
         | install       | setup-0:2.12.1-1.fc29.noarch              |
 
 Examples:
-        | path type               | path                                                                                |
-        | absolute                | {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm |
-        | relative                | noarch/setup-2.12.1-1.fc29.noarch.rpm                                               |
-        | relative with wildcards | noarch/setup-*.fc29.noarch.rpm                                                      |
-        | file://                 | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm |
+        | path type                   | path                                                                                       |
+        | absolute                    | {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm        |
+        | relative                    | noarch/setup-2.12.1-1.fc29.noarch.rpm                                                      |
+        | relative with wildcards     | noarch/setup-*.fc29.noarch.rpm                                                             |
+        | file://                     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm |
+        | case insensitive URL scheme | FiLe://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm |
 
 
 Scenario: I can install an RPM from path, when specifying the RPM multiple times
@@ -56,9 +57,27 @@ Scenario: I can install an RPM from url, where url is http address
         | install       | setup-0:2.12.1-1.fc29.noarch              |
 
 
+Scenario: I can install an RPM from url, where url is http address - test case insensitivity of the URL scheme
+  Given I use repository "dnf-ci-fedora" as http
+  And I execute dnf with args "install hTtP://localhost:{context.dnf.ports[dnf-ci-fedora]}/noarch/setup-2.12.1-1.fc29.noarch.rpm"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                                   |
+        | install       | setup-0:2.12.1-1.fc29.noarch              |
+
+
 Scenario: I can install an RPM from url, where url is ftp address
   Given I use repository "dnf-ci-fedora" as ftp
   And I execute dnf with args "install ftp://localhost:{context.dnf.ports[dnf-ci-fedora]}/noarch/setup-2.12.1-1.fc29.noarch.rpm"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                                   |
+        | install       | setup-0:2.12.1-1.fc29.noarch              |
+
+
+Scenario: I can install an RPM from url, where url is ftp address - test case insensitivity of the URL scheme
+  Given I use repository "dnf-ci-fedora" as ftp
+  And I execute dnf with args "install fTP://localhost:{context.dnf.ports[dnf-ci-fedora]}/noarch/setup-2.12.1-1.fc29.noarch.rpm"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |

--- a/dnf-behave-tests/dnf/install-path.feature
+++ b/dnf-behave-tests/dnf/install-path.feature
@@ -1,9 +1,7 @@
+@dnf5
 Feature: Tests for installing RPM from paths
 
 
-# @dnf5
-# TODO(nsella) rpmdb check fail
-# Failed to access RPM "file:///opt/ci/dnf-behave-tests/fixtures/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm": No such file or directory
 Scenario Outline: I can install an RPM from path, where path is <path type>
   Given I set working directory to "{context.dnf.fixturesdir}/repos/dnf-ci-fedora"
    When I execute dnf with args "install <path>"
@@ -20,7 +18,6 @@ Examples:
         | file://                 | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm |
 
 
-@dnf5
 Scenario: I can install an RPM from path, when specifying the RPM multiple times
    When I execute dnf with args "install {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm {context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm"
    Then the exit code is 0
@@ -50,9 +47,6 @@ Scenario: I can install an RPM from path, when specifying the RPM multiple times
         | install       | setup-0:2.12.1-1.fc29.noarch              |
 
 
-# @dnf5
-# TODO(nsella) rpmdb check fail
-# Failed to access RPM "http://localhost:43717/noarch/setup-2.12.1-1.fc29.noarch.rpm": No such file or directory
 Scenario: I can install an RPM from url, where url is http address
   Given I use repository "dnf-ci-fedora" as http
   And I execute dnf with args "install http://localhost:{context.dnf.ports[dnf-ci-fedora]}/noarch/setup-2.12.1-1.fc29.noarch.rpm"
@@ -62,9 +56,6 @@ Scenario: I can install an RPM from url, where url is http address
         | install       | setup-0:2.12.1-1.fc29.noarch              |
 
 
-# @dnf5
-# TODO(nsella) rpmdb check fail
-# Failed to access RPM "ftp://localhost:42937/noarch/setup-2.12.1-1.fc29.noarch.rpm": No such file or directory
 Scenario: I can install an RPM from url, where url is ftp address
   Given I use repository "dnf-ci-fedora" as ftp
   And I execute dnf with args "install ftp://localhost:{context.dnf.ports[dnf-ci-fedora]}/noarch/setup-2.12.1-1.fc29.noarch.rpm"

--- a/dnf-behave-tests/dnf/upgrade-from-path.feature
+++ b/dnf-behave-tests/dnf/upgrade-from-path.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Upgrade RPMs from path
 
 
@@ -16,7 +17,6 @@ Background: Install glibc, wget
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 
-# @dnf5
 # TODO(nsella) different exit code
 Scenario: Upgrade an RPM from absolute path on disk
   Given I use repository "dnf-ci-fedora-updates"
@@ -29,7 +29,6 @@ Scenario: Upgrade an RPM from absolute path on disk
         | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
 
 
-@dnf5
 Scenario: Upgrade an RPM from relative path on disk
   Given I set working directory to "{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade x86_64/glibc-2.28-26.fc29.x86_64.rpm x86_64/glibc-common-2.28-26.fc29.x86_64.rpm x86_64/glibc-all-langpacks-2.28-26.fc29.x86_64.rpm"
@@ -41,7 +40,6 @@ Scenario: Upgrade an RPM from relative path on disk
         | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
 
 
-@dnf5
 Scenario: Upgrade an RPM from path on disk containing wildcards
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/glibc*"
@@ -53,7 +51,6 @@ Scenario: Upgrade an RPM from path on disk containing wildcards
         | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
 
 
-@dnf5
 Scenario: Upgrade an RPM from path on disk, when specifying the RPM multiple times
    When I execute dnf with args "upgrade {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm"
    Then the exit code is 0
@@ -62,7 +59,6 @@ Scenario: Upgrade an RPM from path on disk, when specifying the RPM multiple tim
         | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
 
 
-@dnf5
 Scenario: Upgrade an RPM from path on disk, when specifying the RPM multiple times using different paths
   Given I set working directory to "{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade x86_64/wget-1.19.6-5.fc29.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm"
@@ -72,7 +68,6 @@ Scenario: Upgrade an RPM from path on disk, when specifying the RPM multiple tim
         | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
 
 
-@dnf5
 Scenario: Upgrade an RPM from path on disk, when specifying the RPM multiple times using symlink
   Given I copy file "{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm" to "/tmp/wget-1.19.6-5.fc29.x86_64.rpm"
     And I create symlink "/tmp/symlink.rpm" to file "/tmp/wget-1.19.6-5.fc29.x86_64.rpm"
@@ -83,9 +78,6 @@ Scenario: Upgrade an RPM from path on disk, when specifying the RPM multiple tim
         | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
 
 
-# @dnf5
-# TODO(nsella) rpmdb check fail
-# Failed to access RPM "http://localhost:40065/x86_64/wget-1.19.6-5.fc29.x86_64.rpm": No such file or directory
 Scenario: Upgrade an RPM from URL where URL is a http address
   Given I use repository "dnf-ci-fedora-updates" as http
   And I execute dnf with args "upgrade http://localhost:{context.dnf.ports[dnf-ci-fedora-updates]}/x86_64/wget-1.19.6-5.fc29.x86_64.rpm"
@@ -95,9 +87,6 @@ Scenario: Upgrade an RPM from URL where URL is a http address
         | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
 
 
-# @dnf5
-# TODO(nsella) rpmdb check fail
-# Failed to access RPM "ftp://localhost:43125/x86_64/wget-1.19.6-5.fc29.x86_64.rpm": No such file or directory
 Scenario: Upgrade an RPM from URL where URL is a ftp address
   Given I use repository "dnf-ci-fedora-updates" as ftp
   And I execute dnf with args "upgrade ftp://localhost:{context.dnf.ports[dnf-ci-fedora-updates]}/x86_64/wget-1.19.6-5.fc29.x86_64.rpm"
@@ -107,9 +96,6 @@ Scenario: Upgrade an RPM from URL where URL is a ftp address
         | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
 
 
-# @dnf5
-# TODO(nsella) rpmdb check fail
-# Failed to access RPM "file:///opt/ci/dnf-behave-tests/fixtures/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm": No such file or directory
 Scenario: Upgrade an RPM from URL where URL is a local path
   Given I use repository "dnf-ci-fedora-updates"
   And I execute dnf with args "upgrade file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm"


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/libdnf/pull/1523