### PR TITLE
[dnf5] Tests for system state correctly handling all common action scenarios

### DIFF
--- a/dnf-behave-tests/dnf/downgrade.feature
+++ b/dnf-behave-tests/dnf/downgrade.feature
@@ -47,6 +47,32 @@ Scenario: Downgrade RPM that requires downgrade of dependency
         | downgrade     | glibc-0:2.28-9.fc29.x86_64                |
         | downgrade     | glibc-common-0:2.28-9.fc29.x86_64         |
         | downgrade     | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+    And package state is
+        | package                                | reason     | from_repo     |
+        | basesystem-11-6.fc29.noarch            | Dependency | dnf-ci-fedora |
+        | filesystem-3.9-2.fc29.x86_64           | Dependency | dnf-ci-fedora |
+        | glibc-2.28-9.fc29.x86_64               | User       | dnf-ci-fedora |
+        | glibc-all-langpacks-2.28-9.fc29.x86_64 | Dependency | dnf-ci-fedora |
+        | glibc-common-2.28-9.fc29.x86_64        | Dependency | dnf-ci-fedora |
+        | setup-2.12.1-1.fc29.noarch             | Dependency | dnf-ci-fedora |
+
+
+@dnf5
+Scenario: Downgrade a package that was installed via rpm
+  Given I use repository "dnf-ci-fedora"
+   When I execute rpm with args "-i --nodeps {context.scenario.repos_location}/dnf-ci-fedora-updates/x86_64/flac-1.3.3-3.fc29.x86_64.rpm"
+   Then the exit code is 0
+   When I execute dnf with args "downgrade flac"
+   Then the exit code is 0
+    And Transaction is following
+        | Action    | Package                    |
+        | downgrade | flac-0:1.3.3-2.fc29.x86_64 |
+   Then package reasons are
+        | Package                  | Reason  |
+        | flac-1.3.3-2.fc29.x86_64 | unknown |
+    And package state is
+        | package                  | reason        | from_repo             |
+        | flac-1.3.3-2.fc29.x86_64 | External User | dnf-ci-fedora-updates |
 
 
 # @dnf5

--- a/dnf-behave-tests/dnf/install-obsoletes.feature
+++ b/dnf-behave-tests/dnf/install-obsoletes.feature
@@ -9,6 +9,9 @@ Scenario: Install an obsoleted RPM
     And Transaction is following
         | Action        | Package                                   |
         | install       | glibc-profile-0:2.3.1-10.x86_64           |
+    And package state is
+        | package                       | reason | from_repo         |
+        | glibc-profile-2.3.1-10.x86_64 | User   | dnf-ci-thirdparty |
 
 
 @dnf5
@@ -25,6 +28,14 @@ Scenario: Install an obsoleted RPM when the obsoleting RPM is available
         | install-dep   | basesystem-0:11-6.fc29.noarch             |
         | install-dep   | glibc-common-0:2.28-9.fc29.x86_64         |
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+    And package state is
+        | package                                | reason     | from_repo     |
+        | glibc-2.28-9.fc29.x86_64               | User       | dnf-ci-fedora |
+        | setup-2.12.1-1.fc29.noarch             | Dependency | dnf-ci-fedora |
+        | filesystem-3.9-2.fc29.x86_64           | Dependency | dnf-ci-fedora |
+        | basesystem-11-6.fc29.noarch            | Dependency | dnf-ci-fedora |
+        | glibc-common-2.28-9.fc29.x86_64        | Dependency | dnf-ci-fedora |
+        | glibc-all-langpacks-2.28-9.fc29.x86_64 | Dependency | dnf-ci-fedora |
 
 
 @bz1672618

--- a/dnf-behave-tests/dnf/obsoletes.feature
+++ b/dnf-behave-tests/dnf/obsoletes.feature
@@ -19,6 +19,9 @@ Scenario: Install of obsoleted package, but higher version than obsoleted presen
     And Transaction is following
         | Action        | Package                                   |
         | install       | PackageA-0:3.0-1.x86_64                   |
+    And package state is
+        | package               | reason | from_repo        |
+        | PackageA-3.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 @dnf5
@@ -31,6 +34,9 @@ Scenario: Install of obsoleting package, even though higher version than obsolet
     And Transaction is following
         | Action        | Package                                   |
         | install       | PackageA-Obsoleter-0:1.0-1.x86_64         |
+    And package state is
+        | package                         | reason | from_repo        |
+        | PackageA-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 # @dnf5
@@ -56,6 +62,38 @@ Scenario: Install of obsoleting package using upgrade command, when obsoleted pa
         | Action        | Package                                   |
         | install       | PackageA-Obsoleter-0:1.0-1.x86_64         |
         | obsoleted     | PackageE-0:1.0-1.x86_64                   |
+    And package state is
+        | package                         | reason | from_repo        |
+        | PackageA-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+
+@dnf5
+# TODO(lukash) passes with reason = User, but correct outcome is reason = None
+Scenario: Obsoleting a package that was installed via rpm, with --best
+   When I execute rpm with args "-i --nodeps {context.scenario.repos_location}/dnf-ci-obsoletes/x86_64/PackageB-1.0-1.x86_64.rpm"
+   Then the exit code is 0
+   When I execute dnf with args "upgrade --best"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                                   |
+        | install       | PackageB-Obsoleter-0:1.0-1.x86_64         |
+        | obsoleted     | PackageB-0:1.0-1.x86_64                   |
+    And package state is
+        | package                         | reason | from_repo        |
+        | PackageB-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+
+@dnf5
+Scenario: Obsoleting a package that was installed via rpm, with --nobest
+   When I execute rpm with args "-i --nodeps {context.scenario.repos_location}/dnf-ci-obsoletes/x86_64/PackageB-1.0-1.x86_64.rpm"
+   Then the exit code is 0
+   When I execute dnf with args "upgrade --nobest"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                                   |
+        | install       | PackageB-Obsoleter-0:1.0-1.x86_64         |
+        | obsoleted     | PackageB-0:1.0-1.x86_64                   |
+    And package state is
+        | package                         | reason        | from_repo        |
+        | PackageB-Obsoleter-1.0-1.x86_64 | External User | dnf-ci-obsoletes |
 
 @dnf5
 # TODO(nsella) transaction table output
@@ -72,6 +110,9 @@ Scenario: Install of obsoleting package from commandline using upgrade command, 
         | Action        | Package                                   |
         | install       | PackageA-Obsoleter-0:1.0-1.x86_64         |
         | obsoleted     | PackageE-0:1.0-1.x86_64                   |
+    And package state is
+        | package                         | reason | from_repo    |
+        | PackageA-Obsoleter-1.0-1.x86_64 | User   | @commandline |
 
 @dnf5
 Scenario: Upgrade of obsoleted package by package of higher version than obsoleted
@@ -85,6 +126,9 @@ Scenario: Upgrade of obsoleted package by package of higher version than obsolet
     And Transaction is following
         | Action        | Package                                   |
         | upgrade       | PackageA-0:3.0-1.x86_64                   |
+    And package state is
+        | package               | reason | from_repo        |
+        | PackageA-3.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 @dnf5
@@ -94,6 +138,9 @@ Scenario: Install of obsoleted package
     And Transaction is following
         | Action        | Package                                   |
         | install       | PackageB-Obsoleter-0:1.0-1.x86_64         |
+    And package state is
+        | package                         | reason | from_repo        |
+        | PackageB-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 @dnf5
@@ -110,6 +157,9 @@ Scenario: Upgrade of obsoleted package
         | Action        | Package                                   |
         | install       | PackageB-Obsoleter-0:1.0-1.x86_64         |
         | obsoleted     | PackageB-0:1.0-1.x86_64                   |
+    And package state is
+        | package                         | reason | from_repo        |
+        | PackageB-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 @dnf5
@@ -124,6 +174,9 @@ Scenario: Upgrade of obsoleted package if package specified by version with glob
     And Transaction is following
         | Action        | Package                                   |
         | upgrade       | PackageB-0:2.0-1.x86_64                   |
+    And package state is
+        | package               | reason | from_repo        |
+        | PackageB-2.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 @xfail @bz1672618
@@ -157,6 +210,9 @@ Scenario: Autoremoval of obsoleted package
         | Action        | Package                                   |
         | install       | PackageB-Obsoleter-0:1.0-1.x86_64         |
         | obsoleted     | PackageB-0:1.0-1.x86_64                   |
+    And package state is
+        | package                         | reason | from_repo        |
+        | PackageB-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
    When I execute dnf with args "autoremove"
    Then the exit code is 0
     But Transaction is empty

--- a/dnf-behave-tests/dnf/plugins-core/actions.feature
+++ b/dnf-behave-tests/dnf/plugins-core/actions.feature
@@ -119,6 +119,10 @@ Examples:
     | out       |             |
 
 
+@xfail
+# TODO(lukash) this test relied on an injected Reason Change for installonly
+# packages, which we no longer inject instead replace with an explicit `dnf
+# mark` once the command is implement
 Scenario: Reason change is in transaction
   Given I create and substitute file "/etc/dnf/libdnf5-plugins/actions.d/test.actions" with
     """

--- a/dnf-behave-tests/dnf/reinstall.feature
+++ b/dnf-behave-tests/dnf/reinstall.feature
@@ -19,6 +19,10 @@ Scenario: Reinstall an RPM from the same repository
     And Transaction is following
         | Action        | Package                                   |
         | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |
+    And package state is
+        | package                           | reason     | from_repo             |
+        | CQRlib-devel-1.1.2-16.fc29.x86_64 | User       | dnf-ci-fedora         |
+        | CQRlib-1.1.2-16.fc29.x86_64       | Dependency | dnf-ci-fedora-updates |
 
 
 Scenario: Reinstall an RPM from different repository
@@ -28,6 +32,10 @@ Scenario: Reinstall an RPM from different repository
     And Transaction is following
         | Action        | Package                                   |
         | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |
+    And package state is
+        | package                           | reason     | from_repo                     |
+        | CQRlib-devel-1.1.2-16.fc29.x86_64 | User       | dnf-ci-fedora                 |
+        | CQRlib-1.1.2-16.fc29.x86_64       | Dependency | dnf-ci-fedora-updates-testing |
 
 
 Scenario: Reinstall an RPM that is not available

--- a/dnf-behave-tests/dnf/remove-pkgspec.feature
+++ b/dnf-behave-tests/dnf/remove-pkgspec.feature
@@ -27,6 +27,8 @@ Scenario Outline: Remove an RPM by <pkgspec-type>
         | remove-unused | basesystem-0:11-6.fc29.noarch             |
         | remove-unused | glibc-common-0:2.28-9.fc29.x86_64         |
         | remove-unused | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
+    And package state is
+        | package | reason | from_repo |
 
 @tier1
 Examples: Name

--- a/dnf-behave-tests/dnf/steps/history.py
+++ b/dnf-behave-tests/dnf/steps/history.py
@@ -141,6 +141,10 @@ def step_impl(context, spec=""):
 
 @behave.then('package reasons are')
 def step_impl(context):
+    # we only do the check for dnf4
+    if hasattr(context, "dnf5_mode") and context.dnf5_mode:
+        return
+
     check_context_table(context, ["Package", "Reason"])
 
     cmd = context.dnf.get_cmd(context) + ["repoquery --qf '%{name}-%{evr}.%{arch},%{reason}' --installed"]

--- a/dnf-behave-tests/dnf/steps/system_state.py
+++ b/dnf-behave-tests/dnf/steps/system_state.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import behave
+import os
+import toml
+
+from common.lib.behave_ext import check_context_table
+from common.lib.diff import print_lines_diff
+from lib.rpm import RPM
+
+
+@behave.then('package state is')
+def package_state_is(context):
+    """
+    Checks the reason in system state packages.toml as well as the from_repo
+    attribute from nevras.toml in one step. For that, the table in context has
+    to contain the full NEVRA, which is converted to NA for checking the
+    reason.
+
+    The reason column also supports value of "None" which represents no
+    record for the given NA.
+
+    For installonly packages, multiple NEVRAS for the same NA can be put into
+    the table, the reason is checked just as one NA record in packages.toml.
+    """
+    # we only do the check for dnf5
+    if not hasattr(context, "dnf5_mode") or not context.dnf5_mode:
+        return
+
+    check_context_table(context, ["package", "reason", "from_repo"])
+
+    found_pkgs = []
+    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/dnf/packages.toml")) as f:
+        for k, v in toml.load(f)["packages"].items():
+            found_pkgs.append((k, v["reason"]))
+    found_pkgs.sort()
+
+    found_nevras = []
+    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/dnf/nevras.toml")) as f:
+        for k, v in toml.load(f)["nevras"].items():
+            found_nevras.append((k, v["from_repo"]))
+    found_nevras.sort()
+
+    expected_pkgs_dict = {}
+    expected_nevras = []
+    for package, reason, from_repo in context.table:
+        if reason != "None":
+            na = RPM(package).na
+            if na in expected_pkgs_dict and expected_pkgs_dict[na] != reason:
+                raise AssertionError("Inconsistent reason for NA \"{}\"".format(na))
+            expected_pkgs_dict[na] = reason
+
+        expected_nevras.append((package, from_repo))
+
+    expected_pkgs = sorted(expected_pkgs_dict.items())
+    expected_nevras.sort()
+
+    fail = False
+    if expected_pkgs != found_pkgs:
+        print("packages.toml system state differs from expected:")
+        print_lines_diff(expected_pkgs, found_pkgs)
+        fail = True
+
+    if expected_nevras != found_nevras:
+        print("nevras.toml system state differs from expected:")
+        print_lines_diff(expected_nevras, found_nevras)
+        fail = True
+
+    if fail:
+        raise AssertionError("System state mismatch")

--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -29,6 +29,7 @@ BuildRequires:  python3-distro
 BuildRequires:  python3-pip
 # a missing dep of python3-pip on f35 beta, remove when unneeded
 BuildRequires:  python3-setuptools
+BuildRequires:  python3-toml
 BuildRequires:  rpm-build
 BuildRequires:  rpm-sign
 BuildRequires:  sqlite


### PR DESCRIPTION
For: https://github.com/rpm-software-management/libdnf/pull/1543

Adds the tests for the system state contents somewhat arbitrarily. I'm not sure if we'll go with this design or changes will be needed, I wouldn't like to redo everything if I added the steps to "all" scenarios.

For that matter, I'm not sure if we should put this in all scenarios or just some select ones.