### PR TITLE
Split zchunk test for dnf4/5 because of optional filelists

### DIFF
--- a/dnf-behave-tests/dnf/zchunk.feature
+++ b/dnf-behave-tests/dnf/zchunk.feature
@@ -112,7 +112,8 @@ Given I copy repository "simple-base" for modification
       | /repodata/filelists.xml.zck |
 
 
-@dnf5
+@use.with_dnf=4
+@not.with_dnf=5
 Scenario: using mirror wihtout ranges supports and zchunk results in only two GET requests per file (the first try is with range specified)
 Given I copy repository "simple-base" for modification
   And I generate repodata for repository "simple-base" with extra arguments "--zck"
@@ -132,3 +133,24 @@ Given I copy repository "simple-base" for modification
   And exactly 2 HTTP GET request should match:
       | path                        |
       | /repodata/filelists.xml.zck |
+
+
+@dnf5
+@not.with_dnf=4
+# dnf5 doesn't require filelists.xml here -> there are no GET requests for it
+Scenario: using mirror wihtout ranges supports and zchunk results in only two GET requests for primary (the first try is with range specified)
+Given I copy repository "simple-base" for modification
+  And I generate repodata for repository "simple-base" with extra arguments "--zck"
+  And I use repository "simple-base" as http
+  And I configure dnf with
+      | key    | value |
+      | zchunk | True |
+  And I start capturing outbound HTTP requests
+ When I execute dnf with args "install labirinto"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                       |
+      | install       | labirinto-0:1.0-1.fc29.x86_64 |
+  And exactly 2 HTTP GET requests should match:
+      | path                      |
+      | /repodata/primary.xml.zck |


### PR DESCRIPTION
Fixes a CI test that is failing since filelists are optional for dnf5.