### PR TITLE
Test for showing detailed error message when TMPDIR does not exist

### DIFF
--- a/dnf-behave-tests/dnf/removed-tmpdir.feature
+++ b/dnf-behave-tests/dnf/removed-tmpdir.feature
@@ -1,0 +1,13 @@
+Feature: Better error message when TMPDIR is missing
+
+@bz2019993
+Scenario: show detailed error message when $TMPDIR does not exist
+Given I use repository "dnf-ci-fedora" with configuration
+      | key             | value                                       |
+      | baseurl         |                                             |
+      | mirrorlist      | {context.dnf.installroot}/tmp/mirrorlist    |
+      | gpgcheck        | 0
+  And I set environment variable "TMPDIR" to "/tmp/dummy.ABC123"
+ When I execute dnf with args "repoquery empty --refresh"
+ Then the exit code is 1
+  And stderr contains "Cannot create temporary file - mkstemp '/tmp/dummy.ABC123/librepo-tmp-*"


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/librepo/pull/262.