### PR TITLE
Tests for system-upgrade plugin migration to core

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/system-upgrade-comps.feature
+++ b/dnf-behave-tests/dnf/plugins-core/system-upgrade-comps.feature
@@ -7,6 +7,7 @@ Background:
     And I use repository "system-upgrade-comps-f$releasever"
 
 
+@bz2054235
 Scenario: Upgrade group when there are new package versions - upgrade packages
   Given I successfully execute dnf with args "group install A-group"
     And I set releasever to "30"
@@ -30,6 +31,7 @@ Scenario: Upgrade group when there are new package versions - upgrade packages
         | group-upgrade | A-group                            |
 
 
+@bz2054235
 Scenario: Upgrade group when there are new packages - install new packages
   Given I successfully execute dnf with args "group install AB-group"
     And I set releasever to "30"
@@ -57,6 +59,7 @@ Scenario: Upgrade group when there are new packages - install new packages
         | group-upgrade | AB-group                           |
 
 
+@bz2054235
 Scenario: Upgrade group when there were excluded packages during installation - don't install these packages
   Given I successfully execute dnf with args "group install A-group --exclude=A-mandatory,A-default,A-optional"
     And I set releasever to "30"
@@ -76,6 +79,7 @@ Scenario: Upgrade group when there were excluded packages during installation - 
         | group-upgrade | A-group                            |
 
 
+@bz2054235
 Scenario: Upgrade group when there were removed packages since installation - don't install these packages
   Given I successfully execute dnf with args "group install A-group"
     And I successfully execute dnf with args "remove A-mandatory A-default"
@@ -96,6 +100,7 @@ Scenario: Upgrade group when there were removed packages since installation - do
         | group-upgrade | A-group                            |
 
 
+@bz2054235
 Scenario: Upgrade environment when there are new groups/packages - install new groups/packages
   Given I successfully execute dnf with args "group install AB-environment"
     And I set releasever to "30"
@@ -127,6 +132,7 @@ Scenario: Upgrade environment when there are new groups/packages - install new g
         | env-upgrade   | AB-environment                     |
 
 
+@bz2054235
 Scenario: Upgrade environment when there were excluded packages during installation - don't install these packages
   Given I execute dnf with args "group install A-environment --exclude=A-mandatory,A-default,A-optional"
     And I set releasever to "30"
@@ -148,6 +154,7 @@ Scenario: Upgrade environment when there were excluded packages during installat
         | env-upgrade   | A-environment                      |
 
 
+@bz2054235
 Scenario: Upgrade environment when there were removed packages since installation - don't install these packages
   Given I successfully execute dnf with args "group install A-environment"
     And I successfully execute dnf with args "remove A-mandatory A-default"
@@ -170,6 +177,7 @@ Scenario: Upgrade environment when there were removed packages since installatio
         | env-upgrade   | A-environment                      |
 
 
+@bz2054235
 Scenario: Upgrade empty group
   Given I successfully execute dnf with args "group install empty-group"
     And I set releasever to "30"
@@ -189,6 +197,7 @@ Scenario: Upgrade empty group
         | group-upgrade | empty-group                        |
 
 
+@bz2054235
 Scenario: Upgrade empty environment
   Given I successfully execute dnf with args "group install empty-environment"
     And I set releasever to "30"
@@ -208,6 +217,7 @@ Scenario: Upgrade empty environment
         | env-upgrade   | empty-environment                  |
 
 
+@bz2054235
 Scenario: Upgrade environment when all groups are removed
   Given I successfully execute dnf with args "group install A-environment"
     And I successfully execute dnf with args "group remove A-group"

--- a/dnf-behave-tests/dnf/plugins-core/system-upgrade.feature
+++ b/dnf-behave-tests/dnf/plugins-core/system-upgrade.feature
@@ -21,6 +21,7 @@ Given I enable plugin "system_upgrade"
   And I set environment variable "DNF_SYSTEM_UPGRADE_NO_REBOOT" to "1"
 
 
+@bz2054235
 Scenario: Test system-upgrade when reboot wasn't performed
  When I execute dnf with args "system-upgrade download"
  Then the exit code is 0
@@ -44,6 +45,7 @@ Scenario: Test system-upgrade when reboot wasn't performed
       """
 
 
+@bz2054235
 Scenario: Test system-upgrade basic functionality
  When I execute dnf with args "system-upgrade download"
  Then the exit code is 0
@@ -71,6 +73,7 @@ Given I successfully execute dnf with args "system-upgrade reboot"
       | downgrade     | pkg-b-1.0-1.noarch    |
 
 
+@bz2054235
 Scenario: Test system-upgrade with --destdir
  When I execute dnf with args "system-upgrade download --destdir={context.dnf.tempdir}/destdir"
  Then the exit code is 0
@@ -98,6 +101,7 @@ Given I successfully execute dnf with args "system-upgrade reboot"
       | downgrade     | pkg-b-1.0-1.noarch    |
 
 
+@bz2054235
 Scenario: Test system-upgrade with --no-downgrade
  When I execute dnf with args "system-upgrade download --no-downgrade"
  Then the exit code is 0
@@ -123,6 +127,7 @@ Given I successfully execute dnf with args "system-upgrade reboot"
       | upgrade       | pkg-both-2.0-1.noarch |
 
 
+@bz2054235
 Scenario: Test system-upgrade transaction file not found
  When I execute dnf with args "system-upgrade download"
  Then the exit code is 0
@@ -148,6 +153,7 @@ Given I successfully execute dnf with args "system-upgrade reboot"
       """
 
 
+@bz2054235
 Scenario: Test system-upgrade downloading a package from a different repo
  When I execute dnf with args "system-upgrade download"
  Then the exit code is 0
@@ -182,6 +188,7 @@ Given I successfully execute dnf with args "system-upgrade reboot"
       | downgrade     | pkg-b-1.0-1.noarch    |
 
 
+@bz2054235
 Scenario: Test system-upgrade empty transaction
 Given I successfully execute dnf with args "distro-sync"
  When I execute dnf with args "system-upgrade download"
@@ -199,6 +206,7 @@ Given I successfully execute dnf with args "distro-sync"
       """
 
 
+@bz2054235
 @bz2024430
 Scenario Outline: Test system-upgrade with <option> doesn't delete user files
 Given I create directory "/downloaddir"


### PR DESCRIPTION
Requires:
- https://github.com/rpm-software-management/dnf-plugins-extras/pull/210
- https://github.com/rpm-software-management/dnf-plugins-core/pull/462