### PR TITLE
Tests for rollback of group upgrade transaction rollback

### DIFF
--- a/dnf-behave-tests/dnf/history-rollback-env-upgrade.feature
+++ b/dnf-behave-tests/dnf/history-rollback-env-upgrade.feature
@@ -16,6 +16,14 @@ Background:
     And History is following
         | Id     | Command                                              | Action        | Altered   |
         | 1      | group install DNF-CI-RollbackTestEnv                 | Install       | 7         |
+   When I execute dnf with args "group list --installed DNF-CI-RollbackTestEnv"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    Installed Environment Groups:
+       DNF-CI-RollbackTestEnv
+    """
   Given I use repository "dnf-ci-group-rollback-2"
     And I successfully execute dnf with args "group upgrade DNF-CI-RollbackTestEnv"
    Then Transaction is following
@@ -48,3 +56,72 @@ Scenario: Rollback an environment upgrade transaction
         | 3      | history rollback 1                                   | Downgrade     | 7         |
         | 2      | group upgrade DNF-CI-RollbackTestEnv                 | Upgrade       | 7         |
         | 1      | group install DNF-CI-RollbackTestEnv                 | Install       | 7         |
+   When I execute dnf with args "group list --installed DNF-CI-RollbackTestEnv"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    Installed Environment Groups:
+       DNF-CI-RollbackTestEnv
+    """
+
+
+@bz2016070
+Scenario: Rollback a rollbacked environment upgrade transaction
+  Given I execute dnf with args "history rollback 1"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                 | Package                              |
+        | downgrade              | TestGroup1PackageA-0:1.0-1.x86_64    |
+        | downgrade              | TestGroup1PackageB-0:1.0-1.x86_64    |
+        | downgrade              | TestGroup2PackageA-0:1.0-1.x86_64    |
+        | downgrade              | TestGroup2PackageB-0:1.0-1.x86_64    |
+    And History is following
+        | Id     | Command                                              | Action        | Altered   |
+        | 3      | history rollback 1                                   | Downgrade     | 7         |
+        | 2      | group upgrade DNF-CI-RollbackTestEnv                 | Upgrade       | 7         |
+        | 1      | group install DNF-CI-RollbackTestEnv                 | Install       | 7         |
+   When I execute dnf with args "history rollback 2"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                 | Package                              |
+        | env-upgrade            | DNF-CI-RollbackTestEnv               |
+        | group-upgrade          | DNF-CI-RollbackTestGroup1            |
+        | group-upgrade          | DNF-CI-RollbackTestGroup2            |
+        | upgrade                | TestGroup1PackageA-0:1.1-1.x86_64    |
+        | upgrade                | TestGroup1PackageB-0:1.1-1.x86_64    |
+        | upgrade                | TestGroup2PackageA-0:1.1-1.x86_64    |
+        | upgrade                | TestGroup2PackageB-0:1.1-1.x86_64    |
+    And History is following
+        | Id     | Command                                              | Action        | Altered   |
+        | 4      | history rollback 2                                   | Upgrade       | 7         |
+        | 3      | history rollback 1                                   | Downgrade     | 7         |
+        | 2      | group upgrade DNF-CI-RollbackTestEnv                 | Upgrade       | 7         |
+        | 1      | group install DNF-CI-RollbackTestEnv                 | Install       | 7         |
+   When I execute dnf with args "group list --installed DNF-CI-RollbackTestEnv"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    Installed Environment Groups:
+       DNF-CI-RollbackTestEnv
+    """
+
+
+@bz2016070
+Scenario: Redo an undo-ed environment upgrade transaction
+  Given I execute dnf with args "history undo last"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                 | Package                              |
+        | downgrade              | TestGroup1PackageA-0:1.0-1.x86_64    |
+        | downgrade              | TestGroup1PackageB-0:1.0-1.x86_64    |
+        | downgrade              | TestGroup2PackageA-0:1.0-1.x86_64    |
+        | downgrade              | TestGroup2PackageB-0:1.0-1.x86_64    |
+    And History is following
+        | Id     | Command                                              | Action        | Altered   |
+        | 3      | history undo last                                    | Downgrade     | 7         |
+        | 2      | group upgrade DNF-CI-RollbackTestEnv                 | Upgrade       | 7         |
+        | 1      | group install DNF-CI-RollbackTestEnv                 | Install       | 7         |
+   When I execute dnf with args "history redo last"
+   Then the exit code is 0

--- a/dnf-behave-tests/dnf/history-rollback-group-upgrade.feature
+++ b/dnf-behave-tests/dnf/history-rollback-group-upgrade.feature
@@ -12,6 +12,14 @@ Background:
     And History is following
         | Id     | Command                                              | Action        | Altered   |
         | 1      | group install DNF-CI-RollbackTestGroup1              | Install       | 3         |
+   When I execute dnf with args "group list --installed DNF-CI-RollbackTestGroup1"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    Installed Groups:
+       DNF-CI-RollbackTestGroup1
+    """
   Given I use repository "dnf-ci-group-rollback-2"
     And I successfully execute dnf with args "group upgrade DNF-CI-RollbackTestGroup1"
    Then Transaction is following
@@ -38,6 +46,67 @@ Scenario: Rollback a group upgrade transaction
         | 3      | history rollback 1                                   | Downgrade     | 3         |
         | 2      | group upgrade DNF-CI-RollbackTestGroup1              | Upgrade       | 3         |
         | 1      | group install DNF-CI-RollbackTestGroup1              | Install       | 3         |
+   When I execute dnf with args "group list --installed DNF-CI-RollbackTestGroup1"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    Installed Groups:
+       DNF-CI-RollbackTestGroup1
+    """
+
+
+@bz2016070
+Scenario: Rollback a rollbacked group upgrade transaction
+  Given I execute dnf with args "history rollback 1"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                 | Package                              |
+        | downgrade              | TestGroup1PackageA-0:1.0-1.x86_64    |
+        | downgrade              | TestGroup1PackageB-0:1.0-1.x86_64    |
+    And History is following
+        | Id     | Command                                              | Action        | Altered   |
+        | 3      | history rollback 1                                   | Downgrade     | 3         |
+        | 2      | group upgrade DNF-CI-RollbackTestGroup1              | Upgrade       | 3         |
+        | 1      | group install DNF-CI-RollbackTestGroup1              | Install       | 3         |
+   When I execute dnf with args "history rollback 2"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                 | Package                              |
+        | group-upgrade          | DNF-CI-RollbackTestGroup1            |
+        | upgrade                | TestGroup1PackageA-0:1.1-1.x86_64    |
+        | upgrade                | TestGroup1PackageB-0:1.1-1.x86_64    |
+    And History is following
+        | Id     | Command                                              | Action        | Altered   |
+        | 4      | history rollback 2                                   | Upgrade       | 3         |
+        | 3      | history rollback 1                                   | Downgrade     | 3         |
+        | 2      | group upgrade DNF-CI-RollbackTestGroup1              | Upgrade       | 3         |
+        | 1      | group install DNF-CI-RollbackTestGroup1              | Install       | 3         |
+   When I execute dnf with args "group list --installed DNF-CI-RollbackTestGroup1"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    Installed Groups:
+       DNF-CI-RollbackTestGroup1
+    """
+
+
+@bz2016070
+Scenario: Redo an undo-ed group upgrade transaction
+  Given I execute dnf with args "history undo last"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                 | Package                              |
+        | downgrade              | TestGroup1PackageA-0:1.0-1.x86_64    |
+        | downgrade              | TestGroup1PackageB-0:1.0-1.x86_64    |
+    And History is following
+        | Id     | Command                                              | Action        | Altered   |
+        | 3      | history undo last                                    | Downgrade     | 3         |
+        | 2      | group upgrade DNF-CI-RollbackTestGroup1              | Upgrade       | 3         |
+        | 1      | group install DNF-CI-RollbackTestGroup1              | Install       | 3         |
+   When I execute dnf with args "history redo last"
+   Then the exit code is 0
 
 
 @bz2016070
@@ -68,6 +137,14 @@ Scenario: Rollback multiple group upgrade transactions
         | 3      | group upgrade DNF-CI-RollbackTestGroup1              | I, U          | 4         |
         | 2      | group upgrade DNF-CI-RollbackTestGroup1              | Upgrade       | 3         |
         | 1      | group install DNF-CI-RollbackTestGroup1              | Install       | 3         |
+   When I execute dnf with args "group list --installed DNF-CI-RollbackTestGroup1"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    Installed Groups:
+       DNF-CI-RollbackTestGroup1
+    """
 
 
 @bz2016070
@@ -124,3 +201,11 @@ Scenario: Excluded package is remembered until next group install when rolling b
         | 3      | group upgrade DNF-CI-RollbackTestGroup1              | Upgrade       | 3         |
         | 2      | group upgrade DNF-CI-RollbackTestGroup1              | Upgrade       | 3         |
         | 1      | group install DNF-CI-RollbackTestGroup1              | Install       | 3         |
+   When I execute dnf with args "group list --installed DNF-CI-RollbackTestGroup1"
+   Then the exit code is 0
+    And stdout is
+    """
+    <REPOSYNC>
+    Installed Groups:
+       DNF-CI-RollbackTestGroup1
+    """


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf/pull/1852.