### PR TITLE
Fix "transaction is empty" step

### DIFF
--- a/dnf-behave-tests/dnf/steps/lib/rpm.py
+++ b/dnf-behave-tests/dnf/steps/lib/rpm.py
@@ -210,4 +210,11 @@ def diff_rpm_lists(list_one, list_two):
             else:
                 result["unchanged"].append(pkg_two)
 
+    # construct 'changed' list which is used to detect if transaction was empty
+    # 'remove' packages will not be 'present' so add them
+    result["changed"] = result["present"] + result["remove"]
+    for pkg in result["unchanged"]:
+        if pkg in result["changed"]:
+            result["changed"].remove(pkg)
+
     return result

--- a/dnf-behave-tests/dnf/steps/lib/rpm.py
+++ b/dnf-behave-tests/dnf/steps/lib/rpm.py
@@ -82,8 +82,6 @@ def diff_rpm_lists(list_one, list_two):
         "upgraded": [],
         "downgrade": [],
         "downgraded": [],
-        "broken": [],
-        "conflict": [],
 
         # it is not clear whether a RPM was reinstalled or not changed at all
         # use "unchanged" instead

--- a/dnf-behave-tests/dnf/steps/transaction.py
+++ b/dnf-behave-tests/dnf/steps/transaction.py
@@ -239,8 +239,12 @@ def then_RPMDB_transaction_is_empty(context):
 def then_DNF_transaction_is_empty(context):
     # check changes in DNF transaction table
     lines = context.cmd_stdout.splitlines()
+    dnf5_mode = hasattr(context, "dnf5_mode") and context.dnf5_mode
     try:
-        dnf_transaction = parse_transaction_table(context, lines)
+        if dnf5_mode:
+            dnf_transaction = parse_transaction_table_dnf5(context, lines)
+        else:
+            dnf_transaction = parse_transaction_table(context, lines)
     except RuntimeError:
         dnf_transaction = {}
     if dnf_transaction:

--- a/dnf-behave-tests/dnf/upgrade-from-noarch.feature
+++ b/dnf-behave-tests/dnf/upgrade-from-noarch.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Upgrade package from noarch to arch
 
 Background: Install package to upgrade


### PR DESCRIPTION
- Check if rpmdb transaction is empty was broken because we never set `result["changed"]`.

- For dnf5 `Transaction is empty` step was always passing because we tried to parse the output with dnf4 transaction parsing which threw a `RuntimeError` - that was caught and empty `dnf_transaction = {}` was used.

Also enables one passing feature for dnf5.