### PR TITLE
Tests for dnf5's history list command

### DIFF
--- a/dnf-behave-tests/common/output.py
+++ b/dnf-behave-tests/common/output.py
@@ -36,6 +36,20 @@ def strip_reposync_dnf5(found_lines, line_number):
     if line_number < len(found_lines) and found_lines[line_number].strip() == "Repositories loaded.":
         found_lines.pop(line_number)
 
+def strip_help_dnf4(found_lines, line_number):
+    pass
+
+def strip_help_dnf5(found_lines, line_number):
+    end_of_help_dnf5 = "--disableplugin=PLUGIN_NAME,...        Alias for '--disable-plugin'"
+    if line_number < len(found_lines) and (found_lines[line_number].strip() == "Missing command" or found_lines[line_number].strip() == "Usage:" ):
+        found_lines.pop(line_number)
+
+    while line_number < len(found_lines) and found_lines[line_number].strip() != end_of_help_dnf5:
+        found_lines.pop(line_number)
+
+    if line_number < len(found_lines) and found_lines[line_number].strip() == end_of_help_dnf5:
+        found_lines.pop(line_number)
+
 
 def handle_reposync(expected, found, dnf5_mode):
     line_number = 0
@@ -45,6 +59,15 @@ def handle_reposync(expected, found, dnf5_mode):
                 strip_reposync_dnf5(found, line_number)
             else:
                 strip_reposync_dnf4(found, line_number)
+
+            expected.pop(line_number)
+            break
+
+        if line == "<HELP>":
+            if dnf5_mode:
+                strip_help_dnf5(found, line_number)
+            else:
+                strip_help_dnf4(found, line_number)
 
             expected.pop(line_number)
             break
@@ -64,6 +87,38 @@ def then_stdout_is_empty(context):
     if not context.cmd_stdout:
         return
     raise AssertionError("Stdout is not empty, it contains: %s" % context.cmd_stdout)
+
+
+@behave.then("stdout is help")
+def then_stdout_is_help(context):
+    expected = context.text.format(context=context).rstrip().split('\n')
+    found = context.cmd_stdout.rstrip().split('\n')
+
+    if found == [""]:
+        found = []
+
+    dnf5_mode = hasattr(context, "dnf5_mode") and context.dnf5_mode
+    clean_expected, clean_found = handle_help(expected, found, dnf5_mode)
+
+    if clean_expected == clean_found:
+        return
+
+    rs_offset = 0
+    if len(clean_expected) < len(expected):
+        if len(clean_found) == len(found):
+            rs_offset = 1
+            # reposync was not in found, prepend a single line to pad for the
+            # <REPOSYNC> line in expected
+            found = [""] + found
+        else:
+            rs_offset = len(found) - len(clean_found)
+            # prepend empty lines to expected to pad for multiple reposync
+            # lines in found
+            expected = [""] * (rs_offset - 1) + expected
+
+    print_lines_diff(expected, found, num_lines_equal=rs_offset)
+
+    raise AssertionError("Stdout is not: %s" % context.text)
 
 
 @behave.then("stdout is")
@@ -247,3 +302,21 @@ def then_dnf_stream_is_empty(context, dnf_version, std_stream):
         then_stream_is_empty(context)
     if dnf_version == "dnf4" and not dnf5_mode:
         then_stream_is_empty(context)
+
+@behave.then("{dnf_version:dnf_version} stdout is help")
+def then_dnf_stdout_is_help(context, dnf_version):
+    """
+    Check that stdout output is help message
+    Works only if running in the appropriate mode otherwise
+    the step is skipped
+    Produce the steps:
+        then dnf4 stdout is help
+        then dnf5 stdout is help
+    """
+    dnf5_mode = hasattr(context, "dnf5_mode") and context.dnf5_mode
+    if dnf_version == "dnf5" and dnf5_mode:
+        then_stdout_is_help(context)
+    if dnf_version == "dnf4" and not dnf5_mode:
+        then_stdout_is_help(context)
+
+

--- a/dnf-behave-tests/common/output.py
+++ b/dnf-behave-tests/common/output.py
@@ -158,17 +158,20 @@ def then_stderr_matches_line_by_line(context):
     lines_match_to_regexps_line_by_line(out_lines, regexp_lines)
 
 
-@behave.then("{dnf_version:dnf_version} exit code is")
-def then_dnf_exit_code_is(context, dnf_version):
+@behave.then("{dnf_version:dnf_version} exit code is {exitcode}")
+def then_dnf_exit_code_is(context, dnf_version, exitcode):
     """
     Check for the test's exit code only if running in the
     appropriate mode otherwise the step is skipped
+    Produce the steps:
+        then dnf4 exit code is
+        then dnf5 exit code is
     """
     dnf5_mode = hasattr(context, "dnf5_mode") and context.dnf5_mode
     if dnf_version == "dnf5" and dnf5_mode:
-        then_the_exit_code_is(context)
+        then_the_exit_code_is(context, exitcode)
     if dnf_version == "dnf4" and not dnf5_mode:
-        then_the_exit_code_is(context)
+        then_the_exit_code_is(context, exitcode)
 
 
 @behave.then("{dnf_version:dnf_version} {std_stream:std_stream} is")

--- a/dnf-behave-tests/dnf/history-list-dnf5.feature
+++ b/dnf-behave-tests/dnf/history-list-dnf5.feature
@@ -1,0 +1,154 @@
+# This tests are somehow redundat for dnf4. the features
+# are tested for history command in dnf4 with feature
+# history-list.feature.
+#
+# The reason for the change is: dnf5 requires list as
+# an argument while dnf4 does not.
+#
+# Example:
+# in dnf4
+# dnf history list last-1 is the same as dnf history last-1
+# in df5
+# dnf history last-1 is not valid
+#
+# This feature file can be merged with history-list.feature
+# in the future if the behavior of history command will change
+@dnf5
+Feature: history list list
+
+Background:
+Given I use repository "dnf-ci-fedora"
+  # create some history to start with
+  And I successfully execute dnf with args "install abcde basesystem"
+  And I successfully execute dnf with args "remove abcde"
+  And I successfully execute dnf with args "install nodejs"
+
+
+Scenario: history list last-1
+ When I execute dnf with args "history list last-1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+
+
+# range tests
+Scenario: history list 1..last-1
+ When I execute dnf with args "history list 1..last-1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+
+Scenario: history list 1..last-2
+ When I execute dnf with args "history list 1..last-2"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 1  |         | Install | 6       |
+
+Scenario: history list 1..last-2
+ When I execute dnf with args "history list 1..last-2"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 1  |         | Install | 6       |
+
+Scenario: history list list 1..-1
+ When I execute dnf with args "history list 1..-1"
+ Then dnf4 exit code is 0
+  And dnf4 stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+  And dnf5 exit code is 1
+  And dnf5 stderr is
+  """
+  Invalid transaction ID range "1..-1", "ID" or "ID..ID" expected, where ID is "NUMBER", "last" or "last-NUMBER".
+  """
+
+Scenario: history list list 1..-2
+ When I execute dnf with args "history list 1..-2"
+ Then dnf4 exit code is 0
+  And dnf4 stdout is history list
+      | Id | Command | Action  | Altered |
+      | 1  |         | Install | 6       |
+  And dnf5 exit code is 1
+  And dnf5 stderr is
+  """
+  Invalid transaction ID range "1..-2", "ID" or "ID..ID" expected, where ID is "NUMBER", "last" or "last-NUMBER".
+  """
+
+Scenario: history list 2..3
+ When I execute dnf with args "history list 2..3"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+      | 2  |         | Removed | 3       |
+
+Scenario: history list 10..11
+ When I execute dnf with args "history list 10..11"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+
+Scenario: history list last..11
+ When I execute dnf with args "history list last..11"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+
+
+# "invalid" range tests
+Scenario: history list 3..2
+ When I execute dnf with args "history list 3..2"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+      | 2  |         | Removed | 3       |
+
+Scenario: history list last-1..1
+ When I execute dnf with args "history list last-1..1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 2  |         | Removed | 3       |
+      | 1  |         | Install | 6       |
+
+Scenario: history list 11..last-1
+ When I execute dnf with args "history list 11..last-1"
+ Then the exit code is 0
+  And stdout is history list
+      | Id | Command | Action  | Altered |
+      | 3  |         | Install | 5       |
+      | 2  |         | Removed | 3       |
+
+Scenario: history list last-1..aaa
+ When I execute dnf with args "history list last-1..aaa"
+ Then the exit code is 1
+  And dnf4 stderr is
+      """
+      Can't convert 'aaa' to transaction ID.
+      Use '<number>', 'last', 'last-<number>'.
+      """
+ And dnf5 stderr is
+      """
+      Invalid transaction ID range "last-1..aaa", "ID" or "ID..ID" expected, where ID is "NUMBER", "last" or "last-NUMBER".
+      """
+
+Scenario: history list 12a..bc
+ When I execute dnf with args "history list 12a..bc"
+ Then the exit code is 1
+  And dnf4 stderr is
+      """
+      Can't convert '12a' to transaction ID.
+      Use '<number>', 'last', 'last-<number>'.
+      """
+  And dnf5 stderr is
+      """
+      Invalid transaction ID range "12a..bc", "ID" or "ID..ID" expected, where ID is "NUMBER", "last" or "last-NUMBER".
+      """

--- a/dnf-behave-tests/dnf/history-list.feature
+++ b/dnf-behave-tests/dnf/history-list.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: history list
 
 Background:

--- a/dnf-behave-tests/dnf/history-list.feature
+++ b/dnf-behave-tests/dnf/history-list.feature
@@ -1,4 +1,3 @@
-@dnf5
 Feature: history list
 
 Background:
@@ -9,10 +8,11 @@ Given I use repository "dnf-ci-fedora"
   And I successfully execute dnf with args "install nodejs"
 
 
+@dnf5
 Scenario: history list
  When I execute dnf with args "history list"
  Then the exit code is 0
-  And stdout is history list
+  And dnf4 stdout is history list
       | Id | Command | Action  | Altered |
       | 3  |         | Install | 5       |
       | 2  |         | Removed | 3       |

--- a/dnf-behave-tests/dnf/history-list.feature
+++ b/dnf-behave-tests/dnf/history-list.feature
@@ -8,7 +8,6 @@ Given I use repository "dnf-ci-fedora"
   And I successfully execute dnf with args "install nodejs"
 
 
-@dnf5
 Scenario: history list
  When I execute dnf with args "history list"
  Then the exit code is 0
@@ -18,9 +17,14 @@ Scenario: history list
       | 2  |         | Removed | 3       |
       | 1  |         | Install | 6       |
 
+@dnf5
 Scenario: history
  When I execute dnf with args "history"
  Then the exit code is 0
+  And dnf5 stdout is
+  """
+  <HELP>
+  """
   And stdout is history list
       | Id | Command | Action  | Altered |
       | 3  |         | Install | 5       |

--- a/dnf-behave-tests/dnf/history-list.feature
+++ b/dnf-behave-tests/dnf/history-list.feature
@@ -11,7 +11,7 @@ Given I use repository "dnf-ci-fedora"
 Scenario: history list
  When I execute dnf with args "history list"
  Then the exit code is 0
-  And dnf4 stdout is history list
+  And stdout is history list
       | Id | Command | Action  | Altered |
       | 3  |         | Install | 5       |
       | 2  |         | Removed | 3       |
@@ -20,18 +20,20 @@ Scenario: history list
 @dnf5
 Scenario: history
  When I execute dnf with args "history"
- Then the exit code is 0
-  And dnf5 stdout is
-  """
-  <HELP>
-  """
-  And stdout is history list
+ Then dnf4 exit code is 0
+  And dnf4 stdout is history list
       | Id | Command | Action  | Altered |
       | 3  |         | Install | 5       |
       | 2  |         | Removed | 3       |
       | 1  |         | Install | 6       |
+  And dnf5 exit code is 2
+  And dnf5 stdout is
+  """
+  <HELP>
+  """
 
 
+@dnf5
 # single item tests
 Scenario: history list 2
  When I execute dnf with args "history list 2"
@@ -40,6 +42,7 @@ Scenario: history list 2
       | Id | Command | Action  | Altered |
       | 2  |         | Removed | 3       |
 
+@dnf5
 Scenario: history list last
  When I execute dnf with args "history list last"
  Then the exit code is 0
@@ -47,13 +50,20 @@ Scenario: history list last
       | Id | Command | Action  | Altered |
       | 3  |         | Install | 5       |
 
+@dnf5
 Scenario: history last
  When I execute dnf with args "history last"
- Then the exit code is 0
-  And stdout is history list
+ Then dnf4 exit code is 0
+  And dnf4 stdout is history list
       | Id | Command | Action  | Altered |
       | 3  |         | Install | 5       |
+  And dnf5 exit code is 2
+  And dnf5 stdout is
+  """
+  <HELP>
+  """
 
+@dnf5
 Scenario: history list last-1
  When I execute dnf with args "history list last-1"
  Then the exit code is 0
@@ -61,6 +71,7 @@ Scenario: history list last-1
       | Id | Command | Action  | Altered |
       | 2  |         | Removed | 3       |
 
+@not.with_dnf=5
 Scenario: history last-1
  When I execute dnf with args "history last-1"
  Then the exit code is 0
@@ -69,6 +80,7 @@ Scenario: history last-1
       | 2  |         | Removed | 3       |
 
 
+@not.with_dnf=5
 # range tests
 Scenario: history 1..last-1
  When I execute dnf with args "history 1..last-1"
@@ -78,6 +90,7 @@ Scenario: history 1..last-1
       | 2  |         | Removed | 3       |
       | 1  |         | Install | 6       |
 
+@not.with_dnf=5
 Scenario: history 1..last-2
  When I execute dnf with args "history 1..last-2"
  Then the exit code is 0
@@ -85,6 +98,7 @@ Scenario: history 1..last-2
       | Id | Command | Action  | Altered |
       | 1  |         | Install | 6       |
 
+@not.with_dnf=5
 Scenario: history 1..last-2
  When I execute dnf with args "history 1..last-2"
  Then the exit code is 0
@@ -92,6 +106,7 @@ Scenario: history 1..last-2
       | Id | Command | Action  | Altered |
       | 1  |         | Install | 6       |
 
+@not.with_dnf=5
 Scenario: history list 1..-1
  When I execute dnf with args "history 1..-1"
  Then the exit code is 0
@@ -100,6 +115,7 @@ Scenario: history list 1..-1
       | 2  |         | Removed | 3       |
       | 1  |         | Install | 6       |
 
+@not.with_dnf=5
 Scenario: history list 1..-2
  When I execute dnf with args "history 1..-2"
  Then the exit code is 0
@@ -107,6 +123,7 @@ Scenario: history list 1..-2
       | Id | Command | Action  | Altered |
       | 1  |         | Install | 6       |
 
+@not.with_dnf=5
 Scenario: history 2..3
  When I execute dnf with args "history 2..3"
  Then the exit code is 0
@@ -115,12 +132,14 @@ Scenario: history 2..3
       | 3  |         | Install | 5       |
       | 2  |         | Removed | 3       |
 
+@not.with_dnf=5
 Scenario: history 10..11
  When I execute dnf with args "history 10..11"
  Then the exit code is 0
   And stdout is history list
       | Id | Command | Action  | Altered |
 
+@not.with_dnf=5
 Scenario: history last..11
  When I execute dnf with args "history last..11"
  Then the exit code is 0
@@ -129,6 +148,7 @@ Scenario: history last..11
       | 3  |         | Install | 5       |
 
 
+@not.with_dnf=5
 # "invalid" range tests
 Scenario: history 3..2
  When I execute dnf with args "history 3..2"
@@ -138,6 +158,7 @@ Scenario: history 3..2
       | 3  |         | Install | 5       |
       | 2  |         | Removed | 3       |
 
+@not.with_dnf=5
 Scenario: history last-1..1
  When I execute dnf with args "history last-1..1"
  Then the exit code is 0
@@ -146,6 +167,7 @@ Scenario: history last-1..1
       | 2  |         | Removed | 3       |
       | 1  |         | Install | 6       |
 
+@not.with_dnf=5
 Scenario: history 11..last-1
  When I execute dnf with args "history 11..last-1"
  Then the exit code is 0
@@ -154,6 +176,7 @@ Scenario: history 11..last-1
       | 3  |         | Install | 5       |
       | 2  |         | Removed | 3       |
 
+@not.with_dnf=5
 Scenario: history last-1..aaa
  When I execute dnf with args "history last-1..aaa"
  Then the exit code is 1
@@ -163,6 +186,7 @@ Scenario: history last-1..aaa
       Use '<number>', 'last', 'last-<number>'.
       """
 
+@not.with_dnf=5
 Scenario: history 12a..bc
  When I execute dnf with args "history 12a..bc"
  Then the exit code is 1

--- a/dnf-behave-tests/dnf/steps/history.py
+++ b/dnf-behave-tests/dnf/steps/history.py
@@ -73,8 +73,25 @@ def assert_history_list(context, cmd_stdout):
 
 
 @behave.then('stdout is history list')
-def step_impl(context):
+def then_stdout_is_history_list(context):
     assert_history_list(context, context.cmd_stdout)
+
+
+@behave.then("{dnf_version:dnf_version} stdout is history list")
+def then_dnf_is_history_list(context, dnf_version):
+    """
+    Check dnf history in stdout
+    Works only if running in the appropriate mode otherwise
+    the step is skipped
+    Produce the steps:
+        then dnf4 stdout is history list
+        then dnf5 stdout is history list
+    """
+    dnf5_mode = hasattr(context, "dnf5_mode") and context.dnf5_mode
+    if dnf_version == "dnf5" and dnf5_mode:
+        then_stdout_is_history_list(context)
+    if dnf_version == "dnf4" and not dnf5_mode:
+        then_stdout_is_history_list(context)
 
 
 @behave.then('History is following')

--- a/dnf-behave-tests/dnf/steps/lib/dnf.py
+++ b/dnf-behave-tests/dnf/steps/lib/dnf.py
@@ -310,6 +310,35 @@ def parse_history_list(lines):
         result.append(dict(zip(labels, [line] + [col.strip() for col in line.split('|')])))
     return result
 
+def parse_history_list_dnf5(lines):
+    result = []
+
+    r_id = "^\s+\d+\s"
+    r_date = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+    p_id = re.compile(r_id)
+    p_date = re.compile(r_date)
+
+    for line in lines:
+        idd = p_id.findall(line)[0]
+        date = p_date.findall(line)[0]
+        #TODO finish action
+        action = ""
+        altered = line[-1:]
+        command = line.replace(idd, "")
+        command = command.replace(date, "")
+        command = command.replace(action, "")
+        command = command.replace(altered, "")
+        result.append({
+            "_line": line,
+            "id": idd.strip(),
+            "command": command.strip(),
+            "date": date.strip(),
+            "action": action.strip(),
+            "altered": altered.strip()
+        })
+    return result
+
+
 
 def parse_history_info(lines):
     result = dict()


### PR DESCRIPTION
https://github.com/rpm-software-management/dnf5/pull/26

Test coverage is partial.

- added step dnf4/5 history list is (there are still some problems on history range when is reverse)
- fixed step dnf4/5 exit code is
- added <HELP> keyword to parse help stdout (only implemented for dnf5 now)