### PR TITLE
Ensure `CQRlib` is reinstalled from `dnf-ci-fedora-updates-testing`

### DIFF
--- a/dnf-behave-tests/dnf/reinstall.feature
+++ b/dnf-behave-tests/dnf/reinstall.feature
@@ -27,6 +27,7 @@ Scenario: Reinstall an RPM from the same repository
 
 Scenario: Reinstall an RPM from different repository
   Given I use repository "dnf-ci-fedora-updates-testing"
+    And I drop repository "dnf-ci-fedora-updates"
    When I execute dnf with args "reinstall CQRlib"
    Then the exit code is 0
     And Transaction is following


### PR DESCRIPTION
Since the original repo was still available it could be used for the reinstall -> we need to drop it to ensure the newly added repo is used.

This way the test should not longer be nondeterministic.

This started failing for: https://github.com/rpm-software-management/dnf5/pull/41