### PR TITLE
[dnf5] A step for checking the history transaction records

### DIFF
--- a/dnf-behave-tests/dnf/downgrade.feature
+++ b/dnf-behave-tests/dnf/downgrade.feature
@@ -55,6 +55,14 @@ Scenario: Downgrade RPM that requires downgrade of dependency
         | glibc-all-langpacks-2.28-9.fc29.x86_64 | Dependency | dnf-ci-fedora |
         | glibc-common-2.28-9.fc29.x86_64        | Dependency | dnf-ci-fedora |
         | setup-2.12.1-1.fc29.noarch             | Dependency | dnf-ci-fedora |
+    And dnf5 transaction items for transaction "last" are
+        | action    | package                                   | reason       | repository    |
+        | Downgrade | glibc-0:2.28-9.fc29.x86_64                | User         | dnf-ci-fedora |
+        | Downgrade | glibc-common-0:2.28-9.fc29.x86_64         | Dependency   | dnf-ci-fedora |
+        | Downgrade | glibc-all-langpacks-0:2.28-9.fc29.x86_64  | Dependency   | dnf-ci-fedora |
+        | Replaced  | glibc-0:2.28-26.fc29.x86_64               | User         | @System       |
+        | Replaced  | glibc-all-langpacks-0:2.28-26.fc29.x86_64 | Dependency   | @System       |
+        | Replaced  | glibc-common-0:2.28-26.fc29.x86_64        | Dependency   | @System       |
 
 
 @dnf5
@@ -73,6 +81,10 @@ Scenario: Downgrade a package that was installed via rpm
     And package state is
         | package                  | reason        | from_repo             |
         | flac-1.3.3-2.fc29.x86_64 | External User | dnf-ci-fedora-updates |
+    And dnf5 transaction items for transaction "last" are
+        | action    | package                    | reason        | repository            |
+        | Downgrade | flac-0:1.3.3-2.fc29.x86_64 | External User | dnf-ci-fedora-updates |
+        | Replaced  | flac-0:1.3.3-3.fc29.x86_64 | External User | @System               |
 
 
 # @dnf5

--- a/dnf-behave-tests/dnf/install-obsoletes.feature
+++ b/dnf-behave-tests/dnf/install-obsoletes.feature
@@ -12,6 +12,9 @@ Scenario: Install an obsoleted RPM
     And package state is
         | package                       | reason | from_repo         |
         | glibc-profile-2.3.1-10.x86_64 | User   | dnf-ci-thirdparty |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                         | reason     | repository        |
+        | Install | glibc-profile-0:2.3.1-10.x86_64 | User       | dnf-ci-thirdparty |
 
 
 @dnf5
@@ -36,6 +39,14 @@ Scenario: Install an obsoleted RPM when the obsoleting RPM is available
         | basesystem-11-6.fc29.noarch            | Dependency | dnf-ci-fedora |
         | glibc-common-2.28-9.fc29.x86_64        | Dependency | dnf-ci-fedora |
         | glibc-all-langpacks-2.28-9.fc29.x86_64 | Dependency | dnf-ci-fedora |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                                  | reason     | repository    |
+        | Install | glibc-0:2.28-9.fc29.x86_64               | User       | dnf-ci-fedora |
+        | Install | basesystem-0:11-6.fc29.noarch            | Dependency | dnf-ci-fedora |
+        | Install | glibc-common-0:2.28-9.fc29.x86_64        | Dependency | dnf-ci-fedora |
+        | Install | filesystem-0:3.9-2.fc29.x86_64           | Dependency | dnf-ci-fedora |
+        | Install | setup-0:2.12.1-1.fc29.noarch             | Dependency | dnf-ci-fedora |
+        | Install | glibc-all-langpacks-0:2.28-9.fc29.x86_64 | Dependency | dnf-ci-fedora |
 
 
 @bz1672618

--- a/dnf-behave-tests/dnf/install-remove.feature
+++ b/dnf-behave-tests/dnf/install-remove.feature
@@ -16,6 +16,10 @@ Scenario Outline: Install remove <spec type> that requires only name
         | package             | reason     | from_repo             |
         | tea-1.0-1.x86_64    | User       | dnf-ci-install-remove |
         | water-1.0-1.x86_64  | Dependency | dnf-ci-install-remove |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package            | reason     | repository            |
+        | Install | tea-0:1.0-1.x86_64   | User       | dnf-ci-install-remove |
+        | Install | water-0:1.0-1.x86_64 | Dependency | dnf-ci-install-remove |
    When I execute dnf with args "install tea"
    Then the exit code is 0
     And Transaction is empty
@@ -46,6 +50,11 @@ Scenario: Install remove package via rpm
         | basesystem-11-6.fc29.noarch  | User       | dnf-ci-fedora |
         | filesystem-3.9-2.fc29.x86_64 | User       | dnf-ci-fedora |
         | setup-2.12.1-1.fc29.noarch   | Dependency | dnf-ci-fedora |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                        | reason     | repository    |
+        | Install | basesystem-0:11-6.fc29.noarch  | User       | dnf-ci-fedora |
+        | Install | filesystem-0:3.9-2.fc29.x86_64 | User       | dnf-ci-fedora |
+        | Install | setup-0:2.12.1-1.fc29.noarch   | Dependency | dnf-ci-fedora |
   Given I successfully execute rpm with args "-e basesystem filesystem setup"
    When I execute dnf with args "install basesystem"
    Then the exit code is 0
@@ -59,6 +68,11 @@ Scenario: Install remove package via rpm
         | basesystem-11-6.fc29.noarch  | User       | dnf-ci-fedora |
         | filesystem-3.9-2.fc29.x86_64 | Dependency | dnf-ci-fedora |
         | setup-2.12.1-1.fc29.noarch   | Dependency | dnf-ci-fedora |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                        | reason     | repository    |
+        | Install | basesystem-0:11-6.fc29.noarch  | User       | dnf-ci-fedora |
+        | Install | filesystem-0:3.9-2.fc29.x86_64 | Dependency | dnf-ci-fedora |
+        | Install | setup-0:2.12.1-1.fc29.noarch   | Dependency | dnf-ci-fedora |
 
 
 # coffee requires water and sugar == 1
@@ -173,6 +187,9 @@ Scenario: Install a package that was already installed via rpm
     And package state is
         | package             | reason | from_repo             |
         | water-1.0-1.x86_64  | User   | dnf-ci-install-remove |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package              | reason     | repository    |
+        | Install | water-0:1.0-1.x86_64 | User       | dnf-ci-fedora |
 
 
 # @dnf5

--- a/dnf-behave-tests/dnf/installonly.feature
+++ b/dnf-behave-tests/dnf/installonly.feature
@@ -37,6 +37,10 @@ Scenario: Install multiple versions of an installonly package with a limit of 2
         | package                             | reason | from_repo                     |
         | kernel-core-4.19.15-300.fc29.x86_64 | User   | dnf-ci-fedora-updates         |
         | kernel-core-4.20.6-300.fc29.x86_64  | User   | dnf-ci-fedora-updates-testing |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason | repository                    |
+        | Install | kernel-core-0:4.20.6-300.fc29.x86_64  | User   | dnf-ci-fedora-updates-testing |
+        | Remove  | kernel-core-0:4.18.16-300.fc29.x86_64 | User   | @System                       |
 
 @dnf5
 Scenario: Install and remove multiple versions of an installonly package
@@ -57,6 +61,9 @@ Scenario: Install and remove multiple versions of an installonly package
         | package                             | reason | from_repo             |
         | kernel-core-4.18.16-300.fc29.x86_64 | User   | dnf-ci-fedora         |
         | kernel-core-4.19.15-300.fc29.x86_64 | User   | dnf-ci-fedora-updates |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason | repository            |
+        | Install | kernel-core-0:4.19.15-300.fc29.x86_64 | User   | dnf-ci-fedora-updates |
    When I execute dnf with args "remove kernel-core"
    Then the exit code is 0
     And Transaction is following
@@ -65,6 +72,10 @@ Scenario: Install and remove multiple versions of an installonly package
         | remove        | kernel-core-0:4.18.16-300.fc29.x86_64 |
     And package state is
         | package | reason | from_repo |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason | repository |
+        | Remove  | kernel-core-0:4.18.16-300.fc29.x86_64 | User   | @System    |
+        | Remove  | kernel-core-0:4.19.15-300.fc29.x86_64 | User   | @System    |
 
 @dnf5
 @bz1769788
@@ -77,6 +88,9 @@ Scenario: Install multiple versions of an installonly package and keep reason
     And package state is
         | package                             | reason | from_repo             |
         | kernel-core-4.18.16-300.fc29.x86_64 | User   | dnf-ci-fedora         |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason | repository    |
+        | Install | kernel-core-0:4.18.16-300.fc29.x86_64 | User   | dnf-ci-fedora |
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade --nobest"
    Then the exit code is 0
@@ -88,6 +102,9 @@ Scenario: Install multiple versions of an installonly package and keep reason
         | package                             | reason | from_repo             |
         | kernel-core-4.18.16-300.fc29.x86_64 | User   | dnf-ci-fedora         |
         | kernel-core-4.19.15-300.fc29.x86_64 | User   | dnf-ci-fedora-updates |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason | repository            |
+        | Install | kernel-core-0:4.19.15-300.fc29.x86_64 | User   | dnf-ci-fedora-updates |
    When I execute dnf with args "autoremove"
    Then the exit code is 0
     And Transaction is empty
@@ -184,6 +201,9 @@ Scenario: Do not autoremove kernel after upgrade with --best
     And package state is
         | package                             | reason        | from_repo             |
         | kernel-core-4.19.15-300.fc29.x86_64 | External User | dnf-ci-fedora-updates |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason        | repository            |
+        | Install | kernel-core-0:4.19.15-300.fc29.x86_64 | External User | dnf-ci-fedora-updates |
    When I execute dnf with args "autoremove"
    Then the exit code is 0
     And Transaction is empty
@@ -212,6 +232,9 @@ Scenario: Do not autoremove kernel after upgrade with --nobest
     And package state is
         | package                             | reason        | from_repo             |
         | kernel-core-4.19.15-300.fc29.x86_64 | External User | dnf-ci-fedora-updates |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason        | repository            |
+        | Install | kernel-core-0:4.19.15-300.fc29.x86_64 | External User | dnf-ci-fedora-updates |
    When I execute dnf with args "autoremove"
    Then the exit code is 0
     And Transaction is empty
@@ -243,6 +266,9 @@ Scenario: Do not remove or change reason after remove of one of installonly pack
         | package                             | reason | from_repo             |
         | kernel-core-4.18.16-300.fc29.x86_64 | User   | dnf-ci-fedora         |
         | kernel-core-4.19.15-300.fc29.x86_64 | User   | dnf-ci-fedora-updates |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason | repository            |
+        | Install | kernel-core-0:4.19.15-300.fc29.x86_64 | User   | dnf-ci-fedora-updates |
    When I execute dnf with args "remove kernel-core-0:4.19.15-300.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -255,6 +281,9 @@ Scenario: Do not remove or change reason after remove of one of installonly pack
     And package state is
         | package                             | reason | from_repo             |
         | kernel-core-4.18.16-300.fc29.x86_64 | User   | dnf-ci-fedora         |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason | repository |
+        | Remove  | kernel-core-0:4.19.15-300.fc29.x86_64 | User   | @System    |
 
 
 @dnf5
@@ -279,6 +308,9 @@ Scenario: Keep reason for installonly packages
         | kernel-core-4.18.16-300.fc29.x86_64    | unknown         |
     And package state is
         | package | reason | from_repo |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                               | reason | repository |
+        | Remove  | kernel-core-0:4.19.15-300.fc29.x86_64 | User   | @System    |
    When I execute dnf with args "autoremove"
    Then the exit code is 0
     And Transaction is empty

--- a/dnf-behave-tests/dnf/obsoletes.feature
+++ b/dnf-behave-tests/dnf/obsoletes.feature
@@ -22,6 +22,9 @@ Scenario: Install of obsoleted package, but higher version than obsoleted presen
     And package state is
         | package               | reason | from_repo        |
         | PackageA-3.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                 | reason | repository       |
+        | Install | PackageA-0:3.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 @dnf5
@@ -37,6 +40,9 @@ Scenario: Install of obsoleting package, even though higher version than obsolet
     And package state is
         | package                         | reason | from_repo        |
         | PackageA-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                           | reason | repository       |
+        | Install | PackageA-Obsoleter-0:1.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 # @dnf5
@@ -64,9 +70,13 @@ Scenario: Install of obsoleting package using upgrade command, when obsoleted pa
     And package state is
         | package                         | reason | from_repo        |
         | PackageA-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                           | reason | repository       |
+        | Install  | PackageA-Obsoleter-0:1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+        | Replaced | PackageE-0:1.0-1.x86_64           | User   | @System          |
 
 @dnf5
-# TODO(lukash) passes with reason = User, but correct outcome is reason = None
+# TODO(lukash) passes with reason = User, but correct outcome is reason = External User
 Scenario: Obsoleting a package that was installed via rpm, with --best
    When I execute rpm with args "-i --nodeps {context.scenario.repos_location}/dnf-ci-obsoletes/x86_64/PackageB-1.0-1.x86_64.rpm"
    Then the exit code is 0
@@ -79,6 +89,10 @@ Scenario: Obsoleting a package that was installed via rpm, with --best
     And package state is
         | package                         | reason | from_repo        |
         | PackageB-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                           | reason        | repository       |
+        | Install  | PackageB-Obsoleter-0:1.0-1.x86_64 | User          | dnf-ci-obsoletes |
+        | Replaced | PackageB-0:1.0-1.x86_64           | External User | @System          |
 
 @dnf5
 Scenario: Obsoleting a package that was installed via rpm, with --nobest
@@ -93,6 +107,10 @@ Scenario: Obsoleting a package that was installed via rpm, with --nobest
     And package state is
         | package                         | reason        | from_repo        |
         | PackageB-Obsoleter-1.0-1.x86_64 | External User | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                           | reason        | repository       |
+        | Install  | PackageB-Obsoleter-0:1.0-1.x86_64 | External User | dnf-ci-obsoletes |
+        | Replaced | PackageB-0:1.0-1.x86_64           | External User | @System          |
 
 @dnf5
 @bz1818118
@@ -111,6 +129,10 @@ Scenario: Install of obsoleting package from commandline using upgrade command, 
     And package state is
         | package                         | reason | from_repo    |
         | PackageA-Obsoleter-1.0-1.x86_64 | User   | @commandline |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                           | reason | repository   |
+        | Install  | PackageA-Obsoleter-0:1.0-1.x86_64 | User   | @commandline |
+        | Replaced | PackageE-0:1.0-1.x86_64           | User   | @System      |
 
 @dnf5
 Scenario: Upgrade of obsoleted package by package of higher version than obsoleted
@@ -127,6 +149,10 @@ Scenario: Upgrade of obsoleted package by package of higher version than obsolet
     And package state is
         | package               | reason | from_repo        |
         | PackageA-3.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                 | reason | repository       |
+        | Upgrade  | PackageA-0:3.0-1.x86_64 | User   | dnf-ci-obsoletes |
+        | Replaced | PackageA-0:1.0-1.x86_64 | User   | @System          |
 
 
 @dnf5
@@ -139,6 +165,9 @@ Scenario: Install of obsoleted package
     And package state is
         | package                         | reason | from_repo        |
         | PackageB-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                           | reason | repository       |
+        | Install | PackageB-Obsoleter-0:1.0-1.x86_64 | User   | dnf-ci-obsoletes |
 
 
 @dnf5
@@ -157,6 +186,10 @@ Scenario: Upgrade of obsoleted package
     And package state is
         | package                         | reason | from_repo        |
         | PackageB-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                           | reason | repository       |
+        | Install  | PackageB-Obsoleter-0:1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+        | Replaced | PackageB-0:1.0-1.x86_64           | User   | @System          |
 
 
 @dnf5
@@ -174,6 +207,10 @@ Scenario: Upgrade of obsoleted package if package specified by version with glob
     And package state is
         | package               | reason | from_repo        |
         | PackageB-2.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                 | reason | repository       |
+        | Upgrade  | PackageB-0:2.0-1.x86_64 | User   | dnf-ci-obsoletes |
+        | Replaced | PackageB-0:1.0-1.x86_64 | User   | @System          |
 
 
 @xfail @bz1672618
@@ -209,6 +246,10 @@ Scenario: Autoremoval of obsoleted package
     And package state is
         | package                         | reason | from_repo        |
         | PackageB-Obsoleter-1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                           | reason | repository       |
+        | Install  | PackageB-Obsoleter-0:1.0-1.x86_64 | User   | dnf-ci-obsoletes |
+        | Replaced | PackageB-0:1.0-1.x86_64           | User   | @System          |
    When I execute dnf with args "autoremove"
    Then the exit code is 0
     But Transaction is empty

--- a/dnf-behave-tests/dnf/reinstall.feature
+++ b/dnf-behave-tests/dnf/reinstall.feature
@@ -23,6 +23,10 @@ Scenario: Reinstall an RPM from the same repository
         | package                           | reason     | from_repo             |
         | CQRlib-devel-1.1.2-16.fc29.x86_64 | User       | dnf-ci-fedora         |
         | CQRlib-1.1.2-16.fc29.x86_64       | Dependency | dnf-ci-fedora-updates |
+    And dnf5 transaction items for transaction "last" are
+        | action    | package                       | reason     | repository            |
+        | Reinstall | CQRlib-0:1.1.2-16.fc29.x86_64 | Dependency | dnf-ci-fedora-updates |
+        | Replaced  | CQRlib-0:1.1.2-16.fc29.x86_64 | Dependency | @System               |
 
 
 Scenario: Reinstall an RPM from different repository
@@ -37,6 +41,10 @@ Scenario: Reinstall an RPM from different repository
         | package                           | reason     | from_repo                     |
         | CQRlib-devel-1.1.2-16.fc29.x86_64 | User       | dnf-ci-fedora                 |
         | CQRlib-1.1.2-16.fc29.x86_64       | Dependency | dnf-ci-fedora-updates-testing |
+    And dnf5 transaction items for transaction "last" are
+        | action    | package                       | reason     | repository                    |
+        | Reinstall | CQRlib-0:1.1.2-16.fc29.x86_64 | Dependency | dnf-ci-fedora-updates-testing |
+        | Replaced  | CQRlib-0:1.1.2-16.fc29.x86_64 | Dependency | @System                       |
 
 
 Scenario: Reinstall an RPM that is not available

--- a/dnf-behave-tests/dnf/remove-pkgspec.feature
+++ b/dnf-behave-tests/dnf/remove-pkgspec.feature
@@ -29,6 +29,14 @@ Scenario Outline: Remove an RPM by <pkgspec-type>
         | remove-unused | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
     And package state is
         | package | reason | from_repo |
+    And dnf5 transaction items for transaction "last" are
+        | action | package                                  | reason | repository |
+        | Remove | basesystem-0:11-6.fc29.noarch            | Clean  | @System    |
+        | Remove | filesystem-0:3.9-2.fc29.x86_64           | Clean  | @System    |
+        | Remove | glibc-0:2.28-9.fc29.x86_64               | User   | @System    |
+        | Remove | glibc-all-langpacks-0:2.28-9.fc29.x86_64 | Clean  | @System    |
+        | Remove | glibc-common-0:2.28-9.fc29.x86_64        | Clean  | @System    |
+        | Remove | setup-0:2.12.1-1.fc29.noarch             | Clean  | @System    |
 
 @tier1
 Examples: Name


### PR DESCRIPTION
Adds transaction history tests for all scenarios that test the system state, meaning both system state and the transaction history are tested to be correct and consistent for these scenarios.

Requires: https://github.com/rpm-software-management/dnf5/pull/53