### PR TITLE
createrepo_c: using a dnf command: disable plugins and use installroot

### DIFF
--- a/dnf-behave-tests/createrepo_c/bad-packages.feature
+++ b/dnf-behave-tests/createrepo_c/bad-packages.feature
@@ -40,7 +40,7 @@ Given I create symlink "/createrepo_c-ci-packages" to file "/{context.scenario.r
  When I execute createrepo_c with args "--update ." in "/"
  Then the exit code is 0
   And repodata "/repodata" are consistent
-  And I execute "dnf --repofrompath=test,{context.scenario.default_tmp_dir}/ --repo test repoquery --provides ampersand-provide-package"
+  And I execute "dnf --repofrompath=test,{context.scenario.default_tmp_dir}/ --installroot={context.scenario.default_tmp_dir} --disableplugin='*' --repo test repoquery --provides ampersand-provide-package"
   And stdout is
   """
   ampersand-provide-package = 0.2.1-1.fc29


### PR DESCRIPTION
This prevents fails when the host system has specific dnf configuration (such as using subscription manager) and it prints additional messeages to stdout.