### PR TITLE
Run upgrade before distro-sync in case there is a new dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN set -x && \
 RUN set -x && \
     if [ "$TYPE" == "nightly" ]; then \
         dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
+        # run upgrade before distro-sync in case there is a new version in dnf-nightly that has a new dependency
+        dnf -y upgrade; \
         dnf -y distro-sync --repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly; \
     fi
 


### PR DESCRIPTION
If dnf-nighly has a new version that has a new dependency the distory-sync will fail because it is limited to the dnf-nightly repo.

Lets keep the distro-sync command even though it will mostly do nothing but there could teoretically be a situation where the fedora repo has newer packages than nighly and since we are running in a nightly mode we want to make sure we have nighly packages.