### PR TITLE
Switch CI to Fedora 37, to fix failing container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # $ podman build --build-arg TYPE=distro -t ci-dnf-stack -f Dockerfile
 # $ podman run --net none -it ci-dnf-stack behave dnf
 
-ARG BASE=fedora:36
+ARG BASE=fedora:37
 FROM $BASE
 
 ENV LANG C.UTF-8

--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -2,7 +2,7 @@
 # $ podman build --build-arg TYPE=distro -t ansible -f Dockerfile.ansible
 # $ podman run --net none -it ansible ./ansible
 
-FROM fedora:36
+FROM fedora:37
 ARG TYPE=nightly
 
 # enable nightlies if requested

--- a/dnf-behave-tests/dnf/ssl.feature
+++ b/dnf-behave-tests/dnf/ssl.feature
@@ -73,7 +73,7 @@ Scenario: Installing a package using nonexistent client cert should fail
     And stderr matches line by line
     """
     Errors during downloading metadata for repository 'dnf-ci-fedora':
-      - Curl error \(58\): Problem with the local SSL certificate for https://localhost:[0-9]+/repodata/repomd.xml \[could not load PEM client certificate, OpenSSL error error:[0-9]+:system library:.*:No such file or directory, \(no key found, wrong pass phrase, or wrong file format\?\)\]
+      - Curl error \(58\): Problem with the local SSL certificate for https://localhost:[0-9]+/repodata/repomd.xml \[could not load PEM client certificate from .*/nonexistent.pem, OpenSSL error error:[0-9]+:system library:.*:No such file or directory, \(no key found, wrong pass phrase, or wrong file format\?\)\]
     Error: Failed to download metadata for repo 'dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
     """
 


### PR DESCRIPTION
The container is failing to build because new dnf since PR: https://github.com/rpm-software-management/dnf/pull/1854 uses rpm API to block signals.

However the call to unblock `rpm.blockSignals(False)` also polled for caught signals and terminated on `SIGPIPE`. DNF wants to ignore `SIGPIPE` - it has overridden handler for it to do nothing but rpm doesn't know this.

During `podman build` the `SIGPIPE` is received and rpm terminates the run with exit code 141 which fails the build. 

New version of rpm-4.18.0 removes the polling, since PR: https://github.com/rpm-software-management/rpm/pull/1992 this is present in Fedora 37.

Fedora 37 is not released yet but should be very soon (current plan is 2022-10-25).