### PR TITLE
Drop autoremove related tests for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/installonly.feature
+++ b/dnf-behave-tests/dnf/installonly.feature
@@ -286,7 +286,8 @@ Scenario: Do not remove or change reason after remove of one of installonly pack
         | Remove  | kernel-core-0:4.19.15-300.fc29.x86_64 | User   | @System    |
 
 
-@dnf5
+# TODO(jkolarik): autoremove not yet available in dnf5
+# @dnf5
 @bz1934499
 @bz1921063
 Scenario: Keep reason for installonly packages

--- a/dnf-behave-tests/dnf/obsoletes.feature
+++ b/dnf-behave-tests/dnf/obsoletes.feature
@@ -233,7 +233,8 @@ Scenario: Keep reason of obsoleted package
         | PackageB-Obsoleter-1.0-1 | dependency |
 
 
-@dnf5
+# TODO(jkolarik): autoremove not yet available in dnf5
+# @dnf5
 Scenario: Autoremoval of obsoleted package
    When I execute dnf with args "install PackageB-1.0"
    Then the exit code is 0


### PR DESCRIPTION
When `--unneeded` option will be dropped for now, as its alias for the previous `dnf autoremove` behavior we also need to take care of related tests.

Related PR: https://github.com/rpm-software-management/dnf5/pull/109