### PR TITLE
offline-upgrade: Add security filters tests

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/offline-upgrade-security-filters.feature
+++ b/dnf-behave-tests/dnf/plugins-core/offline-upgrade-security-filters.feature
@@ -1,0 +1,341 @@
+Feature: Test the security filters for offline-upgrade commands
+
+
+Background:
+  Given I enable plugin "system-upgrade"
+    And I use repository "dnf-ci-fedora"
+
+
+@bz1939975
+Scenario: Test advisory filter with offline-upgrade
+Given I execute dnf with args "install glibc flac"
+ Then the exit code is 0
+Given I use repository "dnf-ci-fedora-updates"
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package               Arch     Version           Repository               Size
+      ================================================================================
+      Upgrading:
+       flac                  x86_64   1.3.3-3.fc29      dnf-ci-fedora-updates   6.4 k
+       glibc                 x86_64   2.28-26.fc29      dnf-ci-fedora-updates    11 k
+       glibc-all-langpacks   x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.3 k
+       glibc-common          x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.4 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  4 Packages
+      """
+ When I execute dnf with args "offline-upgrade download --advisory FEDORA-2018-318f184000"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package               Arch     Version           Repository               Size
+      ================================================================================
+      Upgrading:
+       glibc                 x86_64   2.28-26.fc29      dnf-ci-fedora-updates    11 k
+       glibc-all-langpacks   x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.3 k
+       glibc-common          x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.4 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  3 Packages
+      """
+
+
+@bz1939975
+Scenario: Test bugfix filter with offline-upgrade
+Given I use repository "dnf-ci-fedora-updates"
+  And I execute dnf with args "install flac-1.3.2 kernel-4.18.16"
+ Then the exit code is 0
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package           Arch      Version             Repository                Size
+      ================================================================================
+      Installing:
+       kernel            x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates    6.2 k
+      Upgrading:
+       flac              x86_64    1.3.3-3.fc29        dnf-ci-fedora-updates    6.4 k
+      Installing dependencies:
+       kernel-core       x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates     51 k
+       kernel-modules    x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates     47 k
+      
+      Transaction Summary
+      ================================================================================
+      Install  3 Packages
+      Upgrade  1 Package
+
+      """
+ When I execute dnf with args "offline-upgrade download --bugfix"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package           Arch      Version             Repository                Size
+      ================================================================================
+      Installing:
+       kernel            x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates    6.2 k
+      Installing dependencies:
+       kernel-core       x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates     51 k
+       kernel-modules    x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates     47 k
+      
+      Transaction Summary
+      ================================================================================
+      Install  3 Packages
+      """
+
+
+@bz1939975
+Scenario: Test bz filter with offline-upgrade
+Given I execute dnf with args "install glibc flac"
+ Then the exit code is 0
+Given I use repository "dnf-ci-fedora-updates"
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package               Arch     Version           Repository               Size
+      ================================================================================
+      Upgrading:
+       flac                  x86_64   1.3.3-3.fc29      dnf-ci-fedora-updates   6.4 k
+       glibc                 x86_64   2.28-26.fc29      dnf-ci-fedora-updates    11 k
+       glibc-all-langpacks   x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.3 k
+       glibc-common          x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.4 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  4 Packages
+      """
+ When I execute dnf with args "offline-upgrade download --bz=222"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package               Arch     Version           Repository               Size
+      ================================================================================
+      Upgrading:
+       glibc                 x86_64   2.28-26.fc29      dnf-ci-fedora-updates    11 k
+       glibc-all-langpacks   x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.3 k
+       glibc-common          x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.4 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  3 Packages
+      """
+
+
+@bz1939975
+Scenario: Test cve filter with offline-upgrade
+Given I execute dnf with args "install glibc flac"
+ Then the exit code is 0
+Given I use repository "dnf-ci-fedora-updates"
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package               Arch     Version           Repository               Size
+      ================================================================================
+      Upgrading:
+       flac                  x86_64   1.3.3-3.fc29      dnf-ci-fedora-updates   6.4 k
+       glibc                 x86_64   2.28-26.fc29      dnf-ci-fedora-updates    11 k
+       glibc-all-langpacks   x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.3 k
+       glibc-common          x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.4 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  4 Packages
+      """
+ When I execute dnf with args "offline-upgrade download --cve=CVE-2999"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package               Arch     Version           Repository               Size
+      ================================================================================
+      Upgrading:
+       glibc                 x86_64   2.28-26.fc29      dnf-ci-fedora-updates    11 k
+       glibc-all-langpacks   x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.3 k
+       glibc-common          x86_64   2.28-26.fc29      dnf-ci-fedora-updates   6.4 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  3 Packages
+      """
+
+
+@bz1939975
+Scenario: Test enhancement filter with offline-upgrade
+Given I use repository "dnf-ci-fedora-updates"
+  And I use repository "enhancement-test"
+  And I execute dnf with args "install flac-1.3.2 kernel-4.18.16"
+ Then the exit code is 0
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package           Arch      Version             Repository                Size
+      ================================================================================
+      Installing:
+       kernel            x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates    6.2 k
+      Upgrading:
+       flac              x86_64    1.3.9-1.fc29        enhancement-test         6.4 k
+      Installing dependencies:
+       kernel-core       x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates     51 k
+       kernel-modules    x86_64    4.19.15-300.fc29    dnf-ci-fedora-updates     47 k
+      
+      Transaction Summary
+      ================================================================================
+      Install  3 Packages
+      Upgrade  1 Package
+
+      """
+ When I execute dnf with args "offline-upgrade download --enhancement"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package     Architecture  Version                Repository               Size
+      ================================================================================
+      Upgrading:
+       flac        x86_64        1.3.9-1.fc29           enhancement-test        6.4 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  1 Package
+      """
+
+
+@bz1939975
+Scenario: Test newpackage filter with offline-upgrade
+Given I use repository "dnf-ci-fedora-updates"
+  And I use repository "newpackage-test"
+  And I execute dnf with args "install flac-1.3.2 somepackage-1.0"
+ Then the exit code is 0
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package         Arch       Version             Repository                 Size
+      ================================================================================
+      Upgrading:
+       flac            x86_64     1.3.3-3.fc29        dnf-ci-fedora-updates     6.4 k
+       somepackage     x86_64     1.1-1               newpackage-test           6.0 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  2 Packages
+      """
+ When I execute dnf with args "offline-upgrade download --newpackage"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package             Architecture   Version       Repository               Size
+      ================================================================================
+      Upgrading:
+       somepackage         x86_64         1.1-1         newpackage-test         6.0 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  1 Package
+      """
+
+
+@bz1939975
+Scenario: Test security filter with offline-upgrade
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install dracut-1-1 B-1-1"
+ Then the exit code is 0
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package         Architecture    Version        Repository                 Size
+      ================================================================================
+      Upgrading:
+       B               x86_64          2-2            security-upgrade          6.0 k
+       dracut          x86_64          2-2            security-upgrade          6.0 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  2 Packages
+      """
+ When I execute dnf with args "offline-upgrade download --security"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package     Architecture     Version          Repository                  Size
+      ================================================================================
+      Upgrading:
+       B           x86_64           2-2              security-upgrade           6.0 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  1 Package
+      """
+
+
+@bz1939975
+Scenario: Test security severity filter with offline-upgrade
+Given I use repository "dnf-ci-security"
+  And I execute dnf with args "install bugfix_B-1.0-1 advisory_B-1.0-3 security_A-1.0-1"
+ Then the exit code is 0
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package            Architecture   Version        Repository               Size
+      ================================================================================
+      Upgrading:
+       advisory_B         x86_64         1.0-4          dnf-ci-security         6.0 k
+       bugfix_B           x86_64         1.0-2          dnf-ci-security         6.0 k
+       security_A         x86_64         1.0-4          dnf-ci-security         6.0 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  3 Packages
+      """
+ When I execute dnf with args "offline-upgrade download --secseverity=Critical"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package            Architecture   Version        Repository               Size
+      ================================================================================
+      Upgrading:
+       advisory_B         x86_64         1.0-4          dnf-ci-security         6.0 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  1 Package
+      """
+

--- a/dnf-behave-tests/dnf/plugins-core/offline-upgrade-security-filters.feature
+++ b/dnf-behave-tests/dnf/plugins-core/offline-upgrade-security-filters.feature
@@ -339,3 +339,42 @@ Given I use repository "dnf-ci-security"
       Upgrade  1 Package
       """
 
+
+@bz1939975
+Scenario: Test security severity filter with offline-upgrade when higher version of a package is available
+Given I use repository "dnf-ci-security"
+  And I execute dnf with args "install bugfix_B-1.0-1 advisory_B-1.0-3 security_A-1.0-1"
+ Then the exit code is 0
+ When I execute dnf with args "offline-upgrade download"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package            Architecture   Version        Repository               Size
+      ================================================================================
+      Upgrading:
+       advisory_B         x86_64         1.0-4          dnf-ci-security         6.0 k
+       bugfix_B           x86_64         1.0-2          dnf-ci-security         6.0 k
+       security_A         x86_64         1.0-4          dnf-ci-security         6.0 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  3 Packages
+      """
+ When I execute dnf with args "offline-upgrade download --secseverity=Moderate"
+ Then the exit code is 0
+  And stdout contains lines
+      """
+      Dependencies resolved.
+      ================================================================================
+       Package            Architecture   Version        Repository               Size
+      ================================================================================
+      Upgrading:
+       security_A         x86_64         1.0-3          dnf-ci-security         6.0 k
+      
+      Transaction Summary
+      ================================================================================
+      Upgrade  1 Package
+      """
+

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-security/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-security/updateinfo.xml
@@ -84,6 +84,7 @@
     <update from="dnf-testing@redhat.com" status="stable" type="security" severity="low" version="1">
         <id>DNF-2019-1</id>
         <title>security_A-1.0-2</title>
+        <severity>Low</severity>
         <release>Fedora 29</release>
         <issue date="2019-02-22 15:30:01" />
         <references>
@@ -102,6 +103,7 @@
     <update from="dnf-testing@redhat.com" status="stable" type="security" severity="moderate" version="1">
         <id>DNF-2019-2</id>
         <title>security_A-1.0-3</title>
+        <severity>Moderate</severity>
         <release>Fedora 29</release>
         <issue date="2019-02-22 15:30:01" />
         <references>

--- a/dnf-behave-tests/fixtures/specs/enhancement-test/flac-1.3.9-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/enhancement-test/flac-1.3.9-1.fc29.spec
@@ -1,0 +1,35 @@
+Name: flac
+Version: 1.3.9
+Release: 1%{?dist}
+Summary: An encoder/decoder for the Free Lossless Audio Codec
+
+License: BSD and GPLv2+ and GFDL
+URL: http://www.xiph.org/flac/
+
+%description
+FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+the stream format, reference encoders and decoders in library form,
+flac, a command-line program to encode and decode FLAC files, metaflac,
+a command-line metadata editor for FLAC files and input plugins for
+various music players.
+
+This package contains the command-line tools and documentation.
+
+%package libs
+Summary: Libraries for the Free Lossless Audio Codec
+
+%description libs
+FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+the stream format, reference encoders and decoders in library form,
+flac, a command-line program to encode and decode FLAC files, metaflac,
+a command-line metadata editor for FLAC files and input plugins for
+various music players.
+This package contains the FLAC libraries.
+
+%files
+
+%files libs
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/enhancement-test/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/enhancement-test/updateinfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="secresponseteam@foo.bar" status="final" type="enhancement" version="3">
+        <id>FEDORA-2999:002-03</id>
+        <title>flac enhacements</title>
+        <issued date="2019-01-17 00:00:00"/>
+        <updated date="2019-01-17 00:00:00"/>
+        <severity>Moderate</severity>
+        <summary>summary_1</summary>
+        <description>Enhance some stuff</description>
+        <references>
+            <reference href="https://foobar/foobarupdate_1" id="1" type="self" title="update_1"/>
+        </references>
+        <pkglist>
+        <collection short="named collection">
+            <name>Bar component</name>
+            <package name="flac" version="1.3.3" release="3.fc29" epoch="0" arch="x86_64" src="flac-0:1.3.3-3.fc29.x86_64.rpm">
+            <filename>flac-0:1.3.3-3.fc29.x86_64.rpm</filename>
+            <reboot_suggested/>
+            </package>
+        </collection>
+        </pkglist>
+  </update>
+</updates>

--- a/dnf-behave-tests/fixtures/specs/newpackage-test/newpackage_A-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/newpackage-test/newpackage_A-1-1.spec
@@ -1,0 +1,17 @@
+Name:           newpackage_A
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory newpackage options
+
+Requires:       somepackage = 1.1
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/newpackage-test/somepackage-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/newpackage-test/somepackage-1.0-1.spec
@@ -1,0 +1,15 @@
+Name:           somepackage
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory newpackage options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/newpackage-test/somepackage-1.1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/newpackage-test/somepackage-1.1-1.spec
@@ -1,0 +1,15 @@
+Name:           somepackage
+Version:        1.1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory newpackage options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/newpackage-test/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/newpackage-test/updateinfo.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="newpackage" version="1">
+        <id>DNF-NEWPACKAGE-001</id>
+        <title>newpackage_A advisory</title>
+        <release>Fedora 29</release>
+        <issue date="2019-01-01 10:00:00" />
+        <references />
+        <description>testing advisory</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="newpackage_A" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>newpackage_A-1-1.x86_64.rpm</filename>
+                </package>
+                <package name="somepackage" version="1.1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>somepackage-1.1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>


### PR DESCRIPTION
Add security filters tests for the `offline-upgrade` command.

Requires PR: https://github.com/rpm-software-management/dnf-plugins-core/pull/465