### PR TITLE
Adjust "strip_reposync_dnf5" - remove num widget check from regex

### DIFF
--- a/dnf-behave-tests/common/output.py
+++ b/dnf-behave-tests/common/output.py
@@ -24,7 +24,7 @@ def strip_reposync_dnf4(found_lines, line_number):
 
 
 sync_line_dnf5 = re.compile(
-    r"\[[0-9]+/[0-9]+\] .* [0-9]+% \| +[0-9.]+ +[KMG]?i?B/s \| +[0-9.]+ +[KMG]?i?B \| + [0-9hms]+")
+    r".* [0-9]+% \| +[0-9.]+ +[KMG]?i?B/s \| +[0-9.]+ +[KMG]?i?B \| + [0-9hms]+")
 
 def strip_reposync_dnf5(found_lines, line_number):
     if line_number < len(found_lines) and found_lines[line_number].strip() == "Updating and loading repositories:":


### PR DESCRIPTION
The prefix "[0/0]" was removed from repository download progress bar in dnf5 output in this PR https://github.com/rpm-software-management/dnf5/pull/130 .