### PR TITLE
Backport security tests to 8.8

### DIFF
--- a/dnf-behave-tests/dnf/list.feature
+++ b/dnf-behave-tests/dnf/list.feature
@@ -284,3 +284,37 @@ Scenario: dnf list doesn't show package with same nevra from lower-priority repo
    Then the exit code is 0
     And stdout section "Available Packages" contains "flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora"
     And stdout section "Available Packages" does not contain "dnf-ci-fedora2"
+
+
+@bz2124483
+Scenario: dnf list updates --security shows upgrades as available when it changes arch from noarch
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install change-arch-noarch-1-1.noarch"
+ When I execute dnf with args "list upgrades --security"
+ Then the exit code is 0
+  And stdout is
+  """
+  <REPOSYNC>
+  Available Upgrades
+  change-arch-noarch.x86_64                  2-2                  security-upgrade
+  """
+
+
+@bz2124483
+Scenario: dnf list updates --security doesn't shnow an upgrade when it would require an arch change (when its not noarch)
+Given I use repository "security-upgrade"
+  And I successfully execute dnf with args "install change-arch-1-1.i686"
+  # Make sure change-arch-2-2.x86_64 is available since we are testing we don't list it.
+  # It also has to have an available advisory. (We cannot verify that here because the updateinfo command is bugged when dealing with arch changes)
+  And I successfully execute dnf with args "repoquery change-arch-2-2.x86_64"
+  Then stdout is
+  """
+  <REPOSYNC>
+  change-arch-0:2-2.x86_64
+  """
+ When I execute dnf with args "list upgrades --security"
+ Then the exit code is 0
+  And stdout is
+  """
+  <REPOSYNC>
+  """

--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -260,3 +260,20 @@ Given I use repository "security-upgrade"
   When I execute dnf with args "upgrade --security --setopt=obsoletes=false"
  Then the exit code is 0
   And Transaction is empty
+
+
+# Tests that we correctly filter packages and include both arches in transaction
+# (both have an advisory) if we didn't libsolv would fail to resolve the transaction.
+Scenario: --security upgrade with packages of multiple arches installed
+Given I use repository "security-upgrade-multilib"
+  And I successfully execute dnf with args "install B-1-1.x86_64 B-1-1.i686"
+  Then Transaction is following
+      | Action        | Package        |
+      | install       | B-0:1-1.x86_64 |
+      | install       | B-0:1-1.i686   |
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package        |
+      | upgrade       | B-0:2-2.x86_64 |
+      | upgrade       | B-0:2-2.i686   |

--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -226,3 +226,37 @@ Given I successfully execute dnf with args "repoquery obsoleter-change-arch-reve
  When I execute dnf with args "upgrade --security"
  Then the exit code is 0
   And Transaction is empty
+
+
+Scenario: --security upgrade specific package with obsoletes when obsoletes are turned off
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install E-1-1"
+  # Make sure F-2-2 is available and obsoletes E since we are testing we don't upgrade to it.
+  # There also should be an available advisory for it. (We cannot verify that here because the updateinfo command is bugged when dealing with obsoletes)
+  And I successfully execute dnf with args "repoquery F-2-2.x86_64 --obsoletes"
+  Then stdout is
+  """
+  <REPOSYNC>
+  E
+  """
+  When I execute dnf with args "upgrade E --security --setopt=obsoletes=false"
+ Then the exit code is 0
+  And Transaction is empty
+
+
+@xfail
+# This has likely never worked on dnf4, it will be fixed in dnf5
+Scenario: --security upgrade all packages with obsoletes when obsoletes are turned off
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install E-1-1"
+  # Make sure F-2-2 is available and obsoletes E since we are testing we don't upgrade to it.
+  # There also should be an available advisory for it. (We cannot verify that here because the updateinfo command is bugged when dealing with obsoletes)
+  And I successfully execute dnf with args "repoquery F-2-2.x86_64 --obsoletes"
+  Then stdout is
+  """
+  <REPOSYNC>
+  E
+  """
+  When I execute dnf with args "upgrade --security --setopt=obsoletes=false"
+ Then the exit code is 0
+  And Transaction is empty

--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -53,7 +53,7 @@ Given I use repository "security-upgrade"
       | upgrade       | dracut-0:2-2.x86_64      |
 
 
-Scenario: --security upgrade with advisory for obsoleter when obsoleted installed
+Scenario: --security upgrade with advisory for obsoleter B with two versions 1-1 and 2-2 when obsoleted A is installed
 Given I use repository "security-upgrade"
   And I execute dnf with args "install A-1-1"
  When I execute dnf with args "upgrade --security"
@@ -62,3 +62,25 @@ Given I use repository "security-upgrade"
       | Action        | Package        |
       | install       | B-0:2-2.x86_64 |
       | obsoleted     | A-0:1-1.x86_64 |
+
+
+Scenario: --security upgrade with advisory for obsoleter with one version exactly matching advisory when obsoleted installed
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install C-1-1"
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package        |
+      | install       | D-0:1-1.x86_64 |
+      | obsoleted     | C-0:1-1.x86_64 |
+
+
+Scenario: --security upgrade with advisory for obsoleter with one bigger version than in advisory when obsoleted installed
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install E-1-1"
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package        |
+      | install       | F-0:2-2.x86_64 |
+      | obsoleted     | E-0:1-1.x86_64 |

--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -84,3 +84,67 @@ Given I use repository "security-upgrade"
       | Action        | Package        |
       | install       | F-0:2-2.x86_64 |
       | obsoleted     | E-0:1-1.x86_64 |
+
+
+@bz2124483
+Scenario: --security upgrade of a package that changes arch from noarch to x86_64
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install change-arch-noarch-1-1.noarch"
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 0
+  And RPMDB Transaction is following
+      | Action        | Package                  |
+      | install       | change-arch-noarch-0:2-2.x86_64 |
+      | remove        | change-arch-noarch-0:1-1.noarch |
+  And DNF Transaction is following
+      | Action        | Package                  |
+      | upgrade       | change-arch-noarch-0:2-2.x86_64 |
+
+
+@bz2124483
+Scenario: --security upgrade of a package that changes arch from x86_64 to noarch
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install change-arch-noarch-reversed-1-1.x86_64"
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 0
+  And RPMDB Transaction is following
+      | Action        | Package                           |
+      | install       | change-arch-noarch-reversed-0:2-2.noarch |
+      | remove        | change-arch-noarch-reversed-0:1-1.x86_64 |
+  And DNF Transaction is following
+      | Action        | Package                           |
+      | upgrade       | change-arch-noarch-reversed-0:2-2.noarch |
+
+
+@bz2124483
+Scenario: --security upgrade of a package that changes arch from i686 to x86_64 is not allowed
+Given I use repository "security-upgrade"
+  And I successfully execute dnf with args "install change-arch-1-1.i686"
+  # Make sure change-arch-2-2.x86_64 is available since we are testing we don't upgrade to it.
+  # It also has to have an available advisory. (We cannot verify that here because the updateinfo command is bugged when dealing with arch changes)
+  And I successfully execute dnf with args "repoquery change-arch-2-2.x86_64"
+  Then stdout is
+  """
+  <REPOSYNC>
+  change-arch-0:2-2.x86_64
+  """
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 0
+  And Transaction is empty
+
+
+@bz2124483
+Scenario: --security upgrade of a package that changes arch from x86_64 to i686 is not allowed
+Given I use repository "security-upgrade"
+  And I successfully execute dnf with args "install change-arch-reversed-1-1.x86_64"
+  # Make sure change-arch-reversed-2-2.i686 is available and has an adivosry since we are testing we don't upgrade to it.
+  # It also has to have an available advisory. (We cannot verify that here because the updateinfo command is bugged when dealing with arch changes)
+  And I successfully execute dnf with args "repoquery change-arch-reversed-2-2.i686"
+  Then stdout is
+  """
+  <REPOSYNC>
+  change-arch-reversed-0:2-2.i686
+  """
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 0
+  And Transaction is empty

--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -1,6 +1,8 @@
 Feature: --security upgrades
 
 
+@bz2088149
+# More details in: https://github.com/rpm-software-management/libdnf/pull/1526
 Scenario: --security upgrade with advisories with pkgs of different arches
 Given I use repository "security-upgrade"
   And I execute dnf with args "install json-c-1-1 bind-libs-lite-1-1"
@@ -10,6 +12,33 @@ Given I use repository "security-upgrade"
       | Action        | Package                     |
       | upgrade       | bind-libs-lite-0:2-2.x86_64 |
       | upgrade       | json-c-0:2-2.x86_64         |
+
+
+@bz2124483
+# This scenario is the same as the one above just with noarch packages present in the
+# repo and advisory instead of i686 this causes different behavior - it fails.
+# Technically we could get bz2088149 again with just a different package set.
+# However while this is possible it shouldn't happen because noarch packages are special - they work
+# on all architectures and we shouldn't see noarch builds together with arch specific builds as it
+# is setup in this scenario (in repo security-upgrade-noarch).
+# More details in: https://github.com/rpm-software-management/libdnf/pull/1526
+Scenario: --security upgrade with advisories with pkgs of different arches (noarch variant)
+Given I use repository "security-upgrade-noarch"
+  And I successfully execute dnf with args "install json-c-1-1 bind-libs-lite-1-1"
+ Then Transaction is following
+      | Action        | Package                     |
+      | install       | bind-libs-lite-0:1-1.x86_64 |
+      | install       | json-c-0:1-1.x86_64         |
+ When I execute dnf with args "upgrade --security"
+ Then the exit code is 1
+ And stderr is
+ """
+ Error: 
+  Problem: cannot install both json-c-2-2.x86_64 and json-c-2-2.noarch
+   - package bind-libs-lite-2-2.x86_64 requires libjson-c.so.4()(64bit), but none of the providers can be installed
+   - cannot install the best update candidate for package json-c-1-1.x86_64
+   - cannot install the best update candidate for package bind-libs-lite-1-1.x86_64
+ """
 
 
 @2097757

--- a/dnf-behave-tests/dnf/steps/lib/rpm.py
+++ b/dnf-behave-tests/dnf/steps/lib/rpm.py
@@ -201,7 +201,7 @@ def diff_rpm_lists(list_one, list_two):
 
     for pkg_one in list_one:
         for pkg_two in list_two:
-            if pkg_one.name != pkg_two.name:
+            if pkg_one.na != pkg_two.na:
                 continue
             if pkg_one < pkg_two:
                 result["upgraded"].append(pkg_one)

--- a/dnf-behave-tests/dnf/updateinfo.feature
+++ b/dnf-behave-tests/dnf/updateinfo.feature
@@ -458,3 +458,62 @@ Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode
     2999     bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
     CVE-2999 bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
     """
+
+
+Scenario: advisory for x86_64 package is not shown as installed when noarch version of the pkg is installed
+Given I use repository "updateinfo"
+  And I execute dnf with args "install A-2-2.noarch"
+# The test requires that advisory for A-2-2.x86_64 is available
+ When I execute dnf with args "updateinfo list --installed"
+ Then the exit code is 0
+  And stdout is
+  """
+  <REPOSYNC>
+  """
+
+
+@xfail
+# This has been broken in dnf4 for a long time, it will be fixed for dnf5
+Scenario: updateinfo --updates with advisory for obsoleter when obsoleted installed
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install C-1-1"
+ When I execute dnf with args "updateinfo list --updates"
+ Then the exit code is 0
+  And stdout is
+  """
+  <REPOSYNC>
+  DNF-D-2022-9 security      D-1-1.fc29.x86_64
+  """
+
+
+Scenario: updateinfo --updates with advisory for obsoleter when obsoleted installed
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install C-1-1"
+  # Make sure D-1-1 is available and obsoletes C since we are testing we don't list it.
+  # There also should be an available advisory for it. (We cannot verify that here because the updateinfo command is bugged when dealing with obsoletes)
+  And I successfully execute dnf with args "repoquery D-1-1.x86_64 --obsoletes"
+  Then stdout is
+  """
+  <REPOSYNC>
+  C
+  """
+ When I execute dnf with args "updateinfo list --updates --setopt=obsoletes=false"
+ Then the exit code is 0
+  And stdout is
+  """
+  <REPOSYNC>
+  """
+
+
+@xfail
+# This has been broken in dnf4 for a long time, it will be fixed for dnf5
+Scenario: advisory for noarch package is shown as an upgrade when lower arch version of the pkg is installed
+Given I use repository "security-upgrade"
+  And I execute dnf with args "install change-arch-noarch-1-1.noarch"
+ When I execute dnf with args "updateinfo list --updates"
+ Then the exit code is 0
+  And stdout is
+  """
+  <REPOSYNC>
+  DNF-2019-4 security      change-arch-noarch-2-2.fc29.x86_64
+  """

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-multilib/B-1-1.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-multilib/B-1-1.i686.spec
@@ -1,0 +1,16 @@
+Name:           B
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-multilib/B-2-2.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-multilib/B-2-2.i686.spec
@@ -1,0 +1,16 @@
+Name:           B
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-multilib/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-multilib/updateinfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-B-i686-2022-9</id>
+        <title>multiarch security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with multiarch pkgs</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="B" version="2" release="2" epoch="0" arch="i686" src="https://the.url/the.package.rpm">
+                    <filename>B-2-2.i686.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-B-i686-2022-9</id>
+        <title>multiarch security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with multiarch pkgs</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="B" version="2" release="2" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>B-2-2.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/bind-libs-lite-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/bind-libs-lite-1-1.spec
@@ -1,0 +1,16 @@
+Name:           bind-libs-lite
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/bind-libs-lite-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/bind-libs-lite-2-2.spec
@@ -1,0 +1,18 @@
+Name:           bind-libs-lite
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+Requires:       libjson-c.so.4()(64bit)
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/json-c-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/json-c-1-1.spec
@@ -1,0 +1,16 @@
+Name:           json-c
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/json-c-2-2.noarch.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/json-c-2-2.noarch.spec
@@ -1,0 +1,19 @@
+Name:           json-c
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+BuildArch:      noarch
+
+Summary:        Testing advisory upgrade options
+
+Provides:       libjson-c.so.4()
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/json-c-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/json-c-2-2.spec
@@ -1,0 +1,18 @@
+Name:           json-c
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+Provides:       libjson-c.so.4()(64bit)
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-noarch/updateinfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-1</id>
+        <title>json-c security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisory</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="json-c" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>json-c-1-1.x86_64.rpm</filename>
+                </package>
+                <package name="json-c" version="1" release="1" epoch="0" arch="noarch" src="https://the.url/the.package.rpm">
+                    <filename>json-c-1-1.noarch.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-1</id>
+        <title>bind-libs-lite security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisory</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="bind-libs-lite" version="2" release="2" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>bind-libs-lite-2-2.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleted-change-arch-1-1.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleted-change-arch-1-1.i686.spec
@@ -1,0 +1,16 @@
+Name:           obsoleted-change-arch
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleted-change-arch-noarch-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleted-change-arch-noarch-1-1.spec
@@ -1,0 +1,17 @@
+Name:           obsoleted-change-arch-noarch
+Epoch:          0
+Version:        1
+Release:        1
+BuildArch:      noarch
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleted-change-arch-noarch-reversed-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleted-change-arch-noarch-reversed-1-1.spec
@@ -1,0 +1,16 @@
+Name:           obsoleted-change-arch-noarch-reversed
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleted-change-arch-reversed-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleted-change-arch-reversed-1-1.spec
@@ -1,0 +1,16 @@
+Name:           obsoleted-change-arch-reversed
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleter-change-arch-1-1.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleter-change-arch-1-1.i686.spec
@@ -1,0 +1,18 @@
+Name:           obsoleter-change-arch
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+Obsoletes:      obsoleted-change-arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleter-change-arch-noarch-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleter-change-arch-noarch-1-1.spec
@@ -1,0 +1,18 @@
+Name:           obsoleter-change-arch-noarch
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+Obsoletes:      obsoleted-change-arch-noarch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleter-change-arch-noarch-reversed-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleter-change-arch-noarch-reversed-1-1.spec
@@ -1,0 +1,19 @@
+Name:           obsoleter-change-arch-noarch-reversed
+Epoch:          0
+Version:        1
+Release:        1
+BuildArch:      noarch
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+Obsoletes:      obsoleted-change-arch-noarch-reversed
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleter-change-arch-reversed-1-1.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/obsoleter-change-arch-reversed-1-1.i686.spec
@@ -1,0 +1,18 @@
+Name:           obsoleter-change-arch-reversed
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+Obsoletes:      obsoleted-change-arch-reversed
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-obsoletes/updateinfo.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>obsolete package of different arch, from noarch</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with x86_64 pkg that obsoletes noarch pkg</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="obsoleter-change-arch-noarch" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>obsoleter-change-arch-noarch-1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>obsolete package of different arch, to noarch</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with noarch pkg that obsoletes x86_64 pkg</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="obsoleter-change-arch-noarch-reversed" version="1" release="1" epoch="0" arch="noarch" src="https://the.url/the.package.rpm">
+                    <filename>obsoleter-change-arch-noarch-reversed-1-1.noarch.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>obsolete package of different arch, from i686, doens't work</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with x86_64 pkg that obsoletes i686 pkg</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="obsoleter-change-arch" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>obsoleter-change-arch-1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>obsolete package of different arch, to i686, doesn't work</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with i686 pkg that obsoletes x86_64 pkg</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="obsoleter-change-arch-reversed" version="1" release="1" epoch="0" arch="i686" src="https://the.url/the.package.rpm">
+                    <filename>obsoleter-change-arch-reversed-1-1.i686.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/C-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/C-1-1.spec
@@ -1,0 +1,16 @@
+Name:           C
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/D-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/D-1-1.spec
@@ -1,0 +1,18 @@
+Name:           D
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+Obsoletes:      C
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/E-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/E-1-1.spec
@@ -1,0 +1,16 @@
+Name:           E
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/F-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/F-2-2.spec
@@ -1,0 +1,18 @@
+Name:           F
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+Obsoletes:      E
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-1-1.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-1-1.i686.spec
@@ -1,0 +1,16 @@
+Name:           change-arch
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-2-2.spec
@@ -1,0 +1,16 @@
+Name:           change-arch
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-noarch-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-noarch-1-1.spec
@@ -1,0 +1,17 @@
+Name:           change-arch-noarch
+Epoch:          0
+Version:        1
+Release:        1
+BuildArch:      noarch
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-noarch-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-noarch-2-2.spec
@@ -1,0 +1,16 @@
+Name:           change-arch-noarch
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-noarch-reversed-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-noarch-reversed-1-1.spec
@@ -1,0 +1,16 @@
+Name:           change-arch-noarch-reversed
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-noarch-reversed-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-noarch-reversed-2-2.spec
@@ -1,0 +1,17 @@
+Name:           change-arch-noarch-reversed
+Epoch:          0
+Version:        2
+Release:        2
+BuildArch:      noarch
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-reversed-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-reversed-1-1.spec
@@ -1,0 +1,16 @@
+Name:           change-arch-reversed
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-reversed-2-2.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/change-arch-reversed-2-2.i686.spec
@@ -1,0 +1,16 @@
+Name:           change-arch-reversed
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
@@ -67,4 +67,36 @@
             </collection>
         </pkglist>
     </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-D-2022-9</id>
+        <title>obsoleter with one version exactly matching advisory security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with obsoleteing pkg</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="D" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>D-1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>obsoleter with one version exactly matching advisory security fix</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with obsoleteing pkg</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="F" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>F-1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
 </updates>

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
@@ -99,4 +99,68 @@
             </collection>
         </pkglist>
     </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>upgrade package of different arch, from noarch</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with pkg that changes arch, it has to change from noarch</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="change-arch-noarch" version="2" release="2" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>change-arch-noarch-2-2.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>upgrade package of different arch, to noarch</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with pkg that changes arch, it has to change to noarch</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="change-arch-noarch-reversed" version="2" release="2" epoch="0" arch="noarch" src="https://the.url/the.package.rpm">
+                    <filename>change-arch-noarch-reversed-2-2.noarch.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>upgrade package of different arch, from i686, deosn't work</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with pkg that changes arch, it is not allowed when arch is not noarch</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="change-arch" version="2" release="2" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>change-arch-2-2.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-4</id>
+        <title>upgrade package of different arch, to i686, doesn't work</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories during upgrade with pkg that changes arch, it is not allowed when arch is not noarch</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="change-arch-reversed" version="2" release="2" epoch="0" arch="i686" src="https://the.url/the.package.rpm">
+                    <filename>change-arch-reversed-2-2.i686.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
 </updates>

--- a/dnf-behave-tests/fixtures/specs/updateinfo/A-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/updateinfo/A-2-2.spec
@@ -1,0 +1,17 @@
+Name:           A
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+BuildArch:      noarch
+
+Summary:        Testing advisory upgrade with pkg that changes arch
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/updateinfo/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/updateinfo/updateinfo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2022-9</id>
+        <title>Test advisory, it is not shown when an noarch A is installed</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>testing advisories with pkg that changes arch</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="A" version="2" release="2" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>A-2-2.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>


### PR DESCRIPTION
Backport PR: https://github.com/rpm-software-management/ci-dnf-stack/pull/1154

Most of the commits are identical but I have removed a couple of dnf5 tags and steps specific to dnf5.