### PR TITLE
libdnf5 python API: add steps and first two tests

### DIFF
--- a/dnf-behave-tests/dnf/api/package-query.feature
+++ b/dnf-behave-tests/dnf/api/package-query.feature
@@ -1,0 +1,34 @@
+@dnf5
+@not.with_dnf=4
+Feature: api: query packages
+
+
+Scenario: Construct query and filter labirinto package
+Given I use repository "simple-base"
+ When I execute python libdnf5 api script with setup
+      """
+      query = libdnf5.rpm.PackageQuery(base)
+      query.filter_name(["labirinto"])
+      for pkg in query:
+          print(pkg.get_nevra())
+      """
+ Then the exit code is 0
+  And stdout is
+      """
+      labirinto-1.0-1.fc29.src
+      labirinto-1.0-1.fc29.x86_64
+      """
+
+
+Scenario: Construct query and filter fails due to bad argument type
+Given I use repository "simple-base"
+ When I execute python libdnf5 api script with setup
+      """
+      query = libdnf5.rpm.PackageQuery(base)
+      query.filter_name(99)
+      for pkg in query:
+          print(pkg.get_nevra())
+      """
+ Then the exit code is 1
+  And stdout is empty
+  And stderr contains "TypeError: Wrong number or type of arguments for overloaded function 'PackageQuery_filter_name'."


### PR DESCRIPTION
It adds two steps:

One general step to execute arbitrary python code, this should be
used if we want to test setting up base, config or repositories API.
It could also potentially be used for dnf4 api tests.

One more specific step for libdnf5 that already has setup base, config
and repositories in a default way with installroot that a lot of tests
would need to do.

Originally I wanted to create the new directory for tests (`api`) outside
 the `dnf` directory (as agreed) but given that the api tests will need
basically the same infrastructure as the dnf tests it makes sense to
keep it together. Otherwise we would have to duplicate quite a lot of
the setup and move basically all dnf steps in the `common` steps
directory. 