### PR TITLE
dnf5 API testing transactions

### DIFF
--- a/dnf-behave-tests/dnf/api/transaction-remove-install.feature
+++ b/dnf-behave-tests/dnf/api/transaction-remove-install.feature
@@ -1,0 +1,24 @@
+@dnf5
+@not.with_dnf=4
+Feature: transaction: remove a package with dependency, then install the dependency again
+
+
+Scenario: Construct query, remove vagare, then install labirinto
+Given I use repository "simple-base"
+Given I successfully execute dnf with args "install vagare"
+# vagare depends on labirinto
+ When I execute python libdnf5 api script with setup
+      """
+      goal = libdnf5.base.Goal(base)
+      goal.add_rpm_remove("vagare")
+      goal.add_rpm_install("labirinto")
+      execute_transaction(goal, "remove and install")
+      """
+ Then the exit code is 0
+  And stdout is
+      """
+      vagare-1.0-1.fc29.x86_64 : Remove
+      """
+  And RPMDB Transaction is following
+      | Action        | Package                       |
+      | remove        | vagare-0:1.0-1.fc29.x86_64    |

--- a/dnf-behave-tests/dnf/api/transaction-simple-install.feature
+++ b/dnf-behave-tests/dnf/api/transaction-simple-install.feature
@@ -1,0 +1,21 @@
+@dnf5
+@not.with_dnf=4
+Feature: transaction: install a package without dependencies
+
+
+Scenario: Construct query and install labirinto package
+Given I use repository "simple-base"
+ When I execute python libdnf5 api script with setup
+      """
+      goal = libdnf5.base.Goal(base)
+      goal.add_rpm_install("labirinto")
+      execute_transaction(goal, "install a package without dependencies")
+      """
+ Then the exit code is 0
+  And stdout is
+      """
+      labirinto-1.0-1.fc29.x86_64 : Install
+      """
+  And RPMDB Transaction is following
+      | Action        | Package                       |
+      | install       | labirinto-0:1.0-1.fc29.x86_64 |

--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -446,6 +446,21 @@ def execute_python_libdnf5_api_script_with_setup(context):
 import libdnf5
 import os
 
+def execute_transaction(goal,description):
+    transaction = goal.resolve()
+    for tspkg in transaction.get_transaction_packages():
+        print(tspkg.get_package().get_nevra(), ":", libdnf5.base.transaction.transaction_item_action_to_string(tspkg.get_action()))
+    downloader = libdnf5.repo.PackageDownloader()
+    downloader_callbacks = libdnf5.repo.DownloadCallbacks()
+    downloader_callbacks_ptr = libdnf5.repo.DownloadCallbacksUniquePtr(downloader_callbacks)
+    for tspkg in transaction.get_transaction_packages():
+        if libdnf5.base.transaction.transaction_item_action_is_inbound(tspkg.get_action()):
+            downloader.add(tspkg.get_package(), downloader_callbacks_ptr)
+    downloader.download(True, True)
+    transaction_callbacks = libdnf5.rpm.TransactionCallbacks()
+    transaction_callbacks_ptr = libdnf5.rpm.TransactionCallbacksUniquePtr(transaction_callbacks)
+    transaction.run(transaction_callbacks_ptr, description, None, None)
+
 base = libdnf5.base.Base()
 config = base.get_config()
 vars = base.get_vars()


### PR DESCRIPTION
added a helper function into dnf/steps/cmd.py for testing dnf5 API transactions
added two tests for testing transactions
passed on F37 (when dnf5 and python3-libdnf5 are installed and @not.with_dnf=4 is disabled)