### PR TITLE
Advisory: additional tests for duplicates

### DIFF
--- a/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/E-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/E-1-1.spec
@@ -1,0 +1,16 @@
+Name:           E
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/E-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/E-2-2.spec
@@ -1,0 +1,16 @@
+Name:           E
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/F-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/F-1-1.spec
@@ -1,0 +1,16 @@
+Name:           F
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/F-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/F-2-2.spec
@@ -1,0 +1,16 @@
+Name:           F
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/updateinfo.xml
@@ -43,4 +43,40 @@
       </collection>
     </pkglist>
   </update>
+  <update from="secresponseteam@foo.bar" type="security" version="3">
+    <id>custom_id</id>
+    <title>custom_title</title>
+    <issued date="2019-02-17 00:00:00"/>
+    <updated date="2022-12-17 00:00:00"/>
+    <severity>Moderate</severity>
+    <summary>custom summary</summary>
+    <description>custom description</description>
+    <pkglist>
+      <collection short="custom collection">
+        <name>custom component</name>
+        <package name="E" version="2" release="2" epoch="0" arch="x86_64" src="E-0:2-2.x86_64.rpm">
+          <filename>E-0:2-2.x86_64.rpm</filename>
+          <reboot_suggested/>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
+  <update from="secresponseteam@foo.bar" type="security" version="3">
+    <id>custom_id</id>
+    <title>custom_title</title>
+    <issued date="2022-12-17 00:00:00"/>
+    <updated date="2019-08-19 22:00:00"/>
+    <severity>Moderate</severity>
+    <summary>custom summary</summary>
+    <description>custom description</description>
+    <pkglist>
+      <collection short="custom collection">
+        <name>custom component</name>
+        <package name="E" version="2" release="2" epoch="0" arch="x86_64" src="E-0:2-2.x86_64.rpm">
+          <filename>E-0:2-2.x86_64.rpm</filename>
+          <reboot_suggested/>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
 </updates>

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-1/updateinfo.xml
@@ -79,4 +79,22 @@
       </collection>
     </pkglist>
   </update>
+  <update from="secresponseteam@foo.bar" type="security" version="3">
+    <id>custom_id_F</id>
+    <title>custom_title_F</title>
+    <issued date="2002-12-17 00:00:00"/>
+    <updated date="2019-08-19 22:00:00"/>
+    <severity>Moderate</severity>
+    <summary>custom summary F</summary>
+    <description>custom description</description>
+    <pkglist>
+      <collection short="custom collection">
+        <name>custom component F</name>
+        <package name="F" version="2" release="2" epoch="0" arch="x86_64" src="F-0:2-2.x86_64.rpm">
+          <filename>F-0:2-2.x86_64.rpm</filename>
+          <reboot_suggested/>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
 </updates>

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-2/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-2/updateinfo.xml
@@ -43,4 +43,22 @@
       </collection>
     </pkglist>
   </update>
+  <update from="secresponseteam@foo.bar" type="security" version="3">
+    <id>custom_id</id>
+    <title>custom_title</title>
+    <issued date="1990-02-07 00:22:00"/>
+    <updated date="2022-12-17 00:00:00"/>
+    <severity>Moderate</severity>
+    <summary>custom summary</summary>
+    <description>custom description</description>
+    <pkglist>
+      <collection short="custom collection">
+        <name>custom component</name>
+        <package name="E" version="2" release="2" epoch="0" arch="x86_64" src="E-0:2-2.x86_64.rpm">
+          <filename>E-0:2-2.x86_64.rpm</filename>
+          <reboot_suggested/>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
 </updates>

--- a/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-2/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade-duplicates-2/updateinfo.xml
@@ -61,4 +61,22 @@
       </collection>
     </pkglist>
   </update>
+  <update from="secresponseteam@foo.bar" type="security" version="3">
+    <id>custom_id_F</id>
+    <title>custom_title_F</title>
+    <issued date="2002-12-17 00:00:00"/>
+    <updated date="2019-08-19 22:00:00"/>
+    <severity>Moderate</severity>
+    <summary>different custom summary F</summary>
+    <description>custom description</description>
+    <pkglist>
+      <collection short="custom collection">
+        <name>custom component F</name>
+        <package name="F" version="2" release="2" epoch="0" arch="x86_64" src="F-0:2-2.x86_64.rpm">
+          <filename>F-0:2-2.x86_64.rpm</filename>
+          <reboot_suggested/>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
 </updates>


### PR DESCRIPTION
Testing for duplicate advisories with different issued/updated dates and when only summary is different.

Follow up for: https://github.com/rpm-software-management/ci-dnf-stack/pull/1169