### PR TITLE
Separate dnf4/dnf5 CI container dependencies

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -13,6 +13,9 @@ inputs:
   base-image:
     description: The base image for the tests, defaults to the Dockerfile's default
     default: ""
+  build-type:
+    description: Build type for the image, e.g. nightly, dnf5.
+    default: ""
 
 runs:
   using: "composite"
@@ -31,13 +34,18 @@ runs:
           BASE_ARG="--base ${{inputs.base-image}}"
         fi
 
+        BUILD_TYPE_ARG=""
+        if [ -n "${{inputs.build-type}}" ]; then
+          BUILD_TYPE_ARG="--type ${{inputs.build-type}}"
+        fi
+
         echo "Downloading RPMs:"
         for RPM in ${{inputs.package-urls}}; do
           wget -P rpms ${RPM};
         done
 
         CONTAINER=$(uuidgen)
-        ./container-test -c $CONTAINER build $BASE_ARG
+        ./container-test -c $CONTAINER build $BASE_ARG $BUILD_TYPE_ARG
 
         TESTS=($(./container-test -c $CONTAINER -s "${{inputs.suite}}" list))
         parallel -j2 ./container-test --container "$CONTAINER" -s "${{inputs.suite}}" run ${{inputs.extra-run-args}} "{}" ::: "${TESTS[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
       fail-fast: false  # don't fail all matrix jobs if one of them fails
       matrix:
         include:
-          - { component: dnf, suite: dnf, extra-run-args: '' }
-          - { component: dnf5, suite: dnf, extra-run-args: --tags dnf5 --command dnf5 }
-          - { component: dnf5, suite: dnf, extra-run-args: --tags dnf5daemon --command dnf5daemon-client }
-          - { component: createrepo_c, suite: createrepo_c, extra-run-args: '' }
+          - { component: dnf, build-type: '', suite: dnf, extra-run-args: '' }
+          - { component: dnf5, build-type: dnf5, suite: dnf, extra-run-args: --tags dnf5 --command dnf5 }
+          - { component: dnf5, build-type: dnf5, suite: dnf, extra-run-args: --tags dnf5daemon --command dnf5daemon-client }
+          - { component: createrepo_c, build-type: '', suite: createrepo_c, extra-run-args: '' }
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/rpm-software-management/dnf-ci-host
@@ -72,3 +72,4 @@ jobs:
           package-urls: ${{steps.copr-build.outputs.package-urls}}
           suite: ${{matrix.suite}}
           extra-run-args: ${{matrix.extra-run-args}}
+          build-type: ${{matrix.build-type}}

--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -29,7 +29,6 @@ BuildRequires:  python3-distro
 BuildRequires:  python3-pip
 # a missing dep of python3-pip on f35 beta, remove when unneeded
 BuildRequires:  python3-setuptools
-BuildRequires:  python3-toml
 BuildRequires:  rpm-build
 BuildRequires:  rpm-sign
 BuildRequires:  sqlite
@@ -37,6 +36,16 @@ BuildRequires:  sqlite
 BuildRequires:  python3-behave
 BuildRequires:  python3-pexpect
 BuildRequires:  zchunk
+%endif
+
+%if 0%{?dnf5}
+# dnf5 tests need toml to check system state
+BuildRequires:  python3-toml
+
+# dnfdaemon
+BuildRequires:  dbus-daemon
+BuildRequires:  python3-dbus
+BuildRequires:  polkit
 %endif
 
 # tested packages
@@ -60,10 +69,6 @@ BuildRequires:  dnf-plugin-swidtags
 
 BuildRequires:  microdnf
 
-# dnfdaemon
-BuildRequires:  dbus-daemon
-BuildRequires:  python3-dbus
-BuildRequires:  polkit
 
 # debugging tools (always installed for simplicity)
 BuildRequires: less

--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -51,6 +51,16 @@ BuildRequires:  polkit
 # tested packages
 BuildRequires:  createrepo_c
 
+%if 0%{?dnf5}
+# dnf5 tests need dnf5
+BuildRequires:  dnf5
+BuildRequires:  dnf5-plugins
+BuildRequires:  dnf5daemon-server
+BuildRequires:  dnf5daemon-client
+BuildRequires:  dnf5-plugins
+# dnf5 python api tests need libdnf5 python bindings
+BuildRequires:  python3-libdnf5
+%else
 BuildRequires:  dnf
 BuildRequires:  dnf-automatic
 BuildRequires:  yum
@@ -68,7 +78,7 @@ BuildRequires:  dnf-plugin-swidtags
 %endif
 
 BuildRequires:  microdnf
-
+%endif
 
 # debugging tools (always installed for simplicity)
 BuildRequires: less


### PR DESCRIPTION
This would also have to be added to dnf5: https://github.com/rpm-software-management/dnf5/pull/195

Another approach could be just do the branching first (separate branch for dnf4 and dnf5) and then hard-code it. It would be simpler approach.

