### PR TITLE
Fix python API script after SWIG-related changes

### DIFF
--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -459,7 +459,7 @@ def execute_transaction(goal,description):
     downloader.download(True, True)
     transaction_callbacks = libdnf5.rpm.TransactionCallbacks()
     transaction_callbacks_ptr = libdnf5.rpm.TransactionCallbacksUniquePtr(transaction_callbacks)
-    transaction.run(transaction_callbacks_ptr, description, None, None)
+    transaction.run(transaction_callbacks_ptr, description)
 
 base = libdnf5.base.Base()
 config = base.get_config()


### PR DESCRIPTION
The API of `libdnf::base::Transaction` binding was changed, therefore updating the behave tests API script.

Requires https://github.com/rpm-software-management/dnf5/pull/217.