### PR TITLE
Check package returns correct reason in Python API

### DIFF
--- a/dnf-behave-tests/dnf/api/package-query.feature
+++ b/dnf-behave-tests/dnf/api/package-query.feature
@@ -32,3 +32,19 @@ Given I use repository "simple-base"
  Then the exit code is 1
   And stdout is empty
   And stderr contains "TypeError: Wrong number or type of arguments for overloaded function 'PackageQuery_filter_name'."
+
+
+Scenario: Package from query returns correct reason value
+Given I use repository "simple-base"
+ When I execute python libdnf5 api script with setup
+      """
+      query = libdnf5.rpm.PackageQuery(base)
+      query.filter_name(["vagare"])
+      package = next(iter(query))
+      print(package.get_reason())
+      """
+ Then the exit code is 0
+  And stdout is
+      """
+      0
+      """


### PR DESCRIPTION
This test is intended to check if the reason value of package from query is correctly wrapped by the SWIG.

Requires https://github.com/rpm-software-management/dnf5/pull/219
Tests rpm-software-management/dnf5#216