### PR TITLE
Convert the main branch for dnf5 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       fail-fast: false  # don't fail all matrix jobs if one of them fails
       matrix:
         include:
-          - { component: dnf, suite: dnf, extra-run-args: '' }
           - { component: dnf5, suite: dnf, extra-run-args: --tags dnf5 --command dnf5 }
           - { component: dnf5, suite: dnf, extra-run-args: --tags dnf5daemon --command dnf5daemon-client }
           - { component: createrepo_c, suite: createrepo_c, extra-run-args: '' }

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,14 @@ RUN set -x && \
     dnf -y install dnf-plugins-core; \
     dnf -y copr enable rpmsoftwaremanagement/test-utils;
 
-# enable nightlies if requested
+# enable dnf5
 RUN set -x && \
-    if [ "$TYPE" == "nightly" ]; then \
-        dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
-        # run upgrade before distro-sync in case there is a new version in dnf-nightly that has a new dependency
-        dnf -y upgrade; \
-        dnf -y distro-sync --repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly; \
-    fi
+    dnf -y copr enable rpmsoftwaremanagement/dnf5-unstable; \
+    #  enable dnf-nightly as well to get librepo and libsolv
+    dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
+    # run upgrade before distro-sync in case there is a new version in dnf-nightly that has a new dependency
+    dnf -y upgrade; \
+    dnf -y distro-sync --repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf5-unstable;
 
 # copy test suite
 COPY ./dnf-behave-tests/ /opt/ci/dnf-behave-tests

--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -42,28 +42,18 @@ BuildRequires:  zchunk
 # tested packages
 BuildRequires:  createrepo_c
 
-BuildRequires:  dnf
-BuildRequires:  dnf-automatic
-BuildRequires:  yum
-
-BuildRequires:  dnf-plugins-core
-BuildRequires:  dnf-utils
-BuildRequires:  python3-dnf-plugin-modulesync
-BuildRequires:  python3-dnf-plugin-post-transaction-actions
-BuildRequires:  python3-dnf-plugin-versionlock
-BuildRequires:  python3-dnf-plugins-core
-
-%if 0%{?fedora}
-BuildRequires:  python3-dnf-plugin-system-upgrade
-BuildRequires:  dnf-plugin-swidtags
-%endif
-
-BuildRequires:  microdnf
-
 # dnfdaemon
 BuildRequires:  dbus-daemon
 BuildRequires:  python3-dbus
 BuildRequires:  polkit
+
+BuildRequires:  dnf5
+BuildRequires:  dnf5-plugins
+BuildRequires:  dnf5daemon-server
+BuildRequires:  dnf5daemon-client
+BuildRequires:  dnf5-plugins
+# dnf5 python api tests need libdnf5 python bindings
+BuildRequires:  python3-libdnf5
 
 # debugging tools (always installed for simplicity)
 BuildRequires: less


### PR DESCRIPTION
QA already switched to the new branch `dnf-4-stack` for dnf4.
Before this is merged we also have to switch our repositories:
https://github.com/rpm-software-management/libcomps/pull/100
https://github.com/rpm-software-management/libdnf/pull/1593
https://github.com/rpm-software-management/dnf/pull/1877
https://github.com/rpm-software-management/microdnf/pull/130
https://github.com/rpm-software-management/dnf-plugins-core/pull/478
https://github.com/rpm-software-management/dnf-plugins-extras/pull/214