### PR TITLE
Add tests for transaction.test()

### DIFF
--- a/dnf-behave-tests/dnf/api/transaction-test.feature
+++ b/dnf-behave-tests/dnf/api/transaction-test.feature
@@ -1,0 +1,30 @@
+@dnf5
+Feature: transaction: dry-run a transaction
+
+
+@bz2109660
+Scenario: Test labirinto install transaction when it should succeed
+Given I use repository "simple-base"
+ When I execute python libdnf5 api script with setup
+      """
+      goal = libdnf5.base.Goal(base)
+      goal.add_rpm_install("labirinto")
+      assert test_transaction(goal) == libdnf5.base.Transaction.TransactionRunResult_SUCCESS
+      """
+ Then the exit code is 0
+  And stderr is empty
+
+@bz2109660
+Scenario: Test labirinto install transaction when it should fail
+Given I use repository "simple-base"
+ When I execute python libdnf5 api script with setup
+      """
+      goal = libdnf5.base.Goal(base)
+      goal.add_rpm_install("labirinto")
+      execute_transaction(goal, "install a package")
+
+      # We have already run the transaction, so test_transaction should return a failing status
+      assert test_transaction(goal) == libdnf5.base.Transaction.TransactionRunResult_ERROR_RPM_RUN
+      """
+ Then the exit code is 0
+  And stderr is empty

--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -458,6 +458,17 @@ def execute_transaction(goal,description):
     transaction.set_description(description)
     transaction.run()
 
+def test_transaction(goal):
+    transaction = goal.resolve()
+    for tspkg in transaction.get_transaction_packages():
+        print(tspkg.get_package().get_nevra(), ":", libdnf5.base.transaction.transaction_item_action_to_string(tspkg.get_action()))
+    downloader = libdnf5.repo.PackageDownloader()
+    for tspkg in transaction.get_transaction_packages():
+        if libdnf5.base.transaction.transaction_item_action_is_inbound(tspkg.get_action()):
+            downloader.add(tspkg.get_package())
+    downloader.download(True, True)
+    return transaction.test()
+
 base = libdnf5.base.Base()
 config = base.get_config()
 vars = base.get_vars()


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/251

@glum23 I added a `test_transaction` function in `dnf-behave-tests/dnf/steps/cmd.py` instead of adding on to `execute_transaction`, since `transaction.run()` already does the same checks that `transaction.test()` does.