### PR TITLE
Add missing `libdnf5-plugin-actions` dependency

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -51,7 +51,7 @@ BuildRequires:  dnf5
 BuildRequires:  dnf5-plugins
 BuildRequires:  dnf5daemon-server
 BuildRequires:  dnf5daemon-client
-BuildRequires:  dnf5-plugins
+BuildRequires:  libdnf5-plugin-actions
 # dnf5 python api tests need libdnf5 python bindings
 BuildRequires:  python3-libdnf5
 


### PR DESCRIPTION
It is tested for dnf5 in: plugins-core/actions.feature

It also removes duplicate require for dnf5-plugins.

Required by: https://github.com/rpm-software-management/librepo/pull/272