### PR TITLE
Enable install-non-existent.feature for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/install-non-existent.feature
+++ b/dnf-behave-tests/dnf/install-non-existent.feature
@@ -1,43 +1,45 @@
+@dnf5
 Feature: Test for installation of non-existent rpm or package
 
 
-# @dnf5
-# TODO(nsella) different stdout
 @bz1578369
 Scenario: Try to install a non-existent rpm
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install non-existent.rpm"
    Then the exit code is 1
-    And stderr contains "Can not load RPM file"
-    And stderr contains "Could not open"
+    And stderr is
+    """
+    Failed to access RPM "non-existent.rpm": No such file or directory
+    """
 
 
-# @dnf5
-# TODO(nsella) different stderr
 Scenario: Try to install a non-existent package
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install non-existent-package"
    Then the exit code is 1
-    And stdout contains "No match for argument"
-    And stderr contains "Error: Unable to find a match"
+    And stderr is
+    """
+    Failed to resolve the transaction:
+    No match for argument: non-existent-package
+    """
 
 
-# @dnf5
-# TODO(nsella) different stderr
 @bz1717429
 Scenario: Install an existent and an non-existent package
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup non-existent-package"
    Then the exit code is 1
-    And stdout contains "No match for argument: non-existent-package"
-    And stderr contains "Error: Unable to find a match: non-existent-package"
+    And stderr is
+    """
+    Failed to resolve the transaction:
+    No match for argument: non-existent-package
+    """
 
 
-@dnf5
 @bz1717429
-Scenario: Install an existent and an non-existent package with --skip-broken
+Scenario: Install an existent and an non-existent package with --skip-unavailable
   Given I use repository "dnf-ci-fedora"
-   When I execute dnf with args "install setup non-existent-package --skip-broken"
+   When I execute dnf with args "install setup non-existent-package --skip-unavailable"
    Then the exit code is 0
     And stdout contains "No match for argument: non-existent-package"
     And Transaction is following

--- a/dnf-behave-tests/dnf/plugins-core/builddep.feature
+++ b/dnf-behave-tests/dnf/plugins-core/builddep.feature
@@ -146,8 +146,7 @@ Scenario: I exclude the highest verion of a package and call dnf builddep with -
         | Action                | Package                    |
         | install               | flac-0:1.3.3-2.fc29.x86_64 |
 
-# @dnf5
-# TODO(nsella) different stderr
+@dnf5
 @bz1628634
 Scenario: Builddep with unavailable build dependency
     Given I use repository "dnf-ci-fedora"


### PR DESCRIPTION
Also one scenario needed to be changed because of change in the --skip-broken switch meaning. What the scenario actually tests is --skip-unavailable option.

Requires https://github.com/rpm-software-management/dnf5/pull/316