### PR TITLE
Add `CAP_SYS_CHROOT` capability when running DNF CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # $ podman build --build-arg TYPE=distro -t ci-dnf-stack -f Dockerfile
 # $ podman run --net none -it ci-dnf-stack behave dnf
 
-ARG BASE=fedora:33
+ARG BASE=fedora:37
 FROM $BASE
 
 ENV LANG C.UTF-8

--- a/container-test
+++ b/container-test
@@ -205,6 +205,10 @@ class BehaveRunner(object):
         return self._volumes
 
     @property
+    def capabilities(self):
+        return ['--cap-add', 'CAP_SYS_CHROOT']
+
+    @property
     def tags(self):
         if hasattr(self.command_line_args, 'tags'):
             tags = self.command_line_args.tags
@@ -300,6 +304,7 @@ class BehaveRunner(object):
         '''
         command = self.docker_bin + ['run', '-it', '--rm']
         command += self.volumes
+        command += self.capabilities
         command += [self.command_line_args.container, 'bash']
         subprocess.call(command)
 
@@ -338,7 +343,7 @@ class BehaveRunner(object):
             return ['--junit-directory="/junit/{}_{}"'.format(feature_name, i)]
 
 
-        command = self.docker_bin + ['run', '--rm'] + self.param_tty + self.volumes
+        command = self.docker_bin + ['run', '--rm'] + self.param_tty + self.volumes + self.capabilities
 
         if self.command_line_args.container_args:
             command += self.command_line_args.container_args


### PR DESCRIPTION
Since podman-4.4.0 `CAP_SYS_CHROOT` is required in order to use installroot (chroot) inside the containers.

https://bugzilla.redhat.com/show_bug.cgi?id=2167735