### PR TITLE
Test for storing the comps metadata cache along with other metadata

### DIFF
--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -601,3 +601,28 @@ Scenario: 'dnf group list -C' works for unprivileged user even when decompressed
        CQRlib-non-devel
        SuperRipper-and-deps
     """
+
+
+@dnf5
+@bz2173929
+Scenario: dnf5 group list: empty output when run for the second time
+ Given I use repository "advisories-and-groups"
+  When I execute dnf with args "clean metadata"
+   And I execute dnf with args "group list"
+  Then the exit code is 0
+   And dnf5 stdout is
+    """
+    <REPOSYNC>
+    ID                   Name         Installed
+    test-group-1         Test Group 1        no
+    test-group-2         Test Group 2        no
+    """
+  When I execute dnf with args "group list"
+  Then the exit code is 0
+   And dnf5 stdout is
+    """
+    <REPOSYNC>
+    ID                   Name         Installed
+    test-group-1         Test Group 1        no
+    test-group-2         Test Group 2        no
+    """

--- a/dnf-behave-tests/fixtures/specs/advisories-and-groups/comps.xml
+++ b/dnf-behave-tests/fixtures/specs/advisories-and-groups/comps.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
+<comps>
+  <group>
+    <id>test-group-1</id>
+    <name>Test Group 1</name>
+    <description>Test Group 1 description.</description>
+      <packagelist>
+        <packagereq type="mandatory">test</packagereq>
+      </packagelist>
+  </group>
+
+  <group>
+    <id>test-group-2</id>
+    <name>Test Group 2</name>
+    <description>Test Group 2 description.</description>
+  </group>
+</comps>

--- a/dnf-behave-tests/fixtures/specs/advisories-and-groups/test.spec
+++ b/dnf-behave-tests/fixtures/specs/advisories-and-groups/test.spec
@@ -1,0 +1,16 @@
+Name:           test
+Version:        1.0
+Release:        1
+Summary:        Dummy summary.
+
+License:        GPLv2+ and Public Domain
+URL:            https://url.com/
+
+BuildArch:      noarch
+
+%description
+A testing package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/advisories-and-groups/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/advisories-and-groups/updateinfo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-TEST-2023-1</id>
+        <title>Test fix</title>
+        <release>Fedora 38</release>
+        <issue date="2023-03-01 10:00:01" />
+        <references />
+        <description>Testing advisory</description>
+        <pkglist>
+            <collection short="F38">
+                <name>Fedora 38</name>
+                <package name="test" version="1.0" release="1" epoch="0" arch="noarch" src="https://the.url/the.package.rpm">
+                    <filename>test-1.0-1.noarch.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
+</updates>


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/346.