### PR TITLE
Add test for installation according binary name

### DIFF
--- a/dnf-behave-tests/dnf/install-provides.feature
+++ b/dnf-behave-tests/dnf/install-provides.feature
@@ -97,3 +97,13 @@ Examples:
         | file provide                 | /etc/ld.so.conf  |
         | file provide with wildcards  | /etc/ld*conf     |
         | directory provide            | /var/db/         |
+
+@dnf5
+Scenario: Install package using binary name
+#  wget provides binary wget-bivary, but it is not explicitly in provides
+  Given I use repository "dnf-ci-fedora"
+   When I execute dnf with args "install wget-binary"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                                  |
+        | install       | wget-0:1.19.5-5.fc29.x86_64              |

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora/wget-1.19.5-5.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora/wget-1.19.5-5.fc29.spec
@@ -19,6 +19,11 @@ storage and comparison, use of Rest with FTP servers and Range with
 HTTP servers to retrieve files over slow or unstable connections,
 support for Proxy servers, and configurability.
 
+%install
+mkdir -p %{buildroot}%{_bindir}
+touch %{buildroot}%{_bindir}/wget-binary
+
 %files
+%{_bindir}/wget-binary
 
 %changelog


### PR DESCRIPTION
This is a new functionality in DNF5 where it installs provider of binary using binary name without binary path