### PR TITLE
Test for package split

### DIFF
--- a/dnf-behave-tests/dnf/package-split.feature
+++ b/dnf-behave-tests/dnf/package-split.feature
@@ -1,0 +1,26 @@
+Feature: Test package splitting
+
+@dnf5
+Scenario: Install splitted package
+  Given I use repository "split-package"
+   When I execute dnf with args "install systemd-udev"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | install       | systemd-udev-0:2.0-1.fc29.noarch      |
+
+
+@dnf5
+Scenario: Upgrade splitted package
+  Given I use repository "split-package"
+   When I execute dnf with args "install systemd-udev-1.0"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | install       | systemd-udev-0:1.0-1.fc29.noarch      |
+   When I execute dnf with args "upgrade"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | upgrade       | systemd-udev-0:2.0-1.fc29.noarch      |
+        | install       | systemd-boot-unsigned-0:2.0-1.fc29.noarch      |

--- a/dnf-behave-tests/fixtures/specs/split-package/systemd-boot-unsigned-2.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/split-package/systemd-boot-unsigned-2.0-1.fc29.spec
@@ -1,0 +1,18 @@
+Name: systemd-boot-unsigned
+Version: 2.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+BuildArch:      noarch
+
+Obsoletes: systemd-udev < 2
+
+%description
+systemd-boot-unsigned description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/split-package/systemd-udev-1.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/split-package/systemd-udev-1.0-1.fc29.spec
@@ -1,0 +1,16 @@
+Name: systemd-udev
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+BuildArch:      noarch
+
+%description
+systemd-udev description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/split-package/systemd-udev-2.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/split-package/systemd-udev-2.0-1.fc29.spec
@@ -1,0 +1,18 @@
+Name: systemd-udev
+Version: 2.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+BuildArch:      noarch
+
+Obsoletes: systemd-udev < 2
+
+%description
+systemd-udev description
+
+%files
+
+%changelog


### PR DESCRIPTION
Test that dnf selects correct package to install in case some older version is being obsoleted.

Requires: https://github.com/rpm-software-management/dnf5/pull/354