### PR TITLE
Adjust tests problems output to stderr

### DIFF
--- a/dnf-behave-tests/dnf/broken-dependencies-report.feature
+++ b/dnf-behave-tests/dnf/broken-dependencies-report.feature
@@ -14,21 +14,16 @@ Scenario: Broken dependencies are reported when strict and best options are off
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install postgresql --exclude=postgresql-libs --setopt=strict=false --setopt=best=false"
    Then the exit code is 0
-    And dnf4 stderr is
+    And stderr is
     """
     Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
       - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests
       - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
     """
-    And dnf5 stdout is
+    And stdout is
     """
     <REPOSYNC>
-    Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
-      - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
-      - conflicting requests
-      - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
-    
     Nothing to do.
     """
 
@@ -38,21 +33,16 @@ Scenario: Broken dependencies are reported when strict option is off and best op
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install postgresql --exclude=postgresql-libs --setopt=strict=false --setopt=best=true"
    Then the exit code is 0
-    And dnf4 stderr is
+    And stderr is
     """
     Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
       - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests
       - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
     """
-    And dnf5 stdout is
+    And stdout is
     """
     <REPOSYNC>
-    Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
-      - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
-      - conflicting requests
-      - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
-    
     Nothing to do.
     """
 
@@ -62,20 +52,15 @@ Scenario: Broken dependencies are reported when skip-broken and best options are
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install postgresql --exclude=postgresql-libs --skip-broken --setopt=best=true"
    Then the exit code is 0
-    And dnf4 stderr is
+    And stderr is
     """
     Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
       - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests
       - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
     """
-    And dnf5 stdout is
+    And stdout is
     """
     <REPOSYNC>
-    Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
-      - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
-      - conflicting requests
-      - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
-    
     Nothing to do.
     """

--- a/dnf-behave-tests/dnf/install-non-existent.feature
+++ b/dnf-behave-tests/dnf/install-non-existent.feature
@@ -41,7 +41,10 @@ Scenario: Install an existent and an non-existent package with --skip-unavailabl
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup non-existent-package --skip-unavailable"
    Then the exit code is 0
-    And stdout contains "No match for argument: non-existent-package"
+    And stderr is
+    """
+    No match for argument: non-existent-package
+    """
     And Transaction is following
         | Action        | Package                                   |
         | install       | setup-0:2.12.1-1.fc29.noarch              |


### PR DESCRIPTION
Now are resolve logs printed to stderr, need to adjust several steps. Also removed dnf4/dnf5 steps since this branch is supposed to be run only with dnf5.

Requires: https://github.com/rpm-software-management/dnf5/pull/365