### PR TITLE
[dnf5] Fix argument error messages in search and download command tests

### DIFF
--- a/dnf-behave-tests/dnf/dnf5/download.feature
+++ b/dnf-behave-tests/dnf/dnf5/download.feature
@@ -55,9 +55,6 @@ Scenario: Download with resolve and alldeps options
 Scenario: Download with alldeps options
   Given I set working directory to "{context.dnf.tempdir}"
    When I execute dnf with args "download abcde --alldeps"
-   Then stderr is
-   """
-   Option alldeps should be used with resolve
-   """
+   Then stderr contains "Option \"--alldeps\" should be used with \"--resolve\""
     And the exit code is 2
 

--- a/dnf-behave-tests/dnf/search.feature
+++ b/dnf-behave-tests/dnf/search.feature
@@ -9,7 +9,7 @@ Background:
 Scenario: without keyword
    When I execute dnf with args "search"
    Then the exit code is 2
-   And stdout contains "Missing positional argument \"patterns\" for command \"search\""
+   And stderr contains "Missing positional argument \"patterns\" for command \"search\""
 
 
 Scenario: with keyword


### PR DESCRIPTION
For https://github.com/rpm-software-management/dnf5/pull/450