### PR TITLE
Test bug in libsolv which installed pkg condition pkg (dnf-4-stack)

### DIFF
--- a/dnf-behave-tests/dnf/rich-dependencies.feature
+++ b/dnf-behave-tests/dnf/rich-dependencies.feature
@@ -160,3 +160,13 @@ Scenario: Command-line installation if condition is not met, but package explici
         | install       | flour-0:1.0-1.x86_64              |
         | install       | milk-0:1.0-1.x86_64               |
 
+
+@bz2185061
+Scenario: Install pkg with weak complex deps and don't install the condition pkg with broken deps
+    Given I execute dnf with args "install breakfast"
+     Then the exit code is 0
+      And Transaction is following
+        | Action        | Package                           |
+        | install       | breakfast-0:1.0-1.x86_64          |
+        | install-weak  | water-0:1.0-1.x86_64              |
+

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-rich/breakfast-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-rich/breakfast-1.0-1.spec
@@ -1,0 +1,18 @@
+Name:           breakfast
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for weak and rich dependencies testing.
+
+Recommends:     (blue-cheese if spoiled-milk else water)
+
+%description
+Weak and Rich dependencies testing package.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-rich/spoiled-milk-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-rich/spoiled-milk-1.0-1.spec
@@ -1,0 +1,19 @@
+Name:           spoiled-milk
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for rich dependencies testing.
+
+Requires:       mold
+
+%description
+Rich and complex dependencies testing package.
+It requires a missing dependency.
+
+%files
+
+%changelog


### PR DESCRIPTION
The package that the condition is based on should no be installed.

For: https://bugzilla.redhat.com/show_bug.cgi?id=2185061

The fix is in libsolv.