### PR TITLE
Test undoing install transaction when another arch is installed (dnf-4-stack)

### DIFF
--- a/dnf-behave-tests/dnf/install-remove-multilib.feature
+++ b/dnf-behave-tests/dnf/install-remove-multilib.feature
@@ -73,3 +73,14 @@ Scenario: Installing an older version of x86_64 pulls in a newer version of i686
       | install       | foo-1.0-1.x86_64               |
       | install-dep   | python3-foo-1.0-1.x86_64       |
       | install-dep   | python3-foo-clibs-1.0-1.x86_64 |
+
+
+@bz2172292
+Scenario: undo install transaction when another arch is installed
+Given I successfully execute dnf with args "install perduto.i686"
+  And I successfully execute dnf with args "install perduto.x86_64"
+ When I execute dnf with args "history undo last"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                        |
+      | remove        | perduto-0:1.0-1.fc29.x86_64    |

--- a/dnf-behave-tests/fixtures/specs/install-remove-multilib/perduto-1.0-1.fc29.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/install-remove-multilib/perduto-1.0-1.fc29.i686.spec
@@ -1,0 +1,14 @@
+Name: perduto
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+pedruto description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/install-remove-multilib/perduto-1.0-1.fc29.x86_64.spec
+++ b/dnf-behave-tests/fixtures/specs/install-remove-multilib/perduto-1.0-1.fc29.x86_64.spec
@@ -1,0 +1,14 @@
+Name: perduto
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+pedruto description
+
+%files
+
+%changelog


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=2172292 
The fix is in libsolv.