### PR TITLE
Enable tests for group upgrade command

### DIFF
--- a/dnf-behave-tests/dnf/comps-group-disabled-repo.feature
+++ b/dnf-behave-tests/dnf/comps-group-disabled-repo.feature
@@ -16,7 +16,7 @@ Background: Install group DNF-CI-Testgroup
           | group-install | DNF-CI-Testgroup                  |
 
 Scenario: Remove group with disabled repository
-   When I execute dnf with args "group remove dnf-ci-testgroup --disablerepo=dnf-ci-thirdparty"
+   When I execute dnf with args "group remove dnf-ci-testgroup --disable-repo=dnf-ci-thirdparty"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                           |
@@ -28,7 +28,7 @@ Scenario: Remove group with disabled repository
 
 @bz2064341
 Scenario: Remove group with no enabed repository
-   When I execute dnf with args "group remove dnf-ci-testgroup --disablerepo=\*"
+   When I execute dnf with args "group remove dnf-ci-testgroup --disable-repo=\*"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                           |

--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -109,7 +109,7 @@ Scenario: Install installed group when group is not available
         | install-group | filesystem-0:3.9-2.fc29.x86_64    |
         | install-dep   | setup-0:2.12.1-1.fc29.noarch      |
         | group-install | DNF-CI-Testgroup                  |
-   When I execute dnf with args "group install --disablerepo=dnf-ci-thirdparty dnf-ci-testgroup"
+   When I execute dnf with args "group install --disable-repo=dnf-ci-thirdparty dnf-ci-testgroup"
    Then the exit code is 1
     And dnf4 stderr contains "Module or Group 'dnf-ci-testgroup' is not available."
     And dnf5 stderr is

--- a/dnf-behave-tests/dnf/comps-upgrade.feature
+++ b/dnf-behave-tests/dnf/comps-upgrade.feature
@@ -93,10 +93,9 @@ Scenario: Upgrade group when there are both old and new packages - install only 
         | group-upgrade | AB-group                           |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "mark" for command "group"
+@dnf5
 Scenario: Upgrade group to new metadata and back - always install new packages
-  Given I successfully execute dnf with args "group mark install AB-group"
+  Given I successfully execute dnf with args "group install --no-packages AB-group"
     And I drop repository "comps-upgrade-1"
     And I use repository "comps-upgrade-2"
    When I execute dnf with args "group upgrade AB-group"
@@ -116,6 +115,9 @@ Scenario: Upgrade group to new metadata and back - always install new packages
         | install-group | A-mandatory-0:1.0-1.x86_64         |
         | install-group | A-default-0:1.0-1.x86_64           |
         | install-group | A-conditional-true-0:1.0-1.x86_64  |
+        | remove        | B-mandatory-0:1.0-1.x86_64         |
+        | remove        | B-default-0:1.0-1.x86_64           |
+        | remove        | B-conditional-true-0:1.0-1.x86_64  |
         | group-upgrade | AB-group                           |
 
 

--- a/dnf-behave-tests/dnf/comps-upgrade.feature
+++ b/dnf-behave-tests/dnf/comps-upgrade.feature
@@ -53,10 +53,9 @@ Scenario: Upgrade group when there are new package versions - upgrade packages
         | group-upgrade | A-group - repo#2                   |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "mark" for command "group"
+@dnf5
 Scenario: Upgrade group when there are no new packages - nothing is installed
-  Given I successfully execute dnf with args "group mark install AB-group"
+  Given I successfully execute dnf with args "group install --no-packages AB-group"
    When I execute dnf with args "group upgrade AB-group"
    Then the exit code is 0
     And Transaction is following
@@ -64,10 +63,9 @@ Scenario: Upgrade group when there are no new packages - nothing is installed
         | group-upgrade | AB-group                           |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "mark" for command "group"
+@dnf5
 Scenario: Upgrade group when there are new packages - install new packages
-  Given I successfully execute dnf with args "group mark install AB-group"
+  Given I successfully execute dnf with args "group install --no-packages AB-group"
     And I drop repository "comps-upgrade-1"
     And I use repository "comps-upgrade-2"
    When I execute dnf with args "group upgrade AB-group"
@@ -80,10 +78,9 @@ Scenario: Upgrade group when there are new packages - install new packages
         | group-upgrade | AB-group                           |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "mark" for command "group"
+@dnf5
 Scenario: Upgrade group when there are both old and new packages - install only new packages
-  Given I successfully execute dnf with args "group mark install AB-group"
+  Given I successfully execute dnf with args "group install --no-packages AB-group"
       # I don't drop repository comps-upgrade-1, so the comps are merged
     And I use repository "comps-upgrade-2"
    When I execute dnf with args "group upgrade AB-group"

--- a/dnf-behave-tests/dnf/comps-upgrade.feature
+++ b/dnf-behave-tests/dnf/comps-upgrade.feature
@@ -39,12 +39,11 @@ Background: Enable comps-upgrade-1 nad install dummy
   Given I use repository "comps-upgrade-1"
     And I successfully execute dnf with args "install dummy"
 
-# @dnf5
-# TODO(nsella) Unknown argument "install" for command "group"
+@dnf5
 Scenario: Upgrade group when there are new package versions - upgrade packages
-  Given I successfully execute dnf with args "group install 'A-group - repo#1'"
+  Given I successfully execute dnf with args "group install a-group"
     And I use repository "comps-upgrade-2"
-   When I execute dnf with args "group upgrade 'A-group - repo#1'"
+   When I execute dnf with args "group upgrade a-group"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                            |
@@ -123,8 +122,7 @@ Scenario: Upgrade group to new metadata and back - always install new packages
         | group-upgrade | AB-group                           |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "install" for command "group"
+@dnf5
 Scenario: Upgrade group when there were excluded packages during installation - don't install these packages
    When I execute dnf with args "group install AB-group --exclude=A-mandatory,A-default,A-optional,A-conditional-true"
    Then the exit code is 0
@@ -138,8 +136,7 @@ Scenario: Upgrade group when there were excluded packages during installation - 
         | group-upgrade | AB-group                           |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "install" for command "group"
+@dnf5
 Scenario: Upgrade group when there were removed packages since installation - don't install these packages
   Given I successfully execute dnf with args "group install AB-group"
     And I successfully execute dnf with args "remove A-mandatory A-default A-conditional-true"
@@ -256,8 +253,7 @@ Scenario: Upgrade environment when there were removed packages since installatio
         | env-upgrade   | AB-environment                     |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "install" for command "group"
+@dnf5
 @bz1872586
 Scenario: Upgrade empty group
   Given I successfully execute dnf with args "group install empty-group"
@@ -305,24 +301,22 @@ Scenario: Upgrade environment with installed optional groups
         | env-upgrade   | optional-environment               |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "upgrade" for command "group"
+@dnf5
 Scenario: Upgrade nonexistent group
    When I execute dnf with args "group upgrade nonexistent"
    Then the exit code is 1
     And Transaction is empty
     And stderr is
         """
-        Module or Group 'nonexistent' is not installed.
-        Error: No group marked for upgrade.
+        Failed to resolve the transaction:
+        No match for argument: nonexistent
         """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "install" for command "group"
+@dnf5
 Scenario: Upgrade nonexistent and existent group
   Given I successfully execute dnf with args "group install empty-group"
-   When I execute dnf with args "group upgrade nonexistent empty-group"
+   When I execute dnf with args "group upgrade nonexistent empty-group --skip-unavailable"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                            |

--- a/dnf-behave-tests/dnf/steps/lib/dnf.py
+++ b/dnf-behave-tests/dnf/steps/lib/dnf.py
@@ -48,6 +48,7 @@ ACTIONS_EN = {
     "Removing Groups": "group-remove",
     "Removing groups": "group-remove",
     "Upgrading Groups": "group-upgrade",
+    "Upgrading groups": "group-upgrade",
     "Installing Environment Groups": "env-install",
     "Removing Environment Groups": "env-remove",
     "Upgrading Environment Groups": "env-upgrade",


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/491 and https://github.com/rpm-software-management/dnf5/pull/478