### PR TITLE
clean and clean-cachefiles: update scenarios for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/clean-cachefiles.feature
+++ b/dnf-behave-tests/dnf/clean-cachefiles.feature
@@ -1,8 +1,7 @@
+@dnf5
 Feature: Testing that dnf clean command removes files from the cache
 
 
-# @dnf5
-# TODO(nsella) different stdout
 Background: Fill the cache
   Given I use repository "simple-base" as http
    When I execute dnf with args "--setopt=keepcache=true install labirinto"
@@ -15,16 +14,14 @@ Background: Fill the cache
    Then stdout matches line by line
    """
    \.
-   \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/filelists\.xml\.gz
    \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.gz
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
-   \./simple-base-filenames\.solvx
-   \./simple-base\.solv
+   \./simple-base-[0-9a-f]{16}/solv
+   \./simple-base-[0-9a-f]{16}/solv/simple-base\.solv
    """
 
 
@@ -34,10 +31,6 @@ Scenario: Cleanup of the whole cache (dnf clean all)
    Then stdout matches line by line
    """
    \.
-   \./expired_repos\.json
-   \./simple-base-[0-9a-f]{16}
-   \./simple-base-[0-9a-f]{16}/packages
-   \./simple-base-[0-9a-f]{16}/repodata
    """
 
 
@@ -47,11 +40,9 @@ Scenario: Cached metadata cleanup (dnf clean metadata)
    Then stdout matches line by line
    """
    \.
-   \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
-   \./simple-base-[0-9a-f]{16}/repodata
    """
 
 
@@ -61,15 +52,12 @@ Scenario: Cached packages cleanup (dnf clean packages)
    Then stdout matches line by line
    """
    \.
-   \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
-   \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/filelists\.xml\.gz
    \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.gz
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
-   \./simple-base-filenames\.solvx
-   \./simple-base\.solv
+   \./simple-base-[0-9a-f]{16}/solv
+   \./simple-base-[0-9a-f]{16}/solv/simple-base\.solv
    """
 
 
@@ -79,12 +67,10 @@ Scenario: Database cached cleanup (dnf clean dbcache)
    Then stdout matches line by line
    """
    \.
-   \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/filelists\.xml\.gz
    \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.gz
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
    """

--- a/dnf-behave-tests/dnf/clean.feature
+++ b/dnf-behave-tests/dnf/clean.feature
@@ -2,7 +2,7 @@ Feature: Testing dnf clean command
 
 
 # @dnf5
-# TODO(nsella) Unknown argument "makecache" for command "microdnf"
+# TODO(nsella) -C not available for dnf5
 Scenario: Ensure that metadata are unavailable after "dnf clean all"
   Given I use repository "dnf-ci-rich" with configuration
         | key                 | value |
@@ -26,8 +26,7 @@ Scenario: Ensure that metadata are unavailable after "dnf clean all"
         | remove        | cream-0:1.0-1.x86_64                  |
 
 
-# @dnf5
-# TODO(nsella) different stdout
+@dnf5
 @tier1
 Scenario: Expire dnf cache and run repoquery for a package that has been removed meanwhile
   Given I copy repository "dnf-ci-thirdparty-updates" for modification
@@ -36,6 +35,7 @@ Scenario: Expire dnf cache and run repoquery for a package that has been removed
    Then the exit code is 0
     And stdout is
         """
+        <REPOSYNC>
         SuperRipper-0:1.2-1.src
         SuperRipper-0:1.2-1.x86_64
         SuperRipper-0:1.3-1.src
@@ -48,6 +48,7 @@ Scenario: Expire dnf cache and run repoquery for a package that has been removed
    Then the exit code is 0
     And stdout is
         """
+        <REPOSYNC>
         SuperRipper-0:1.2-1.src
         SuperRipper-0:1.2-1.x86_64
         SuperRipper-0:1.3-1.src
@@ -60,6 +61,7 @@ Scenario: Expire dnf cache and run repoquery for a package that has been removed
    Then the exit code is 0
     And stdout is
         """
+        <REPOSYNC>
         SuperRipper-0:1.2-1.src
         SuperRipper-0:1.3-1.src
         SuperRipper-0:1.3-1.x86_64


### PR DESCRIPTION
Scenarios in clean.feature and clean-cachefiles.feature have been updated for dnf5.
One scenario is still not enabled for dnf5 due to -C option which is not implemented in dnf5 yet.