### PR TITLE
Add a scenario to test alias is not present and dnf5 exits gracefully

### DIFF
--- a/dnf-behave-tests/dnf/command-aliases.feature
+++ b/dnf-behave-tests/dnf/command-aliases.feature
@@ -82,7 +82,6 @@ Examples:
         | repository-packages | repo-packages                |
         | repository-packages | repository-pkgs              |
         | search              | search                       |
-        | search              | se                           |
         | shell               | shell                        |
         | shell               | sh                           |
         | swap                | swap                         |
@@ -103,3 +102,13 @@ Examples:
         | upgrade-minimal     | upgrade-minimal              |
         | upgrade-minimal     | update-minimal               |
         | upgrade-minimal     | up-min                       |
+
+@dnf5
+Scenario Outline: "<alias>" is not an alias for "<command>"
+   When I execute dnf with args "<alias>"
+   Then the exit code is 2
+    And stderr contains "Unknown argument \"<alias>\" for command "
+
+Examples:
+        | command             | alias                        |
+        | search              | se                           |


### PR DESCRIPTION
New scenario to test that dnf5 doesn't contain specific aliases as part of aliases reduction.

https://github.com/rpm-software-management/ci-dnf-stack/issues/1270

As a follow-up we will just move the aliases from the scenario above to this one.