### PR TITLE
Tests for transaction test file conflicts reporting

### DIFF
--- a/dnf-behave-tests/dnf/install-file-conflicts.feature
+++ b/dnf-behave-tests/dnf/install-file-conflicts.feature
@@ -1,0 +1,16 @@
+@dnf5
+Feature: Tests for file conflicts reporting
+
+Background:
+  Given I use repository "dnf-ci-install-conflicts"
+
+
+Scenario: An error is reported when a package with a file conflict is tried to be installed
+  Given I successfully execute dnf with args "install package-one-1.0-1.x86_64"
+   Then Transaction is following
+        | Action                    | Package                      |
+        | install                   | package-one-0:1.0-1.x86_64   |
+   When I execute dnf with args "install package-two-1.0-1.x86_64"
+   Then the exit code is 0
+   Then stdout contains "Rpm transaction failed."
+    And stdout contains "file /usr/lib/package/conflicting-file from install of package-two-0:1.0-1.x86_64 conflicts with file from package package-one-0:1.0-1.x86_64"

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-install-conflicts/package-one-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-install-conflicts/package-one-1.0-1.spec
@@ -1,0 +1,22 @@
+Name:           package-one
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package to fail on a file conflict
+
+%description
+File conflict package 1.
+
+%install
+mkdir -p %{buildroot}/usr/lib/package
+echo 1 > %{buildroot}/usr/lib/package/conflicting-file
+
+%files
+%dir /usr/lib/package
+/usr/lib/package/conflicting-file
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-install-conflicts/package-two-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-install-conflicts/package-two-1.0-1.spec
@@ -1,0 +1,22 @@
+Name:           package-two
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package to fail on a file conflict
+
+%description
+File conflict package 2.
+
+%install
+mkdir -p %{buildroot}/usr/lib/package
+echo 2 > %{buildroot}/usr/lib/package/conflicting-file
+
+%files
+%dir /usr/lib/package
+/usr/lib/package/conflicting-file
+
+%changelog


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/517.