### PR TITLE
reinstall: added scenarios for --skip-unavailable

### DIFF
--- a/dnf-behave-tests/dnf/reinstall.feature
+++ b/dnf-behave-tests/dnf/reinstall.feature
@@ -51,3 +51,49 @@ Scenario: Reinstall an RPM that is not available
   Given I drop repository "dnf-ci-fedora-updates"
    When I execute dnf with args "reinstall CQRlib"
    Then the exit code is 1
+
+
+Scenario: Reinstall list of packages, one of them is not available
+   When I execute dnf with args "reinstall CQRlib nosuchpkg"
+   Then the exit code is 1
+    And stderr is
+    """
+    Failed to resolve the transaction:
+    No match for argument: nosuchpkg
+    """
+    And Transaction is empty
+
+
+Scenario: Reinstall list of packages with --skip-unavailable, one of them is not available
+   When I execute dnf with args "reinstall --skip-unavailable CQRlib nosuchpkg"
+   Then the exit code is 0
+    And stderr is
+    """
+    No match for argument: nosuchpkg
+    """
+    And Transaction is following
+        | Action        | Package                                   |
+        | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |
+
+
+Scenario: Reinstall list of packages, one of them is not installed
+   When I execute dnf with args "reinstall abcde CQRlib"
+   Then the exit code is 1
+    And stderr is
+    """
+    Failed to resolve the transaction:
+    Packages for argument 'abcde' available, but not installed.
+    """
+    And Transaction is empty
+
+
+Scenario: Reinstall list of packages with --skip-unavailable, one of them is not installed
+   When I execute dnf with args "reinstall --skip-unavailable abcde CQRlib"
+   Then the exit code is 0
+    And stderr is
+    """
+    Packages for argument 'abcde' available, but not installed.
+    """
+    And Transaction is following
+        | Action        | Package                                   |
+        | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |


### PR DESCRIPTION
Added scenarios for reinstall when at least one of the arguments is either not installed or does not exist, also for --skip-unavailable