### PR TITLE
dnf-nighly: keep libsolv fedora patches

### DIFF
--- a/overlays/dnf-nightly/overlay.yml
+++ b/overlays/dnf-nightly/overlay.yml
@@ -13,7 +13,7 @@ components:
       src: github:openSUSE/libsolv.git
     distgit:
       src: fedorapkgs:libsolv.git
-      patches: drop
+      patches: keep
     distgit-overrides:
       - chroots:
           - centos-stream-8-x86_64


### PR DESCRIPTION
Since we take libsolv specfile from fedora we also need to keep patches if there are any. Otherwise the build will fail because the spec requires them.

There was a recent libsolv fedora release which contains several patches and it is currenly causing our nightly builds to fail.

Here is one failing action: https://github.com/rpm-software-management/ci-dnf-stack/actions/runs/4998121904/jobs/8957172363