### PR TITLE
Remove microdnf from install obsolete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN set -x && \
 
 # install local RPMs if available
 COPY ./rpms/ /opt/ci/rpms/
-RUN rm /opt/ci/rpms/*-{devel,debuginfo,debugsource}*.rpm; \
+#  Remove also microdnf because it is obsoleted in Fedora 38+ by dnf5 therefore cannot be install
+RUN rm /opt/ci/rpms/*-{devel,debuginfo,debugsource}*.rpm /opt/ci/rpms/microdnf-*.rpm; \
     if [ -n "$(find /opt/ci/rpms/ -maxdepth 1 -name '*.rpm' -print -quit)" ]; then \
         dnf -y install /opt/ci/rpms/*.rpm --disableplugin=local; \
     fi

--- a/overlays/dnf-ci/overlay.yml
+++ b/overlays/dnf-ci/overlay.yml
@@ -39,8 +39,8 @@ components:
     requires:
       - dnf
 
-  - name: microdnf
+  - name: dnf5
     git:
-      src: github:rpm-software-management/microdnf.git
+      src: github:rpm-software-management/dnf5.git
     requires:
-      - libdnf
+      - librepo


### PR DESCRIPTION
In Fedora 38, microdnf is obsoleted by dnf5 therefore we cannot install both - microdnf and dnf5.