### PR TITLE
[dnf4 backport] Fix podman runs: temporarily hardcode crun downgrade

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -20,6 +20,9 @@ runs:
     - name: Run Integration Tests
       shell: bash
       run: |
+        # Temporary workaround for an issue: https://github.com/containers/crun/issues/1226
+        dnf downgrade crun-1.8.3 -y
+
         # needed for podman user containers to work
         export STORAGE_OPTS='overlay2.mount_program=/usr/bin/fuse-overlayfs'
         echo "[engine]" > /etc/containers/containers.conf


### PR DESCRIPTION
There appears to be a problem with the newest crun. Reported issue: https://github.com/containers/crun/issues/1226

This should make the CI work again.