### PR TITLE
Move all pids into a sub-cgroup to allow nested containers

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -20,8 +20,15 @@ runs:
     - name: Run Integration Tests
       shell: bash
       run: |
-        # Temporary workaround for an issue: https://github.com/containers/crun/issues/1226
-        dnf downgrade crun-1.8.3 -y
+        # Nested container (podman) in container requires that the root
+        # cgroup is empty: https://github.com/containers/crun/issues/1226
+        # Move all running processes into a sub-cgroup.
+        mkdir /sys/fs/cgroup/init
+        pgrep '.*' |
+        while read pid; do
+          # pids can only be written one at a time
+          echo $pid > /sys/fs/cgroup/init/cgroup.procs;
+        done
 
         # needed for podman user containers to work
         export STORAGE_OPTS='overlay2.mount_program=/usr/bin/fuse-overlayfs'

--- a/.github/workflows/ci-host.yml
+++ b/.github/workflows/ci-host.yml
@@ -36,6 +36,8 @@ jobs:
           RUN dnf -y install rpm-gitoverlay fuse-overlayfs parallel podman wget clang-tools-extra
           # needed for pre-commit hooks
           RUN dnf -y install git python3-pip rpmlint
+          # needed for moving of PIDs in integration-tests
+          RUN dnf -y install procps-ng
           RUN dnf clean all  # remove dnf cache to make the image smaller
           EOF
 


### PR DESCRIPTION
Additional details: https://github.com/containers/crun/issues/1226

The CI will fail for this PR because it requires updated ci-host image.