### PR TITLE
Revert "dnf-nighly: keep libsolv fedora patches"

### DIFF
--- a/overlays/dnf-nightly/overlay.yml
+++ b/overlays/dnf-nightly/overlay.yml
@@ -13,7 +13,7 @@ components:
       src: github:openSUSE/libsolv.git
     distgit:
       src: fedorapkgs:libsolv.git
-      patches: keep
+      patches: drop
     distgit-overrides:
       - chroots:
           - centos-stream-8-x86_64


### PR DESCRIPTION
This reverts commit b241747b47d98fc14831f5dc4075945df514ade2.

It was a bad approach fixing a symptom not the cause: https://github.com/rpm-software-management/rpm-gitoverlay/pull/39

We cannot apply downstream patches to latest upstream commits.