### PR TITLE
CLI now returns error exit code after RPM transaction error

### DIFF
--- a/dnf-behave-tests/dnf/install-file-conflicts.feature
+++ b/dnf-behave-tests/dnf/install-file-conflicts.feature
@@ -11,6 +11,6 @@ Scenario: An error is reported when a package with a file conflict is tried to b
         | Action                    | Package                      |
         | install                   | package-one-0:1.0-1.x86_64   |
    When I execute dnf with args "install package-two-1.0-1.x86_64"
-   Then the exit code is 0
+   Then the exit code is 1
    Then stdout contains "Rpm transaction failed."
     And stdout contains "file /usr/lib/package/conflicting-file from install of package-two-0:1.0-1.x86_64 conflicts with file from package package-one-0:1.0-1.x86_64"


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf5/pull/586.