### PR TITLE
repoquery: enable passing recent/rich-deps/weak-deps features

### DIFF
--- a/dnf-behave-tests/dnf/repoquery/recent.feature
+++ b/dnf-behave-tests/dnf/repoquery/recent.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Tests for dnf repoquery --recent option
 
 
@@ -17,7 +18,10 @@ Background: prepare repository with recent package labirinto
 Scenario: dnf repoquery --recent vagare (when there's no such recent pkg)
    When I execute dnf with args "repoquery --recent vagare"
    Then the exit code is 0
-    And stdout is empty
+    And stdout is
+    """
+    <REPOSYNC>
+    """
 
 
 Scenario: dnf repoquery --recent labirinto (when recent pkg exists)
@@ -25,6 +29,7 @@ Scenario: dnf repoquery --recent labirinto (when recent pkg exists)
    Then the exit code is 0
     And stdout is
     """
+    <REPOSYNC>
     labirinto-0:1.0-1.fc29.x86_64
     """
 
@@ -34,5 +39,6 @@ Scenario: dnf repoquery --recent --installed labirinto (when recent pkg exists)
    Then the exit code is 0
     And stdout is
     """
+    <REPOSYNC>
     labirinto-0:1.0-1.fc29.x86_64
     """

--- a/dnf-behave-tests/dnf/repoquery/rich-deps.feature
+++ b/dnf-behave-tests/dnf/repoquery/rich-deps.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Tests for rich (boolean) dependencies:
  and - requires all operands to be fulfilled for the term to be True.
  or - requires one of the operands to be fulfilled
@@ -17,12 +18,12 @@ Scenario: repoquery --recommends NAME
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       (b1 and a1)
       """
 
 
 # c1-1.0: Requires: (a1-prov1 if b1)
-@dnf5
 Scenario: repoquery --whatrequires for "(a1-prov1 if b1)"
  When I execute dnf with args "repoquery --whatrequires a1"
  Then the exit code is 0
@@ -36,7 +37,6 @@ Scenario: repoquery --whatrequires for "(a1-prov1 if b1)"
 
 @bz1534123
 @bz1698034
-@dnf5
 Scenario: repoquery --whatrequires NAME for "(b1-prov2 >= 1.0 with b1-prov2 < 2.0)"
  When I execute dnf with args "repoquery --whatrequires b1"
  Then the exit code is 0
@@ -48,7 +48,6 @@ Scenario: repoquery --whatrequires NAME for "(b1-prov2 >= 1.0 with b1-prov2 < 2.
 
 @bz1534123
 @bz1698034
-@dnf5
 Scenario: repoquery --whatrequires PROVIDE_NAME = VERSION for "(b1-prov2 >= 1.0 with b1-prov2 < 2.0)"
  When I execute dnf with args "repoquery --whatrequires 'b1-prov2 = 1.0'"
  Then the exit code is 0
@@ -60,7 +59,6 @@ Scenario: repoquery --whatrequires PROVIDE_NAME = VERSION for "(b1-prov2 >= 1.0 
 
 
 # a1-1.0: Conflicts: ((b1 and x1) or c1)
-@dnf5
 Scenario: repoquery --whatconflicts for "((b1 and x1) or c1)"
  When I execute dnf with args "repoquery --whatconflicts b1"
  Then the exit code is 0
@@ -109,7 +107,6 @@ Given I successfully execute dnf with args "install x1"
 
 @bz1534123
 @bz1698034
-@dnf5
 Scenario: repoquery --whatconflicts for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)"
  When I execute dnf with args "repoquery --whatconflicts d1-1.0"
  Then the exit code is 0
@@ -121,7 +118,6 @@ Scenario: repoquery --whatconflicts for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)"
 
 @bz1534123
 @bz1698034
-@dnf5
 Scenario: repoquery --whatconflicts PROVIDE_NAME = VERSION for "(d1-prov1 >= 1.0 with d1-prov0 < 2.0)"
  When I execute dnf with args "repoquery --whatconflicts 'd1-prov1 = 1.0'"
  Then the exit code is 0
@@ -133,7 +129,6 @@ Scenario: repoquery --whatconflicts PROVIDE_NAME = VERSION for "(d1-prov1 >= 1.0
 
 
 # a1-1.0: Recommends: (b1 < 2.0 if x1 >= 2.0 else c1)
-@dnf5
 Scenario: repoquery --whatrecommends for "(b1 < 2.0 if x1 >= 2.0 else c1)"
  When I execute dnf with args "repoquery --whatrecommends b1"
  Then the exit code is 0
@@ -168,7 +163,6 @@ Scenario: repoquery --whatrecommends for "(b1 < 2.0 if x1 >= 2.0 else c1)"
 
 
 # a1-1.0: Suggests: ((b1 with b1-prov2 > 1.7) or (c1 <= 1.0 without c1-prov1 > 0.5))
-@dnf5
 Scenario: repoquery --whatsuggests for "((b1 with b1-prov2 > 1.7) or (c1 <= 1.0 without c1-prov1 > 0.5))"
  When I execute dnf with args "repoquery --whatsuggests b1"
  Then the exit code is 0
@@ -188,7 +182,6 @@ Scenario: repoquery --whatsuggests for "((b1 with b1-prov2 > 1.7) or (c1 <= 1.0 
 
 @bz1534123
 @bz1698034
-@dnf5
 Scenario: repoquery --whatsuggests for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" - only d1-1.0 should match
  When I execute dnf with args "repoquery --whatsuggests d1"
  Then the exit code is 0
@@ -200,7 +193,6 @@ Scenario: repoquery --whatsuggests for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" -
 
 @bz1534123
 @bz1698034
-@dnf5
 Scenario: repoquery --whatsuggests with provide for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" - only b1-1.0 should match
 When I execute dnf with args "repoquery --whatsuggests 'd1-prov1 = 1.0'"
  Then the exit code is 0
@@ -212,7 +204,6 @@ When I execute dnf with args "repoquery --whatsuggests 'd1-prov1 = 1.0'"
 
 
 # a1-1.0: Supplements: ((b1 < 2.0 with b1-prov2 > 1.7) or (c1 > 1.0 without c1-prov1 > 0.5))
-@dnf5
 Scenario: repoquery --whatsupplements for "((b1 < 2.0 with b1-prov2 > 1.7) or (c1 > 1.0 without c1-prov1 > 0.5))"
  When I execute dnf with args "repoquery --whatsupplements b1"
  Then the exit code is 0
@@ -230,7 +221,6 @@ Scenario: repoquery --whatsupplements for "((b1 < 2.0 with b1-prov2 > 1.7) or (c
 
 
 # a1-1.0: Enhances: (b1 unless x1)
-@dnf5
 Scenario: repoquery --whatenhances for "(b1 unless x1)"
  When I execute dnf with args "repoquery --whatenhances b1"
  Then the exit code is 0
@@ -250,7 +240,6 @@ Given I successfully execute dnf with args "install x1"
 
 
 # b1-1.0: Enhances: (a1 unless x1 else c1)
-@dnf5
 Scenario: repoquery --whatenhances for "(a1 unless x1 else c1)"
  When I execute dnf with args "repoquery --whatenhances a1"
  Then the exit code is 0
@@ -284,7 +273,6 @@ Given I successfully execute dnf with args "install x1"
 
 
 # --whatdepends
-@dnf5
 Scenario: repoquery --whatdepends NAME
  When I execute dnf with args "repoquery --whatdepends c1"
  Then the exit code is 0

--- a/dnf-behave-tests/dnf/repoquery/weak-deps.feature
+++ b/dnf-behave-tests/dnf/repoquery/weak-deps.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Tests for repoquery weak deps related functionality:
  --recommends, --supplements, --suggests, --enhances,
  --whatrecommends, --whatsupplements, --whatsuggests, --whatenhances
@@ -29,6 +30,7 @@ Scenario: repoquery --recommends NAME
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       b1
       b1 > 1.0
       b2 = 2.0
@@ -39,6 +41,7 @@ Scenario: repoquery --recommends NAME-VERSION
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       b1
       """
 
@@ -47,6 +50,7 @@ Scenario: repoquery --recommends NAMEGLOB-VERSION
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       b1 > 1.0
       b2 = 2.0
       """
@@ -54,7 +58,10 @@ Scenario: repoquery --recommends NAMEGLOB-VERSION
 Scenario: repoquery --recommends NAME (nonexisting package)
  When I execute dnf with args "repoquery --recommends dummy"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
 # --supplements
@@ -63,6 +70,7 @@ Scenario: repoquery --supplements NAME
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       c1
       c1 >= 1.0
       c2 = 2.0
@@ -73,6 +81,7 @@ Scenario: repoquery --supplements NAME-VERSION
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       c1
       """
 
@@ -81,6 +90,7 @@ Scenario: repoquery --supplements NAMEGLOB-VERSIONGLOB
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       c1
       c1 >= 1.0
       c2 = 1.0
@@ -90,7 +100,10 @@ Scenario: repoquery --supplements NAMEGLOB-VERSIONGLOB
 Scenario: repoquery --supplements NAME (nonexisting package)
  When I execute dnf with args "repoquery --supplements dummy"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
 # --suggests
@@ -99,6 +112,7 @@ Scenario: repoquery --suggests NAME
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       d1
       d1 < 1.0
       d2 = 2.0
@@ -109,6 +123,7 @@ Scenario: repoquery --suggests NAME-VERSION
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       d1
       """
 
@@ -117,13 +132,17 @@ Scenario: repoquery --suggests NAMEGLOB-VERSION
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       d1
       """
 
 Scenario: repoquery --suggests NAME (nonexisting package)
  When I execute dnf with args "repoquery --suggests dummy"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
 # --enhances
@@ -132,6 +151,7 @@ Scenario: repoquery --enhances NAME
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       a1
       a1 <= 1.0
       a2 = 2.0
@@ -142,6 +162,7 @@ Scenario: repoquery --enhances NAME-VERSION
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       a1
       """
 
@@ -150,17 +171,20 @@ Scenario: repoquery --enhances NAMEGLOB-VERSIONGLOB
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       a1
       """
 
 Scenario: repoquery --enhances NAME (nonexisting package)
  When I execute dnf with args "repoquery --enhances dummy"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
 # --whatrecommends
-@dnf5
 Scenario: repoquery --whatrecommends NAME
  When I execute dnf with args "repoquery --whatrecommends b2"
  Then the exit code is 0
@@ -171,7 +195,6 @@ Scenario: repoquery --whatrecommends NAME
       a2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatrecommends NAMEGLOB
  When I execute dnf with args "repoquery --whatrecommends b?"
  Then the exit code is 0
@@ -183,7 +206,6 @@ Scenario: repoquery --whatrecommends NAMEGLOB
       a2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatrecommends NAMEGLOB > VERSION
  When I execute dnf with args "repoquery --whatrecommends 'b? < 1.0'"
  Then the exit code is 0
@@ -194,7 +216,6 @@ Scenario: repoquery --whatrecommends NAMEGLOB > VERSION
       a2-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatrecommends NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatrecommends dummy"
  Then the exit code is 0
@@ -205,7 +226,6 @@ Scenario: repoquery --whatrecommends NAME (nonexisting package)
 
 
 # --whatsupplements
-@dnf5
 Scenario: repoquery --whatsupplements NAME
  When I execute dnf with args "repoquery --whatsupplements c2"
  Then the exit code is 0
@@ -216,7 +236,6 @@ Scenario: repoquery --whatsupplements NAME
       b2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatsupplements NAMEGLOB
  When I execute dnf with args "repoquery --whatsupplements c[2]"
  Then the exit code is 0
@@ -227,7 +246,6 @@ Scenario: repoquery --whatsupplements NAMEGLOB
       b2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatsupplements NAMEGLOB >= VERSION
  When I execute dnf with args "repoquery --whatsupplements 'c[2] >= 1.5'"
  Then the exit code is 0
@@ -237,7 +255,6 @@ Scenario: repoquery --whatsupplements NAMEGLOB >= VERSION
       b2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatsupplements NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatsupplements dummy"
  Then the exit code is 0
@@ -248,7 +265,6 @@ Scenario: repoquery --whatsupplements NAME (nonexisting package)
 
 
 # --whatsuggests
-@dnf5
 Scenario: repoquery --whatsuggests NAME
  When I execute dnf with args "repoquery --whatsuggests d2"
  Then the exit code is 0
@@ -259,7 +275,6 @@ Scenario: repoquery --whatsuggests NAME
       c2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatsuggests NAMEGLOB
  When I execute dnf with args "repoquery --whatsuggests d[12]"
  Then the exit code is 0
@@ -271,7 +286,6 @@ Scenario: repoquery --whatsuggests NAMEGLOB
       c2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatsuggests NAME >= VERSION
  When I execute dnf with args "repoquery --whatsuggests 'd1 >= 3.14'"
  Then the exit code is 0
@@ -282,7 +296,6 @@ Scenario: repoquery --whatsuggests NAME >= VERSION
       c2-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatsuggests NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatsuggests dummy"
  Then the exit code is 0
@@ -293,7 +306,6 @@ Scenario: repoquery --whatsuggests NAME (nonexisting package)
 
 
 # --whatenhances
-@dnf5
 Scenario: repoquery --whatenhances NAME
  When I execute dnf with args "repoquery --whatenhances a2"
  Then the exit code is 0
@@ -304,7 +316,6 @@ Scenario: repoquery --whatenhances NAME
       d2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatenhances NAMEGLOB
  When I execute dnf with args "repoquery --whatenhances a[2]"
  Then the exit code is 0
@@ -315,7 +326,6 @@ Scenario: repoquery --whatenhances NAMEGLOB
       d2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatenhances NAMEGLOB >= VERSION
  When I execute dnf with args "repoquery --whatenhances 'a? >= 3.0'"
  Then the exit code is 0
@@ -326,7 +336,6 @@ Scenario: repoquery --whatenhances NAMEGLOB >= VERSION
       d2-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatenhances NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatenhances dummy"
  Then the exit code is 0
@@ -337,7 +346,6 @@ Scenario: repoquery --whatenhances NAME (nonexisting package)
 
 
 # --whatdepends
-@dnf5
 Scenario: repoquery --whatdepends NAME (requires + enhances)
  When I execute dnf with args "repoquery --whatdepends a1"
  Then the exit code is 0
@@ -350,7 +358,6 @@ Scenario: repoquery --whatdepends NAME (requires + enhances)
       top-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatdepends NAME (requires + recommends)
  When I execute dnf with args "repoquery --whatdepends b1"
  Then the exit code is 0
@@ -363,7 +370,6 @@ Scenario: repoquery --whatdepends NAME (requires + recommends)
       top-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatdepends NAME (requires + supplements)
  When I execute dnf with args "repoquery --whatdepends c1"
  Then the exit code is 0
@@ -376,7 +382,6 @@ Scenario: repoquery --whatdepends NAME (requires + supplements)
       top-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatdepends NAME (requires + suggests)
  When I execute dnf with args "repoquery --whatdepends d1"
  Then the exit code is 0
@@ -389,7 +394,6 @@ Scenario: repoquery --whatdepends NAME (requires + suggests)
       top-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatdepends NAME > VERSION
  When I execute dnf with args "repoquery --whatdepends 'd2 > 1.4'"
  Then the exit code is 0
@@ -399,7 +403,6 @@ Scenario: repoquery --whatdepends NAME > VERSION
       c2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatdepends NAMEGLOB < VERSION
  When I execute dnf with args "repoquery --whatdepends '[abc]2 < 1.5'"
  Then the exit code is 0
@@ -411,7 +414,6 @@ Scenario: repoquery --whatdepends NAMEGLOB < VERSION
       d1-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatdepends NAMEGLOB >= VERSION (ranged matching)
 When I execute dnf with args "repoquery --whatdepends '[abc]1 <= 1.0'"
  Then the exit code is 0
@@ -429,7 +431,6 @@ When I execute dnf with args "repoquery --whatdepends '[abc]1 <= 1.0'"
       top-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --exactdeps --whatdepends NAME
  When I execute dnf with args "repoquery --exactdeps --whatdepends c1"
  Then the exit code is 0
@@ -441,7 +442,6 @@ Scenario: repoquery --exactdeps --whatdepends NAME
       b2-1:2.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --exactdeps --whatdepends NAME (no nonexact deps)
  When I execute dnf with args "repoquery --exactdeps --whatdepends d1"
  Then the exit code is 0
@@ -454,7 +454,6 @@ Scenario: repoquery --exactdeps --whatdepends NAME (no nonexact deps)
       top-1:1.0-1.x86_64
       """
 
-@dnf5
 Scenario: repoquery --whatdepends NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatdepends dummy"
  Then the exit code is 0


### PR DESCRIPTION
repoquery: enable passing recent/rich-deps/weak-deps features