### PR TITLE
createrepo_c tools: switch default compression to zstd 

### DIFF
--- a/dnf-behave-tests/createrepo_c/bad-packages.feature
+++ b/dnf-behave-tests/createrepo_c/bad-packages.feature
@@ -16,9 +16,9 @@ Given I create directory "/temp-repo/"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name      | Epoch | Version | Release | Architecture |
       | package   | 0     | 0.2.1   | 1.fc29  | x86_64       |

--- a/dnf-behave-tests/createrepo_c/cache.feature
+++ b/dnf-behave-tests/createrepo_c/cache.feature
@@ -11,9 +11,9 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type          | File                                | Checksum Type | Compression Type |
-      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary       | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists     | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other         | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -24,9 +24,9 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type          | File                                | Checksum Type | Compression Type |
-      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary       | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists     | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other         | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |

--- a/dnf-behave-tests/createrepo_c/compression.feature
+++ b/dnf-behave-tests/createrepo_c/compression.feature
@@ -37,16 +37,16 @@ Given I create file "/groupfile.xml" with
       <comps>
       </comps>
       """
- When I execute createrepo_c with args "--compress-type zstd --groupfile groupfile.xml ." in "/"
+ When I execute createrepo_c with args "--compress-type gz --groupfile groupfile.xml ." in "/"
  Then the exit code is 0
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha256        | -                |
-      | group_zstd   | ${checksum}-groupfile.xml.zst    | sha256        | zstd             |
+      | group_zstd   | ${checksum}-groupfile.xml.gz     | sha256        | gz               |
   And primary in "/repodata/" doesn't have any packages
 
 

--- a/dnf-behave-tests/createrepo_c/delta-rpms.feature
+++ b/dnf-behave-tests/createrepo_c/delta-rpms.feature
@@ -9,10 +9,10 @@ Scenario: --deltas on empty repo
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type          | File                                | Checksum Type | Compression Type |
-      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
-      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+      | primary       | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists     | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other         | ${checksum}-other.xml.zst           | sha256        | zstd             |
+      | prestodelta   | ${checksum}-prestodelta.xml.zst     | sha256        | zstd             |
 
 
 Scenario: --deltas on repo
@@ -22,10 +22,10 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type          | File                                | Checksum Type | Compression Type |
-      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
-      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+      | primary       | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists     | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other         | ${checksum}-other.xml.zst           | sha256        | zstd             |
+      | prestodelta   | ${checksum}-prestodelta.xml.zst     | sha256        | zstd             |
 
 
 Scenario: --deltas with empty --oldpackagedirs on repo
@@ -36,10 +36,10 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type          | File                                | Checksum Type | Compression Type |
-      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
-      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+      | primary       | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists     | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other         | ${checksum}-other.xml.zst           | sha256        | zstd             |
+      | prestodelta   | ${checksum}-prestodelta.xml.zst     | sha256        | zstd             |
 
 
 Scenario: --deltas with --oldpackagedirs on repo generates drpm
@@ -51,10 +51,10 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages-2/
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type          | File                                | Checksum Type | Compression Type |
-      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
-      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+      | primary       | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists     | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other         | ${checksum}-other.xml.zst           | sha256        | zstd             |
+      | prestodelta   | ${checksum}-prestodelta.xml.zst     | sha256        | zstd             |
   And file "/drpms/package-0.2.1-1.fc29_0.3.1-1.fc29.x86_64.drpm" exists
 
 
@@ -68,10 +68,10 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type          | File                                | Checksum Type | Compression Type |
-      | primary       | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists     | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other         | ${checksum}-other.xml.gz            | sha256        | gz               |
-      | prestodelta   | ${checksum}-prestodelta.xml.gz      | sha256        | gz               |
+      | primary       | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists     | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other         | ${checksum}-other.xml.zst           | sha256        | zstd             |
+      | prestodelta   | ${checksum}-prestodelta.xml.zst     | sha256        | zstd             |
   And file "/drpms/zstd-package-0.2.1-1.fc29_0.3.1-1.fc29.x86_64.drpm" exists
   And I successfully execute "rpm -qp --qf '%{{PAYLOADCOMPRESSOR}}\n' {context.scenario.default_tmp_dir}/drpms/zstd-package-0.2.1-1.fc29_0.3.1-1.fc29.x86_64.drpm"
   And stdout is

--- a/dnf-behave-tests/createrepo_c/empty-repository.feature
+++ b/dnf-behave-tests/createrepo_c/empty-repository.feature
@@ -18,10 +18,10 @@ Scenario: Repo from empty directory with relative path
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
       # These exact file checksums may be fragile (different version of xml lib, slight change to format..)
-      # | primary      | 1cb61ea996355add02b1426ed4c1780ea75ce0c04c5d1107c025c3fbd7d8bcae-primary.xml.gz       | sha256        | gz               |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      # | primary      | 1cb61ea996355add02b1426ed4c1780ea75ce0c04c5d1107c025c3fbd7d8bcae-primary.xml.zst      | sha256        | zstd             |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
 
 
@@ -30,9 +30,9 @@ Scenario: Repo from empty directory with absolute path
  Then the exit code is 0
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
 
 
@@ -42,9 +42,9 @@ Scenario: Repo with --database
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
       | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
       | other_db     | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
@@ -56,9 +56,9 @@ Scenario: Repo with --no-database
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
 
 
 Scenario: Repo with --groupfile
@@ -67,11 +67,11 @@ Scenario: Repo with --groupfile
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha256        | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha256        | gz               |
+      | group_gz     | ${checksum}-groupfile.xml.zst    | sha256        | zstd             |
 
 
 Scenario: Repo with --groupfile and --checksum sha
@@ -80,11 +80,11 @@ Scenario: Repo with --groupfile and --checksum sha
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha224        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha224        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha224        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha224        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha224        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha224        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha224        | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha224        | gz               |
+      | group_gz     | ${checksum}-groupfile.xml.zst    | sha224        | zstd             |
 
 
 Scenario: Repo with --simple-md-filenames and --groupfile
@@ -93,11 +93,11 @@ Scenario: Repo with --simple-md-filenames and --groupfile
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                 | Checksum Type | Compression Type |
-      | primary      | primary.xml.gz       | sha256        | gz               |
-      | filelists    | filelists.xml.gz     | sha256        | gz               |
-      | other        | other.xml.gz         | sha256        | gz               |
+      | primary      | primary.xml.zst      | sha256        | zstd             |
+      | filelists    | filelists.xml.zst    | sha256        | zstd             |
+      | other        | other.xml.zst        | sha256        | zstd             |
       | group        | groupfile.xml        | sha256        | -                |
-      | group_gz     | groupfile.xml.gz     | sha256        | gz               |
+      | group_gz     | groupfile.xml.zst    | sha256        | zstd             |
 
 
 Scenario: Repo with --unique-md-filenames and --groupfile
@@ -106,11 +106,11 @@ Scenario: Repo with --unique-md-filenames and --groupfile
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha256        | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha256        | gz               |
+      | group_gz     | ${checksum}-groupfile.xml.zst    | sha256        | zstd             |
 
 
 Scenario: Repo with --xz compression and --groupfile
@@ -119,9 +119,9 @@ Scenario: Repo with --xz compression and --groupfile
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha256        | -                |
       | group_xz     | ${checksum}-groupfile.xml.xz     | sha256        | xz               |
 
@@ -132,9 +132,9 @@ Scenario: Repo with --compress-type bz2 and --groupfile
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha256        | -                |
       | group_bz2    | ${checksum}-groupfile.xml.bz2    | sha256        | bz2              |
 
@@ -145,9 +145,9 @@ Scenario: Repo with --compress-type gz
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha256        | -                |
       | group_gz     | ${checksum}-groupfile.xml.gz     | sha256        | gz               |
 
@@ -158,9 +158,9 @@ Scenario: Repo with --compress-type xz
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha256        | -                |
       | group_xz     | ${checksum}-groupfile.xml.xz     | sha256        | xz               |
 
@@ -171,11 +171,11 @@ Scenario: Repo with --repomd-checksum and --groupfile
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha224        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha224        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha224        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha224        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha224        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha224        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha224        | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha224        | gz               |
+      | group_gz     | ${checksum}-groupfile.xml.zst    | sha224        | zstd             |
 
 
 Scenario: Repo with --checksum --repomd-checksum and --groupfile
@@ -184,11 +184,11 @@ Scenario: Repo with --checksum --repomd-checksum and --groupfile
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha512        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha512        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha512        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha512        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha512        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha512        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha512        | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha512        | gz               |
+      | group_gz     | ${checksum}-groupfile.xml.zst    | sha512        | zstd             |
 
 
 Scenario: Repo with --general-compress-type and --groupfile
@@ -222,9 +222,9 @@ Scenario: Repo from empty directory with --distro DISTRO-TAG
  Then the exit code is 0
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
   And file "/temp-repo/repodata/repomd.xml" contains lines
       """
@@ -239,9 +239,9 @@ Scenario: Repo from empty directory with --distro CPEID,Footag
  Then the exit code is 0
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
   And file "/temp-repo/repodata/repomd.xml" contains lines
       """
@@ -256,9 +256,9 @@ Scenario: Repo from empty directory with multiple --distro CPEID,Footag
  Then the exit code is 0
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
   And file "/temp-repo/repodata/repomd.xml" contains lines
       """
@@ -274,9 +274,9 @@ Scenario: Repo from empty directory with multiple --content contenttag
  Then the exit code is 0
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
   And file "/temp-repo/repodata/repomd.xml" contains lines
       """
@@ -292,9 +292,9 @@ Scenario: Repo from empty directory with multiple --repo repotag
  Then the exit code is 0
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
   And file "/temp-repo/repodata/repomd.xml" contains lines
       """
@@ -310,9 +310,9 @@ Scenario: Repo from empty directory with --revision XYZ
  Then the exit code is 0
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
   And file "/temp-repo/repodata/repomd.xml" contains lines
       """
@@ -326,8 +326,8 @@ Given I create symlink "/temp-repo/package-0.2.1-1.fc29.x86_64.rpm" to file "/{c
  Then the exit code is 0
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
   And repodata "/temp-repo/repodata/" are consistent
   And primary in "/temp-repo/repodata/" doesn't have any packages

--- a/dnf-behave-tests/createrepo_c/mergerepo_c-compression.feature
+++ b/dnf-behave-tests/createrepo_c/mergerepo_c-compression.feature
@@ -30,7 +30,7 @@ Scenario: Merged repository has zstd compression
   And repodata "/merged_repo/repodata/" are consistent
   And repodata in "/merged_repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | updateinfo   | ${checksum}-updateinfo.xml.zst   | sha256        | zstd             |

--- a/dnf-behave-tests/createrepo_c/mergerepo_c-compression.feature
+++ b/dnf-behave-tests/createrepo_c/mergerepo_c-compression.feature
@@ -17,9 +17,9 @@ Scenario: Merged repository has xz compression
   And repodata "/merged_repo/repodata/" are consistent
   And repodata in "/merged_repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.xz       | sha256        | xz               |
+      | filelists    | ${checksum}-filelists.xml.xz     | sha256        | xz               |
+      | other        | ${checksum}-other.xml.xz         | sha256        | xz               |
       | updateinfo   | ${checksum}-updateinfo.xml.xz    | sha256        | xz               |
 
 

--- a/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
+++ b/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
@@ -89,7 +89,7 @@ Scenario: merged repository contains streams from both source repositories
  Then the exit code is 0
   And stderr is empty
   And repodata "/merged_repo/repodata/" are consistent
-  And file "/merged_repo/repodata/[a-z0-9]*-modules.yaml.gz" contents is
+  And file "/merged_repo/repodata/[a-z0-9]*-modules.yaml.zst" contents is
       """
       ---
       document: modulemd-defaults

--- a/dnf-behave-tests/createrepo_c/mergerepo_c.feature
+++ b/dnf-behave-tests/createrepo_c/mergerepo_c.feature
@@ -17,10 +17,10 @@ Scenario: merged repository doesn't contain sqlite db by default
   And repodata "/merged_repo/repodata/" are consistent
   And repodata in "/merged_repo/repodata/" is
       | Type         | File                          | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz    | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz  | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz      | sha256        | gz               |
-      | updateinfo   | ${checksum}-updateinfo.xml.gz | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst   | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst     | sha256        | zstd             |
+      | updateinfo   | ${checksum}-updateinfo.xml.zst| sha256        | zstd             |
   And primary in "/merged_repo/repodata" has only packages
       | Name         | Epoch | Version | Release | Architecture |
       | package      | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -34,10 +34,10 @@ Scenario: merged repository has sqlite db if specified
   And repodata "/merged_repo/repodata/" are consistent
   And repodata in "/merged_repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | updateinfo   | ${checksum}-updateinfo.xml.gz    | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | updateinfo   | ${checksum}-updateinfo.xml.zst   | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
       | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
       | other_db     | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |

--- a/dnf-behave-tests/createrepo_c/modifyrepo_c-compression.feature
+++ b/dnf-behave-tests/createrepo_c/modifyrepo_c-compression.feature
@@ -20,13 +20,13 @@ Given I create directory "/temp-repo/"
       - MIT
       ...
       """
- When I execute modifyrepo_c with args "--compress-type zstd ../modules.yaml.xz ./repodata" in "/temp-repo"
+ When I execute modifyrepo_c with args "--compress-type gz ../modules.yaml.xz ./repodata" in "/temp-repo"
  Then the exit code is 0
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                             | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules             | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
+      | primary             | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules             | ${checksum}-modules.yaml.gz      | sha256        | gz               |
 

--- a/dnf-behave-tests/createrepo_c/modifyrepo_c.feature
+++ b/dnf-behave-tests/createrepo_c/modifyrepo_c.feature
@@ -28,10 +28,10 @@ Given I create directory "/temp-repo/"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
-      | modules             | ${checksum}-modules.yaml.gz         | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
+      | modules             | ${checksum}-modules.yaml.zst        | sha256        | zstd             |
 
 
 Scenario: Modifying repo with compressed metadata of the same compression type
@@ -58,10 +58,10 @@ Given I create directory "/temp-repo/"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
-      | modules             | ${checksum}-modules.yaml.gz         | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
+      | modules             | ${checksum}-modules.yaml.zst        | sha256        | zstd             |
 
 
 Scenario: Modifying repo with compressed metadata of different compression type
@@ -88,10 +88,10 @@ Given I create directory "/temp-repo/"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
-      | modules             | ${checksum}-modules.yaml.gz         | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
+      | modules             | ${checksum}-modules.yaml.zst        | sha256        | zstd             |
 
 
 # createrepo_c is compiled without support for zchunk on rhel 8 and 9
@@ -120,9 +120,9 @@ Given I create directory "/temp-repo/"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                             | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary             | ${checksum}-primary.xml.zck      | sha256        | zck              |
       | filelists           | ${checksum}-filelists.xml.zck    | sha256        | zck              |
       | other               | ${checksum}-other.xml.zck        | sha256        | zck              |

--- a/dnf-behave-tests/createrepo_c/modular.feature
+++ b/dnf-behave-tests/createrepo_c/modular.feature
@@ -188,10 +188,10 @@ Given I create directory "/empty_repo/"
   And repodata "/empty_repo/repodata/" are consistent
   And repodata in "/empty_repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules      | ${checksum}-modules.yaml.gz      | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules      | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
 
 
 Scenario: modular metadata are added to repository with a package
@@ -204,10 +204,10 @@ Given I create directory "/repo/"
   And repodata "/repo/repodata/" are consistent
   And repodata in "/repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules      | ${checksum}-modules.yaml.gz      | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules      | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
 
 
 Scenario: multiple modular metadata are merged
@@ -218,11 +218,11 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules      | ${checksum}-modules.yaml.gz      | sha256        | gz               |
-  And the text file contents of "/repodata/[a-z0-9]*-modules.yaml.gz" and "/modular-result.yaml" do not differ
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules      | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
+  And the text file contents of "/repodata/[a-z0-9]*-modules.yaml.zst" and "/modular-result.yaml" do not differ
 
 
 Scenario: modular metadata located in repository in subdirectories are added to repodata
@@ -238,11 +238,11 @@ Given I create directory "/repo/a/b"
   And repodata "/repo/repodata/" are consistent
   And repodata in "/repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules      | ${checksum}-modules.yaml.gz      | sha256        | gz               |
-  And the text file contents of "/repo/repodata/[a-z0-9]*-modules.yaml.gz" and "/modular-result.yaml" do not differ
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules      | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
+  And the text file contents of "/repo/repodata/[a-z0-9]*-modules.yaml.zst" and "/modular-result.yaml" do not differ
 
 
 Scenario: modular metadata are added to repodata with pkglist
@@ -261,11 +261,11 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules      | ${checksum}-modules.yaml.gz      | sha256        | gz               |
-  And the text file contents of "/repodata/[a-z0-9]*-modules.yaml.gz" and "/modular-result.yaml" do not differ
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules      | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
+  And the text file contents of "/repodata/[a-z0-9]*-modules.yaml.zst" and "/modular-result.yaml" do not differ
   And primary in "/repodata" has only packages
       | Name             | Epoch | Version | Release | Architecture |
       | modular-package1 | 0     | 0.1     | 1       | x86_64       |
@@ -287,11 +287,11 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules      | ${checksum}-modules.yaml.gz      | sha256        | gz               |
-  And the text file contents of "/repodata/[a-z0-9]*-modules.yaml.gz" and "/modular-result.yaml" do not differ
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules      | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
+  And the text file contents of "/repodata/[a-z0-9]*-modules.yaml.zst" and "/modular-result.yaml" do not differ
   And primary in "/repodata" has only packages
       | Name             | Epoch | Version | Release | Architecture |
       | modular-package1 | 0     | 0.1     | 1       | x86_64       |
@@ -326,9 +326,9 @@ Given I create directory "/empty_repo/"
   And repodata "/empty_repo/repodata/" are consistent
   And repodata in "/empty_repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | modules      | ${checksum}-modules.yaml.xz      | sha256        | xz               |
 
 
@@ -346,11 +346,11 @@ Given I create directory "/repo/"
   And repodata "/repo/repodata/" are consistent
   And repodata in "/repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules      | ${checksum}-modules.yaml.gz      | sha256        | gz               |
-  And file "/repo/repodata/[a-z0-9]*-modules.yaml.gz" contents is
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules      | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
+  And file "/repo/repodata/[a-z0-9]*-modules.yaml.zst" contents is
       """
       ---
       document: modulemd-defaults
@@ -388,11 +388,11 @@ Given I create directory "/repo/"
   And repodata "/repo/repodata/" are consistent
   And repodata in "/repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | modules      | ${checksum}-modules.yaml.gz      | sha256        | gz               |
-  And the text file contents of "/modular-result.yaml" and "/repo/repodata/[a-z0-9]*-modules.yaml.gz" do not differ
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
+      | modules      | ${checksum}-modules.yaml.zst     | sha256        | zstd             |
+  And the text file contents of "/modular-result.yaml" and "/repo/repodata/[a-z0-9]*-modules.yaml.zst" do not differ
 
 
 @bz1906831

--- a/dnf-behave-tests/createrepo_c/regular-repository.feature
+++ b/dnf-behave-tests/createrepo_c/regular-repository.feature
@@ -14,9 +14,9 @@ Scenario: create regular consistent repository with specified packaged and relat
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -30,9 +30,9 @@ Scenario: create regular consistent repository with specified packaged and absol
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -46,9 +46,9 @@ Scenario: create regular consistent repository while excluding all packages
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" doesn't have any packages
 
 
@@ -58,9 +58,9 @@ Scenario: create regular consistent repository while excluding specific packages
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -73,9 +73,9 @@ Scenario: create regular consistent repository while excluding packages by wildc
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -88,9 +88,9 @@ Scenario: create regular consistent repository wihile skipping symlinks
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -108,9 +108,9 @@ Given I create file "/temp-repo/pkglist.txt" with
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -128,9 +128,9 @@ Given I create file "/temp-repo/pkglist.txt" with
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -152,9 +152,9 @@ Given I create file "/temp-repo/pkglist.txt" with
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |

--- a/dnf-behave-tests/createrepo_c/repository-with-subdirs.feature
+++ b/dnf-behave-tests/createrepo_c/repository-with-subdirs.feature
@@ -18,9 +18,9 @@ Scenario: repository with packages in subdirs
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -35,9 +35,9 @@ Scenario: repository with packages in subdirs while skipping symlinks
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -50,9 +50,9 @@ Scenario: repository with packages in subdirs while excluding packages
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name          | Epoch | Version | Release | Architecture |
       | package       | 0     | 0.2.1   | 1.fc29  | x86_64       |
@@ -71,9 +71,9 @@ Given I create directory "/temp-repo/d.rpm"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
   And primary in "/temp-repo/repodata" has only packages
       | Name            | Epoch | Version | Release | Architecture |
       | package         | 0     | 0.2.1   | 1.fc29  | x86_64       |

--- a/dnf-behave-tests/createrepo_c/sqliterepo_c-miscellaneous.feature
+++ b/dnf-behave-tests/createrepo_c/sqliterepo_c-miscellaneous.feature
@@ -23,9 +23,9 @@ Given I execute createrepo_c with args "--no-database ." in "/"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
       | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
       | other_db     | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
@@ -38,9 +38,9 @@ Given I execute createrepo_c with args "--simple-md-filenames --no-database ." i
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                 | Checksum Type | Compression Type |
-      | primary      | primary.xml.gz       | sha256        | gz               |
-      | filelists    | filelists.xml.gz     | sha256        | gz               |
-      | other        | other.xml.gz         | sha256        | gz               |
+      | primary      | primary.xml.zst      | sha256        | zstd             |
+      | filelists    | filelists.xml.zst    | sha256        | zstd             |
+      | other        | other.xml.zst        | sha256        | zstd             |
       | primary_db   | primary.sqlite.bz2   | sha256        | bz2              |
       | filelists_db | filelists.sqlite.bz2 | sha256        | bz2              |
       | other_db     | other.sqlite.bz2     | sha256        | bz2              |
@@ -53,9 +53,9 @@ Given I execute createrepo_c with args "--simple-md-filenames --database ." in "
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                 | Checksum Type | Compression Type |
-      | primary      | primary.xml.gz       | sha256        | gz               |
-      | filelists    | filelists.xml.gz     | sha256        | gz               |
-      | other        | other.xml.gz         | sha256        | gz               |
+      | primary      | primary.xml.zst      | sha256        | zstd             |
+      | filelists    | filelists.xml.zst    | sha256        | zstd             |
+      | other        | other.xml.zst        | sha256        | zstd             |
       | primary_db   | primary.sqlite.bz2   | sha256        | bz2              |
       | filelists_db | filelists.sqlite.bz2 | sha256        | bz2              |
       | other_db     | other.sqlite.bz2     | sha256        | bz2              |
@@ -68,9 +68,9 @@ Given I execute createrepo_c with args "." in "/"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.xz    | sha256        | xz               |
       | filelists_db | ${checksum}-filelists.sqlite.xz  | sha256        | xz               |
       | other_db     | ${checksum}-other.sqlite.xz      | sha256        | xz               |
@@ -83,9 +83,9 @@ Given I execute createrepo_c with args "." in "/"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.gz    | sha256        | gz               |
       | filelists_db | ${checksum}-filelists.sqlite.gz  | sha256        | gz               |
       | other_db     | ${checksum}-other.sqlite.gz      | sha256        | gz               |
@@ -97,10 +97,10 @@ Given I execute createrepo_c with args ". --database" in "/"
  Then the exit code is 0
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
-      | Type         | File                 | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | Type         | File                             | Checksum Type | Compression Type |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.xz    | sha256        | xz               |
       | filelists_db | ${checksum}-filelists.sqlite.xz  | sha256        | xz               |
       | other_db     | ${checksum}-other.sqlite.xz      | sha256        | xz               |
@@ -116,9 +116,9 @@ Given I execute createrepo_c with args "." in "/"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
       | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
       | other_db     | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
@@ -131,9 +131,9 @@ Given I execute createrepo_c with args ". --database" in "/"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.bz2   | sha256        | bz2              |
       | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha256        | bz2              |
       | other_db     | ${checksum}-other.sqlite.bz2     | sha256        | bz2              |
@@ -149,9 +149,9 @@ Given I execute createrepo_c with args "." in "/"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.bz2   | sha512        | bz2              |
       | filelists_db | ${checksum}-filelists.sqlite.bz2 | sha512        | bz2              |
       | other_db     | ${checksum}-other.sqlite.bz2     | sha512        | bz2              |
@@ -164,9 +164,9 @@ Given I execute createrepo_c with args "--no-database ." in "/"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_db   | ${checksum}-primary.sqlite.zst   | sha256        | zstd             |
       | filelists_db | ${checksum}-filelists.sqlite.zst | sha256        | zstd             |
       | other_db     | ${checksum}-other.sqlite.zst     | sha256        | zstd             |

--- a/dnf-behave-tests/createrepo_c/steps/lib/file.py
+++ b/dnf-behave-tests/createrepo_c/steps/lib/file.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import os
+import tempfile
 
 from common.lib.file import decompress_file_by_extension
 
@@ -34,11 +35,11 @@ def decompression_iter(filepath, compression_type, blocksize=65536):
     if compression_type == "bz2":
         return file_as_blockiter(bz2.open(filepath, 'rb'), blocksize)
     if compression_type == "zstd":
-        decompress_file_by_extension_to_dir(filepath, os.path.dirname(filepath))
-        return file_as_blockiter(open(filepath[:-4], 'rb'), blocksize)
+        tmp_file = decompress_file_by_extension_to_dir(filepath, tempfile.mkdtemp())
+        return file_as_blockiter(open(tmp_file, 'rb'), blocksize)
     if compression_type == "zck":
-        decompress_file_by_extension_to_dir(filepath, os.path.dirname(filepath))
-        return file_as_blockiter(open(filepath[:-4], 'rb'), blocksize)
+        tmp_file = decompress_file_by_extension_to_dir(filepath, tempfile.mkdtemp())
+        return file_as_blockiter(open(tmp_file, 'rb'), blocksize)
 
     return file_as_blockiter(open(filepath, 'rb'), blocksize)
 

--- a/dnf-behave-tests/createrepo_c/update-keep-all-metadata.feature
+++ b/dnf-behave-tests/createrepo_c/update-keep-all-metadata.feature
@@ -61,19 +61,19 @@ Scenario: --update with --discard-additional-metadata discards additional metada
 Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/temp-repo"
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | group        | ${checksum}-groupfile.xml        | sha256        | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha256        | gz               |
+      | group_gz     | ${checksum}-groupfile.xml.zst    | sha256        | zstd             |
  When I execute createrepo_c with args "--update --discard-additional-metadata ." in "/temp-repo"
  Then the exit code is 0
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
 
 
 Scenario: --update --keep-all-metadata keeps all additional metadata
@@ -86,14 +86,14 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type            | File                               | Checksum Type | Compression Type |
-      | primary         | ${checksum}-primary.xml.gz         | sha256        | gz               |
-      | filelists       | ${checksum}-filelists.xml.gz       | sha256        | gz               |
-      | other           | ${checksum}-other.xml.gz           | sha256        | gz               |
+      | primary         | ${checksum}-primary.xml.zst        | sha256        | zstd             |
+      | filelists       | ${checksum}-filelists.xml.zst      | sha256        | zstd             |
+      | other           | ${checksum}-other.xml.zst          | sha256        | zstd             |
       | group           | ${checksum}-groupfile.xml          | sha256        | -                |
-      | group_gz        | ${checksum}-groupfile.xml.gz       | sha256        | gz               |
-      | updateinfo      | ${checksum}-updateinfo.xml.gz      | sha256        | gz               |
-      | custom_metadata | ${checksum}-custom_metadata.txt.gz | sha256        | gz               |
-      | modules         | ${checksum}-modules.yaml.gz        | sha256        | gz               |
+      | group_gz        | ${checksum}-groupfile.xml.zst      | sha256        | zstd             |
+      | updateinfo      | ${checksum}-updateinfo.xml.zst     | sha256        | zstd             |
+      | custom_metadata | ${checksum}-custom_metadata.txt.zst| sha256        | zstd             |
+      | modules         | ${checksum}-modules.yaml.zst       | sha256        | zstd             |
 
 
 Scenario: --update --keep-all-metadata --groupfile overrides old groupfile
@@ -104,12 +104,12 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type            | File                               | Checksum Type | Compression Type |
-      | primary         | ${checksum}-primary.xml.gz         | sha256        | gz               |
-      | filelists       | ${checksum}-filelists.xml.gz       | sha256        | gz               |
-      | other           | ${checksum}-other.xml.gz           | sha256        | gz               |
+      | primary         | ${checksum}-primary.xml.zst        | sha256        | zstd             |
+      | filelists       | ${checksum}-filelists.xml.zst      | sha256        | zstd             |
+      | other           | ${checksum}-other.xml.zst          | sha256        | zstd             |
       | group           | ${checksum}-groupfile2.xml         | sha256        | -                |
-      | group_gz        | ${checksum}-groupfile2.xml.gz      | sha256        | gz               |
-      | custom_metadata | ${checksum}-custom_metadata.txt.gz | sha256        | gz               |
+      | group_gz        | ${checksum}-groupfile2.xml.zst     | sha256        | zstd             |
+      | custom_metadata | ${checksum}-custom_metadata.txt.zst| sha256        | zstd             |
 
 
 # createrepo_c is compiled without support for zchunk on rhel 8 and 9
@@ -122,16 +122,16 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
       | primary_zck         | ${checksum}-primary.xml.zck         | sha256        | zck              |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
       | filelists_zck       | ${checksum}-filelists.xml.zck       | sha256        | zck              |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
       | other_zck           | ${checksum}-other.xml.zck           | sha256        | zck              |
       | group               | ${checksum}-groupfile2.xml          | sha256        | -                |
-      | group_gz            | ${checksum}-groupfile2.xml.gz       | sha256        | gz               |
+      | group_gz            | ${checksum}-groupfile2.xml.zst      | sha256        | zstd             |
       | group_zck           | ${checksum}-groupfile2.xml.zck      | sha256        | zck              |
-      | custom_metadata     | ${checksum}-custom_metadata.txt.gz  | sha256        | gz               |
+      | custom_metadata     | ${checksum}-custom_metadata.txt.zst | sha256        | zstd             |
       | custom_metadata_zck | ${checksum}-custom_metadata.txt.zck | sha256        | zck              |
 
 
@@ -145,13 +145,13 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml --zck ." in
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
       | group               | ${checksum}-groupfile.xml           | sha256        | -                |
-      | group_gz            | ${checksum}-groupfile.xml.gz        | sha256        | gz               |
+      | group_gz            | ${checksum}-groupfile.xml.zst       | sha256        | zstd             |
       | group_zck           | ${checksum}-groupfile.xml.zck       | sha256        | zck              |
-      | custom_metadata     | ${checksum}-custom_metadata.txt.gz  | sha256        | gz               |
+      | custom_metadata     | ${checksum}-custom_metadata.txt.zst | sha256        | zstd             |
       | custom_metadata_zck | ${checksum}-custom_metadata.txt.zck | sha256        | zck              |
 
 
@@ -195,15 +195,15 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type            | File                               | Checksum Type | Compression Type |
-      | primary         | ${checksum}-primary.xml.gz         | sha256        | gz               |
-      | filelists       | ${checksum}-filelists.xml.gz       | sha256        | gz               |
-      | other           | ${checksum}-other.xml.gz           | sha256        | gz               |
+      | primary         | ${checksum}-primary.xml.zst        | sha256        | zstd             |
+      | filelists       | ${checksum}-filelists.xml.zst      | sha256        | zstd             |
+      | other           | ${checksum}-other.xml.zst          | sha256        | zstd             |
       | group           | ${checksum}-groupfile.xml          | sha256        | -                |
-      | group_gz        | ${checksum}-groupfile.xml.gz       | sha256        | gz               |
-      | updateinfo      | ${checksum}-updateinfo.xml.gz      | sha256        | gz               |
-      | custom_metadata | ${checksum}-custom_metadata.txt.gz | sha256        | gz               |
-      | modules         | ${checksum}-modules.yaml.gz        | sha256        | gz               |
-  And file "/temp-repo/repodata/[a-z0-9]*-modules.yaml.gz" contents is
+      | group_gz        | ${checksum}-groupfile.xml.zst      | sha256        | zstd             |
+      | updateinfo      | ${checksum}-updateinfo.xml.zst     | sha256        | zstd             |
+      | custom_metadata | ${checksum}-custom_metadata.txt.zst| sha256        | zstd             |
+      | modules         | ${checksum}-modules.yaml.zst       | sha256        | zstd             |
+  And file "/temp-repo/repodata/[a-z0-9]*-modules.yaml.zst" contents is
       """
       ---
       document: modulemd
@@ -269,9 +269,9 @@ Given I execute createrepo_c with args "." in "/temp-repo"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type            | File                               | Checksum Type | Compression Type |
-      | primary         | ${checksum}-primary.xml.gz         | sha256        | gz               |
-      | filelists       | ${checksum}-filelists.xml.gz       | sha256        | gz               |
-      | other           | ${checksum}-other.xml.gz           | sha256        | gz               |
+      | primary         | ${checksum}-primary.xml.zst        | sha256        | zstd             |
+      | filelists       | ${checksum}-filelists.xml.zst      | sha256        | zstd             |
+      | other           | ${checksum}-other.xml.zst          | sha256        | zstd             |
 
 
 Scenario: --update keeps additional metadata by default
@@ -282,9 +282,9 @@ Given I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/tem
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type                | File                                | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz          | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz        | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz            | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst         | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst       | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst           | sha256        | zstd             |
       | group               | ${checksum}-groupfile.xml           | sha256        | -                |
-      | group_gz            | ${checksum}-groupfile.xml.gz        | sha256        | gz               |
-      | custom_metadata     | ${checksum}-custom_metadata.txt.gz  | sha256        | gz               |
+      | group_gz            | ${checksum}-groupfile.xml.zst       | sha256        | zstd             |
+      | custom_metadata     | ${checksum}-custom_metadata.txt.zst | sha256        | zstd             |

--- a/dnf-behave-tests/createrepo_c/update.feature
+++ b/dnf-behave-tests/createrepo_c/update.feature
@@ -17,9 +17,9 @@ Given I create directory "/empty-repo/"
   And repodata "/empty-repo/repodata/" are consistent
   And repodata in "/empty-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
 
 
 Scenario: --update on empty repo with simplified filenames
@@ -30,9 +30,9 @@ Given I create directory "/empty-repo/"
   And repodata "/empty-repo/repodata/" are consistent
   And repodata in "/empty-repo/repodata/" is
       | Type         | File                 | Checksum Type | Compression Type |
-      | primary      | primary.xml.gz       | sha256        | gz               |
-      | filelists    | filelists.xml.gz     | sha256        | gz               |
-      | other        | other.xml.gz         | sha256        | gz               |
+      | primary      | primary.xml.zst      | sha256        | zstd             |
+      | filelists    | filelists.xml.zst    | sha256        | zstd             |
+      | other        | other.xml.zst        | sha256        | zstd             |
 
 
 Scenario: --update discards additional metadata
@@ -47,20 +47,20 @@ Given I create directory "/empty-repo/"
   And I execute createrepo_c with args "--groupfile ../groupfile.xml ." in "/empty-repo"
   And repodata "/empty-repo/repodata/" are consistent
   And repodata in "/empty-repo/repodata/" is
-      | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
-      | group        | ${checksum}-groupfile.xml        | sha256        | -                |
-      | group_gz     | ${checksum}-groupfile.xml.gz     | sha256        | gz               |
+      | Type         | File                              | Checksum Type | Compression Type |
+      | primary      | ${checksum}-primary.xml.zst       | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst     | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst         | sha256        | zstd             |
+      | group        | ${checksum}-groupfile.xml         | sha256        | -                |
+      | group_zst    | ${checksum}-groupfile.xml.zst     | sha256        | zstd             |
  When I execute createrepo_c with args "--update ." in "/empty-repo"
  Then the exit code is 0
   And repodata "/empty-repo/repodata/" are consistent
   And repodata in "/empty-repo/repodata/" is
-      | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | Type         | File                              | Checksum Type | Compression Type |
+      | primary      | ${checksum}-primary.xml.zst       | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst     | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst         | sha256        | zstd             |
 
 
 Scenario: --update on repo with packages
@@ -71,9 +71,9 @@ Given I execute createrepo_c with args "." in "/temp-repo"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
 
 
 Scenario: --update twice on repo with packages
@@ -87,9 +87,9 @@ Given I execute createrepo_c with args "." in "/temp-repo"
   And repodata "/temp-repo/repodata/" are consistent
   And repodata in "/temp-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
 
 
 Scenario: --update with --update-md-path
@@ -100,9 +100,9 @@ Given I create directory "/updated-repo/"
   And repodata "/updated-repo/repodata/" are consistent
   And repodata in "/updated-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
 
 
 Scenario: --update with --update-md-path twice
@@ -116,9 +116,9 @@ Given I create directory "/updated-repo/"
   And repodata "/updated-repo/repodata/" are consistent
   And repodata in "/updated-repo/repodata/" is
       | Type         | File                             | Checksum Type | Compression Type |
-      | primary      | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists    | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other        | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary      | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists    | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other        | ${checksum}-other.xml.zst        | sha256        | zstd             |
 
 
 Scenario: --update with no changes doesn't update the files

--- a/dnf-behave-tests/createrepo_c/zchunk.feature
+++ b/dnf-behave-tests/createrepo_c/zchunk.feature
@@ -9,9 +9,9 @@ Scenario: create empty repository with zck metadata
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type                | File                             | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_zck         | ${checksum}-primary.xml.zck      | sha256        | zck              |
       | filelists_zck       | ${checksum}-filelists.xml.zck    | sha256        | zck              |
       | other_zck           | ${checksum}-other.xml.zck        | sha256        | zck              |
@@ -27,9 +27,9 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type                | File                             | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_zck         | ${checksum}-primary.xml.zck      | sha256        | zck              |
       | filelists_zck       | ${checksum}-filelists.xml.zck    | sha256        | zck              |
       | other_zck           | ${checksum}-other.xml.zck        | sha256        | zck              |
@@ -51,9 +51,9 @@ Given I copy file "{context.scenario.repos_location}/createrepo_c-ci-packages/x8
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type                | File                             | Checksum Type | Compression Type |
-      | primary             | ${checksum}-primary.xml.gz       | sha256        | gz               |
-      | filelists           | ${checksum}-filelists.xml.gz     | sha256        | gz               |
-      | other               | ${checksum}-other.xml.gz         | sha256        | gz               |
+      | primary             | ${checksum}-primary.xml.zst      | sha256        | zstd             |
+      | filelists           | ${checksum}-filelists.xml.zst    | sha256        | zstd             |
+      | other               | ${checksum}-other.xml.zst        | sha256        | zstd             |
       | primary_zck         | ${checksum}-primary.xml.zck      | sha256        | zck              |
       | filelists_zck       | ${checksum}-filelists.xml.zck    | sha256        | zck              |
       | other_zck           | ${checksum}-other.xml.zck        | sha256        | zck              |
@@ -85,9 +85,9 @@ Given I create directory "/dictionaries"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type                | File                 | Checksum Type | Compression Type |
-      | primary             | primary.xml.gz       | sha256        | gz               |
-      | filelists           | filelists.xml.gz     | sha256        | gz               |
-      | other               | other.xml.gz         | sha256        | gz               |
+      | primary             | primary.xml.zst      | sha256        | zstd             |
+      | filelists           | filelists.xml.zst    | sha256        | zstd             |
+      | other               | other.xml.zst        | sha256        | zstd             |
       | primary_zck         | primary.xml.zck      | sha256        | zck              |
       | filelists_zck       | filelists.xml.zck    | sha256        | zck              |
       | other_zck           | other.xml.zck        | sha256        | zck              |
@@ -134,9 +134,9 @@ Given I create directory "/dictionaries"
   And repodata "/repodata/" are consistent
   And repodata in "/repodata/" is
       | Type                | File                 | Checksum Type | Compression Type |
-      | primary             | primary.xml.gz       | sha256        | gz               |
-      | filelists           | filelists.xml.gz     | sha256        | gz               |
-      | other               | other.xml.gz         | sha256        | gz               |
+      | primary             | primary.xml.zst      | sha256        | zstd             |
+      | filelists           | filelists.xml.zst    | sha256        | zstd             |
+      | other               | other.xml.zst        | sha256        | zstd             |
       | primary_zck         | primary.xml.zck      | sha256        | zck              |
       | filelists_zck       | filelists.xml.zck    | sha256        | zck              |
       | other_zck           | other.xml.zck        | sha256        | zck              |

--- a/dnf-behave-tests/dnf/clean-cachefiles.feature
+++ b/dnf-behave-tests/dnf/clean-cachefiles.feature
@@ -18,7 +18,7 @@ Background: Fill the cache
    \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.gz
+   \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
    \./simple-base-[0-9a-f]{16}/solv
    \./simple-base-[0-9a-f]{16}/solv/simple-base\.solv
@@ -54,7 +54,7 @@ Scenario: Cached packages cleanup (dnf clean packages)
    \.
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.gz
+   \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
    \./simple-base-[0-9a-f]{16}/solv
    \./simple-base-[0-9a-f]{16}/solv/simple-base\.solv
@@ -71,6 +71,6 @@ Scenario: Database cached cleanup (dnf clean dbcache)
    \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.gz
+   \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
    """


### PR DESCRIPTION
This PR also contains: https://github.com/rpm-software-management/ci-dnf-stack/pull/1218 which should be merged first.
I just wanted to avoid too many conflicts as both PRs are changing a lot of the same lines.

For: https://github.com/rpm-software-management/createrepo_c/pull/371