### PR TITLE
createrepo_c: disable delta rpm tests for fedora >= 39

### DIFF
--- a/dnf-behave-tests/createrepo_c/delta-rpms.feature
+++ b/dnf-behave-tests/createrepo_c/delta-rpms.feature
@@ -1,4 +1,5 @@
 @not.with_os=rhel__ge__9
+@not.with_os=fedora__ge__39
 Feature: Tests createrepo_c generating delta rpms
 
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2213212

For: https://github.com/rpm-software-management/createrepo_c/pull/372