### PR TITLE
gpg tests - adjust to new outputs, enable more tests

### DIFF
--- a/dnf-behave-tests/dnf/distro-sync.feature
+++ b/dnf-behave-tests/dnf/distro-sync.feature
@@ -73,8 +73,8 @@ Given I use repository "dnf-ci-gpg"
   And dnf4 stderr contains "Error: GPG check FAILED"
   And dnf5 stderr matches line by line
     """
+    Transaction failed: Signature verification failed.
     PGP check for package "wget-2\.0\.0-1\.fc29\.x86_64" \(.*/wget-2.0.0-1.fc29.x86_64.rpm\) from repo "dnf-ci-gpg-updates" has failed: Problem occurred when opening the package.
-    Signature verification failed
     """
 
 
@@ -94,8 +94,8 @@ Given I use repository "dnf-ci-gpg"
   And dnf4 stderr contains "Error: GPG check FAILED"
   And dnf5 stderr matches line by line
     """
+    Transaction failed: Signature verification failed.
     PGP check for package "wget-2\.0\.0-1\.fc29\.x86_64" \(.*/wget-2.0.0-1.fc29.x86_64.rpm\) from repo "dnf-ci-gpg-updates" has failed: Problem occurred when opening the package.
-    Signature verification failed
     """
 
 

--- a/dnf-behave-tests/dnf/gpg-noeol.feature
+++ b/dnf-behave-tests/dnf/gpg-noeol.feature
@@ -1,3 +1,4 @@
+@dnf5daemon
 @dnf5
 Feature: Testing gpg signed packages by keys without any EOL characters at EOF
 

--- a/dnf-behave-tests/dnf/gpg.feature
+++ b/dnf-behave-tests/dnf/gpg.feature
@@ -30,6 +30,7 @@ Background: Add repository with gpgcheck=1
 
 
 @dnf5
+@dnf5daemon
 Scenario: Install masterkey signed package and check GPG key was imported
    When I execute dnf with args "install setup"
    Then the exit code is 0
@@ -44,6 +45,7 @@ Scenario: Install masterkey signed package and check GPG key was imported
 
 
 @dnf5
+@dnf5daemon
 Scenario: Install subkey signed package with masterkey signed dependency
    When I execute dnf with args "install filesystem"
    Then the exit code is 0
@@ -58,6 +60,7 @@ Scenario: Install subkey signed package with masterkey signed dependency
 
 
 @dnf5
+# XXX stderr @dnf5daemon
 Scenario: Fail to install signed package with incorrectly signed dependency (with key from different repository)
    When I execute dnf with args "install glibc"
    Then the exit code is 1
@@ -78,6 +81,7 @@ Scenario: Fail to install signed package with incorrectly signed dependency (wit
 
 
 @dnf5
+# XXX stderr @dnf5daemon
 Scenario: Fail to install signed package with incorrect checksum
    When I execute dnf with args "install broken-package"
    Then the exit code is 1
@@ -93,6 +97,7 @@ Scenario: Fail to install signed package with incorrect checksum
 
 
 @dnf5
+@dnf5daemon
 Scenario: Install masterkey signed, unsigned and masterkey signed with unknown key packages from repo with gpgcheck=0 in repofile
   Given I configure repository "dnf-ci-gpg" with
         | key      | value                                                                      |
@@ -110,6 +115,7 @@ Scenario: Install masterkey signed, unsigned and masterkey signed with unknown k
 
 
 @dnf5
+# XXX stderr @dnf5daemon
 Scenario: Attempt to install unsigned package from repo with gpgcheck=1
    When I execute dnf with args "install flac"
    Then the exit code is 1

--- a/dnf-behave-tests/dnf/gpg.feature
+++ b/dnf-behave-tests/dnf/gpg.feature
@@ -75,8 +75,8 @@ Scenario: Fail to install signed package with incorrectly signed dependency (wit
     And RPMDB Transaction is empty
     And stderr matches line by line
     """
+    Transaction failed: Signature verification failed
     PGP check for package "basesystem-11-6\.fc29\.noarch" \(.*/basesystem-11-6\.fc29\.noarch\.rpm\) from repo "dnf-ci-gpg" has failed: Public key is not installed\.
-    Signature verification failed
     """
 
 
@@ -91,8 +91,8 @@ Scenario: Fail to install signed package with incorrect checksum
     And RPMDB Transaction is empty
     And stderr matches line by line
     """
+    Transaction failed: Signature verification failed
     PGP check for package "broken-package-0\.2\.4-1\.fc29\.noarch" \(.*/broken-package-0\.2\.4-1\.fc29\.noarch\.rpm\) from repo "dnf-ci-gpg" has failed: Problem occurred when opening the package\.
-    Signature verification failed
     """
 
 
@@ -121,8 +121,8 @@ Scenario: Attempt to install unsigned package from repo with gpgcheck=1
    Then the exit code is 1
     And stderr matches line by line
     """
+    Transaction failed: Signature verification failed
     PGP check for package "flac-1\.3\.2-8\.fc29\.x86_64" \(.*/flac-1\.3\.2-8\.fc29\.x86_64\.rpm\) from repo "dnf-ci-gpg" has failed: The package is not signed\.
-    Signature verification failed
     """
 
 
@@ -148,8 +148,7 @@ Scenario: Fail to install package with incorrect checksum with --no-gpgchecks
         | Action        | Package                               |
         | install       | broken-package-0:0.2.4-1.fc29.noarch  |
     And RPMDB Transaction is empty
-    # we should test also stderr here but it looks like error message went to stdout
-    And stdout contains "Transaction failed: Rpm transaction failed."
+    And stderr contains "Transaction failed: Rpm transaction failed."
 
 
 @dnf5

--- a/dnf-behave-tests/dnf/install-file-conflicts.feature
+++ b/dnf-behave-tests/dnf/install-file-conflicts.feature
@@ -12,5 +12,8 @@ Scenario: An error is reported when a package with a file conflict is tried to b
         | install                   | package-one-0:1.0-1.x86_64   |
    When I execute dnf with args "install package-two-1.0-1.x86_64"
    Then the exit code is 1
-   Then stdout contains "Rpm transaction failed."
-    And stdout contains "file /usr/lib/package/conflicting-file from install of package-two-0:1.0-1.x86_64 conflicts with file from package package-one-0:1.0-1.x86_64"
+    And stderr is
+    """
+    Transaction failed: Rpm transaction failed.
+      - file /usr/lib/package/conflicting-file from install of package-two-0:1.0-1.x86_64 conflicts with file from package package-one-0:1.0-1.x86_64
+    """

--- a/dnf-behave-tests/dnf/transaction-gpg-checking.feature
+++ b/dnf-behave-tests/dnf/transaction-gpg-checking.feature
@@ -24,4 +24,4 @@ Scenario: Check GPG signatures with recovery when keys are imported
     And Transaction is following
         | Action        | Package                        |
         | install       | setup-0:2.12.1-1.fc29.noarch   |
-    And stdout contains "Keys were successfully imported."
+    And stdout contains "The key was successfully imported."


### PR DESCRIPTION
- GPG verification tests were made more strict by checking the full output.
- Some gpg tests were enabled for dnf5daemon.
- Also some adujstment to the new, different wording was needed.

Requires: https://github.com/rpm-software-management/dnf5/pull/607