### PR TITLE
repoquery: enable --location, --queryformat, --querytags and --disable-modular-filtering tests

### DIFF
--- a/dnf-behave-tests/common/output.py
+++ b/dnf-behave-tests/common/output.py
@@ -36,6 +36,9 @@ def strip_reposync_dnf5(found_lines, line_number):
     if line_number < len(found_lines) and found_lines[line_number].strip() == "Repositories loaded.":
         found_lines.pop(line_number)
 
+    # For command-line repos
+    while line_number < len(found_lines) and sync_line_dnf5.fullmatch(found_lines[line_number].strip()):
+        found_lines.pop(line_number)
 
 def handle_reposync(expected, found, dnf5_mode):
     line_number = 0

--- a/dnf-behave-tests/dnf/repoquery/main.feature
+++ b/dnf-behave-tests/dnf/repoquery/main.feature
@@ -722,50 +722,79 @@ Given I successfully execute dnf with args "install top-a"
 
 
 # --queryformat
+@dnf5
 Scenario: repoquery --queryformat NVR
- When I execute dnf with args "repoquery --queryformat %{{name}}-%{{version}}-%{{release}} bottom-a1"
+ When I execute dnf with args "repoquery --queryformat "%{{name}}-%{{version}}-%{{release}}\n" bottom-a1"
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       bottom-a1-1.0-1
       bottom-a1-2.0-1
       """
 
-# note: %{{installtime}}, %{{buildtime}}, %{{size}}, %{{downloadsize}}, %{{installsize}} untested as they vary
+# note: %{{installtime}}, %{{buildtime}}, %{{downloadsize}}, %{{installsize}} and %{{location}} untested as they vary
+@dnf5
 Scenario: repoquery --queryformat EVERYTHING
- When I execute dnf with args "repoquery --queryformat '%{{name}} | %{{arch}} | %{{epoch}} | %{{version}} | %{{release}} | %{{reponame}} | %{{repoid}} | %{{evr}} | %{{debug_name}} | %{{source_name}} | %{{source_debug_name}} | %{{provides}} | %{{requires}} | %{{obsoletes}} | %{{conflicts}} | %{{sourcerpm}} | %{{description}} | %{{summary}} | %{{license}} | %{{url}} | %{{reason}}' top*.x86_64"
+ When I execute dnf with args "repoquery --queryformat '%{{name}} | %{{arch}} | %{{epoch}} | %{{version}} | %{{release}} | %{{reponame}} | %{{repoid}} | %{{evr}} | %{{debug_name}} | %{{source_name}} | %{{source_debug_name}} | %{{provides}} | %{{requires}} | %{{obsoletes}} | %{{conflicts}} | %{{sourcerpm}} | %{{description}} | %{{summary}} | %{{license}} | %{{url}} | %{{reason}} | %{{depends}} | %{{files}} | %{{full_nevra}} | %{{prereq_ignoreinst}} | %{{requires_pre}} | %{{regular_requires}}\n\n' top*.x86_64"
  Then the exit code is 0
   And stdout is
       """
-      top-a | x86_64 | 1 | 1.0 | 1 | repoquery-main | repoquery-main | 1:1.0-1 | top-a-debuginfo | top-a | top-a-debuginfo | top-a = 1:1.0-1
-      top-a(x86-64) = 1:1.0-1 | bottom-a1 = 1:1.0-1
+      <REPOSYNC>
+      top-a | x86_64 | 1 | 1.0 | 1 | repoquery-main test repository | repoquery-main | 1:1.0-1 | top-a-debuginfo | top-a | top-a-debuginfo | top-a = 1:1.0-1
+      top-a(x86-64) = 1:1.0-1
+       | bottom-a1 = 1:1.0-1
+      mid-a2 = 1:1.0-1
       mid-a1 >= 2
-      mid-a2 = 1:1.0-1 |  |  | top-a-1.0-1.src.rpm | Dummy. | Top level package (depends on others). | Public Domain | None | (none)
-      top-a | x86_64 | 1 | 2.0 | 1 | repoquery-main | repoquery-main | 1:2.0-1 | top-a-debuginfo | top-a | top-a-debuginfo | top-a = 1:2.0-1
-      top-a(x86-64) = 1:2.0-1 | bottom-a1 = 1:1.0-1
+       |  |  | top-a-1.0-1.src.rpm | Dummy. | Top level package (depends on others). | Public Domain | None | None | bottom-a1 = 1:1.0-1
+      mid-a2 = 1:1.0-1
       mid-a1 >= 2
-      mid-a2 = 1:1.0-1 |  |  | top-a-2.0-1.src.rpm | Dummy. | Top level package (depends on others). | Public Domain | None | (none)
-      top-a | x86_64 | 2 | 2.0 | 2 | repoquery-main | repoquery-main | 2:2.0-2 | top-a-debuginfo | top-a | top-a-debuginfo | top-a = 2:2.0-2
-      top-a(x86-64) = 2:2.0-2 | bottom-a1 = 1:1.0-1
-      mid-a1 >= 2 |  |  | top-a-2.0-2.src.rpm | Dummy. | Top level package (depends on others). | Public Domain | None | (none)
+       |  | top-a-1:1.0-1.x86_64 |  |  | bottom-a1 = 1:1.0-1
+      mid-a2 = 1:1.0-1
+      mid-a1 >= 2
+
+
+      top-a | x86_64 | 1 | 2.0 | 1 | repoquery-main test repository | repoquery-main | 1:2.0-1 | top-a-debuginfo | top-a | top-a-debuginfo | top-a = 1:2.0-1
+      top-a(x86-64) = 1:2.0-1
+       | bottom-a1 = 1:1.0-1
+      mid-a2 = 1:1.0-1
+      mid-a1 >= 2
+       |  |  | top-a-2.0-1.src.rpm | Dummy. | Top level package (depends on others). | Public Domain | None | None | bottom-a1 = 1:1.0-1
+      mid-a2 = 1:1.0-1
+      mid-a1 >= 2
+       |  | top-a-1:2.0-1.x86_64 |  |  | bottom-a1 = 1:1.0-1
+      mid-a2 = 1:1.0-1
+      mid-a1 >= 2
+
+
+      top-a | x86_64 | 2 | 2.0 | 2 | repoquery-main test repository | repoquery-main | 2:2.0-2 | top-a-debuginfo | top-a | top-a-debuginfo | top-a = 2:2.0-2
+      top-a(x86-64) = 2:2.0-2
+       | bottom-a1 = 1:1.0-1
+      mid-a1 >= 2
+       |  |  | top-a-2.0-2.src.rpm | Dummy. | Top level package (depends on others). | Public Domain | None | None | bottom-a1 = 1:1.0-1
+      mid-a1 >= 2
+       |  | top-a-2:2.0-2.x86_64 |  |  | bottom-a1 = 1:1.0-1
+      mid-a1 >= 2
       """
 
 
 # install bottom-a1 using dnf (i.e. has record in history database)
 # install bottom-a2 using rpm (no record in history database)
+@dnf5
 @bz1898968
 @bz1879168
 Scenario: repoquery --queryformat from_repo
 Given I successfully execute dnf with args "install bottom-a1"
   And I successfully execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/repoquery-main/x86_64/bottom-a2-1.0-1.x86_64.rpm"
- When I execute dnf with args "repoquery --available --installed --queryformat '%{{name}}-%{{version}}-%{{release}} %{{repoid}} -%{{from_repo}}-' bottom-*"
+ When I execute dnf with args "repoquery --available --installed --queryformat '%{{name}}-%{{version}}-%{{release}} %{{repoid}} -%{{from_repo}}-\n' bottom-*"
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       bottom-a1-1.0-1 repoquery-main --
       bottom-a1-2.0-1 @System -repoquery-main-
       bottom-a1-2.0-1 repoquery-main --
-      bottom-a2-1.0-1 @System --
+      bottom-a2-1.0-1 @System -<unknown>-
       bottom-a2-1.0-1 repoquery-main --
       bottom-a3-1.0-1 repoquery-main --
       bottom-a3-2.0-1 repoquery-main --
@@ -773,37 +802,45 @@ Given I successfully execute dnf with args "install bottom-a1"
 
 
 # --querytags
+@dnf5
 @bz1744073
 Scenario: dnf repoquery --querytags
  When I execute dnf with args "repoquery --querytags"
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       arch
       buildtime
       conflicts
       debug_name
+      depends
       description
       downloadsize
       enhances
       epoch
       evr
+      files
       from_repo
+      full_nevra
       group
       installsize
       installtime
       license
+      location
       name
       obsoletes
       packager
+      prereq_ignoreinst
       provides
       reason
       recommends
+      regular_requires
       release
       repoid
       reponame
       requires
-      size
+      requires_pre
       source_debug_name
       source_name
       sourcerpm

--- a/dnf-behave-tests/dnf/repoquery/main.feature
+++ b/dnf-behave-tests/dnf/repoquery/main.feature
@@ -530,56 +530,76 @@ Scenario: repoquery --installed NAME (no such packages)
 
 
 # --location
+@dnf5
 @bz1639827
 Scenario: repoquery --location NAME
  When I execute dnf with args "repoquery --location top-a-2.0"
  Then the exit code is 0
   And stdout matches line by line
       """
+      <REPOSYNC>
       .+/fixtures/repos/repoquery-main/src/top-a-2.0-1.src.rpm$
       .+/fixtures/repos/repoquery-main/src/top-a-2.0-2.src.rpm$
       .+/fixtures/repos/repoquery-main/x86_64/top-a-2.0-1.x86_64.rpm$
       .+/fixtures/repos/repoquery-main/x86_64/top-a-2.0-2.x86_64.rpm$
       """
 
+@dnf5
 Scenario: repoquery --location NAME (in an HTTP repo)
 Given I use repository "repoquery-main" as https
  When I execute dnf with args "repoquery --location top-a-2.0"
  Then the exit code is 0
   And stdout matches line by line
       """
+      <REPOSYNC>
       https://localhost:[0-9]+/src/top-a-2.0-1.src.rpm$
       https://localhost:[0-9]+/src/top-a-2.0-2.src.rpm$
       https://localhost:[0-9]+/x86_64/top-a-2.0-1.x86_64.rpm$
       https://localhost:[0-9]+/x86_64/top-a-2.0-2.x86_64.rpm$
       """
 
+@dnf5
 Scenario: repoquery --location NAME (no such package)
  When I execute dnf with args "repoquery --location dummy"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
+@dnf5
 @bz1873146
 Scenario: repoquery --location for local package with file protocol is empty (no traceback)
  When I execute dnf with args "repoquery --location file://{context.dnf.fixturesdir}/repos/repoquery-main/noarch/bottom-a1-1.0-1.noarch.rpm"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
+@dnf5
 @bz1873146
 Scenario: repoquery --location for local package without file protocol is empty (no traceback)
  When I execute dnf with args "repoquery --location /{context.dnf.fixturesdir}/repos/repoquery-main/noarch/bottom-a1-1.0-1.noarch.rpm"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
+@dnf5
 @bz1873146
 Scenario: repoquery --location NAME for --installed is empty (no traceback)
 Given I successfully execute dnf with args "install bottom-a1"
  When I execute dnf with args "repoquery --installed bottom-a1 --location"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
 # --srpm

--- a/dnf-behave-tests/dnf/repoquery/modules.feature
+++ b/dnf-behave-tests/dnf/repoquery/modules.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: repoquery tests for handling modularity.
 
 Background:
@@ -9,12 +10,14 @@ Scenario: Test --disable-modular-filtering with a default module stream
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       nodejs-1:8.11.4-1.module_2030+42747d40.x86_64
       """
  When I execute dnf with args "repoquery nodejs --disable-modular-filtering"
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       nodejs-1:10.0.0-1.src
       nodejs-1:10.0.0-1.x86_64
       nodejs-1:5.3.1-1.module_2011+41787af0.src
@@ -29,12 +32,14 @@ Scenario: Test --disable-modular-filtering with an enabled module stream
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       nodejs-1:5.3.1-1.module_2011+41787af0.x86_64
       """
  When I execute dnf with args "repoquery nodejs --disable-modular-filtering"
  Then the exit code is 0
   And stdout is
       """
+      <REPOSYNC>
       nodejs-1:10.0.0-1.src
       nodejs-1:10.0.0-1.x86_64
       nodejs-1:5.3.1-1.module_2011+41787af0.src


### PR DESCRIPTION
Enable tests for: `--location`, `--queryformat`, `--querytags` and `--disable-modular-filtering`

Requires: https://github.com/rpm-software-management/dnf5/pull/664