### PR TITLE
Enable existing cacheonly tests

### DIFF
--- a/dnf-behave-tests/dnf/clean.feature
+++ b/dnf-behave-tests/dnf/clean.feature
@@ -1,29 +1,31 @@
 Feature: Testing dnf clean command
 
 
-# @dnf5
-# TODO(nsella) -C not available for dnf5
+@dnf5
 Scenario: Ensure that metadata are unavailable after "dnf clean all"
-  Given I use repository "dnf-ci-rich" with configuration
-        | key                 | value |
-        | skip_if_unavailable | 1     |
+  Given I use repository "dnf-ci-rich"
    When I execute dnf with args "makecache"
    Then the exit code is 0
-   When I execute dnf with args "install -C cream"
+   When I execute dnf with args "repoquery cream -C"
    Then the exit code is 0
-    And Transaction is following
-        | Action        | Package                               |
-        | install       | cream-0:1.0-1.x86_64                  |
+    And stdout is
+        """
+        <REPOSYNC>
+        cream-0:1.0-1.src
+        cream-0:1.0-1.x86_64
+        """
    When I execute dnf with args "clean all"
    Then the exit code is 0
-   When I execute dnf with args "install -C dill"
+   When I execute dnf with args "repoquery cream -C"
    Then the exit code is 1
-    And stdout contains "No match for argument: dill"
-   When I execute dnf with args "remove cream"
-   Then the exit code is 0
-    And Transaction is following
-        | Action        | Package                               |
-        | remove        | cream-0:1.0-1.x86_64                  |
+    And stdout is
+        """
+        <REPOSYNC>
+        """
+    And stderr is 
+        """
+        Cache-only enabled but no cache for repository "dnf-ci-rich"
+        """
 
 
 @dnf5

--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -544,14 +544,14 @@ Scenario: Packages that are part of another installed group are not removed
 
 
 # @dnf5
-# TODO(nsella) Unknown argument "-C" for command "list"
+# TODO(jkolarik): Cache files are now created with root-only mask
 # destructive because it can create a new user on the system
 @bz2030255
 @destructive
 Scenario: 'dnf group list -C' works for unprivileged user even when decompressed groups.xml is not present in the cache
  Given I use repository "dnf-ci-thirdparty"
     # unprivileged user will need access to enter installroot and read files there
-   And I successfully execute "chmod go+rx {context.dnf.installroot}"
+   And I successfully execute "chmod go+rwx {context.dnf.installroot}"
     # unprivileged user will need tmp directory to create temporary decompressed groups.xml
    And I create directory "/{context.dnf.installroot}/var/tmp"
    And I successfully execute "chmod 777 {context.dnf.installroot}/var/tmp"

--- a/dnf-behave-tests/dnf/installroot.feature
+++ b/dnf-behave-tests/dnf/installroot.feature
@@ -34,8 +34,7 @@ Scenario: Install package from installroot repository into installroot
    Then the exit code is 1
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "-C" for command "install"
+@dnf5
 @force_installroot
 Scenario: Test metadata handling in installroot
   Given I use repository "dnf-ci-install-remove"
@@ -43,11 +42,11 @@ Scenario: Test metadata handling in installroot
    Then the exit code is 0
    When I execute "rm -rf {context.dnf.installroot}/var/cache/dnf" in "{context.dnf.installroot}"
    Then the exit code is 0
-   When I execute dnf with args "install -C water_still"
+   When I execute dnf with args "repoquery -C water_still"
    Then the exit code is 1
    When I execute dnf with args "makecache"
    Then the exit code is 0
-   When I execute dnf with args "install -C water_still"
+   When I execute dnf with args "repoquery -C water_still"
    Then the exit code is 0
 
 

--- a/dnf-behave-tests/dnf/repoquery/main.feature
+++ b/dnf-behave-tests/dnf/repoquery/main.feature
@@ -231,36 +231,47 @@ Scenario: repoquery --arch ARCH (nonexisting arch)
       """
 
 # --cacheonly
+@dnf5
 Scenario: repoquery -C (without any cache)
  When I execute dnf with args "repoquery --available -C"
  Then the exit code is 1
- Then stdout is empty
+ Then stdout is
+      """
+      <REPOSYNC>
+      """
  Then stderr is
       """
-      Error: Cache-only enabled but no cache for 'repoquery-main'
+      Cache-only enabled but no cache for repository "repoquery-main"
       """
 
+@dnf5
 Scenario: repoquery -Cq (without any cache)
  When I execute dnf with args "repoquery --available -Cq"
  Then the exit code is 1
- Then stdout is empty
+ Then stdout is
+      """
+      <REPOSYNC>
+      """
  Then stderr is
       """
-      Error: Cache-only enabled but no cache for 'repoquery-main'
+      Cache-only enabled but no cache for repository "repoquery-main"
       """
 
+@dnf5
 Scenario: repoquery -C (with cache)
 Given I successfully execute dnf with args "makecache"
  When I execute dnf with args "repoquery -C mid*"
  Then the exit code is 0
  Then stdout is
       """
+      <REPOSYNC>
       mid-a1-1:1.0-1.src
       mid-a1-1:1.0-1.x86_64
       mid-a2-1:1.0-1.src
       mid-a2-1:1.0-1.x86_64
       """
 
+@dnf5
 Scenario: repoquery -C (with cache, installed package)
 Given I successfully execute dnf with args "makecache"
 Given I successfully execute dnf with args "install bottom-a1"
@@ -274,12 +285,16 @@ Given I successfully execute dnf with args "install bottom-a1"
       bottom-a1-1:2.0-1.noarch
       """
 
+@dnf5
 Scenario: repoquery -C (with cache, but disabled repository)
 Given I successfully execute dnf with args "makecache"
 Given I drop repository "repoquery-main"
  When I execute dnf with args "repoquery --available -C"
  Then the exit code is 0
-  And stdout is empty
+  And stdout is
+      """
+      <REPOSYNC>
+      """
 
 
 # --deplist


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/665.