### PR TITLE
Unify `history info` steps and fixes

### DIFF
--- a/dnf-behave-tests/dnf/history-info.feature
+++ b/dnf-behave-tests/dnf/history-info.feature
@@ -11,7 +11,7 @@ Background: Set up dnf-ci-fedora repository
 Scenario: history info shows comment to transaction
   When I execute dnf with args "history info"
   Then the exit code is 0
-  Then stdout contains "Comment          : this_is_a_comment"
+  Then stdout contains "Comment        : this_is_a_comment"
 
 
 @bz1845800
@@ -19,13 +19,13 @@ Scenario: history info for installing a group
   Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "group install dnf-ci-testgroup"
    Then the exit code is 0
-    And History info should match
-        | Key           | Value                           |
-        | Status        | Ok                              |
-        | Install       | filesystem-0:3.9-2.fc29.x86_64  |
-        | Install       | lame-0:3.100-4.fc29.x86_64      |
-        | Install       | setup-0:2.12.1-1.fc29.noarch    |
-        | Install       | lame-libs-0:3.100-4.fc29.x86_64 |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                         | reason     | repository        |
+        | Install | filesystem-0:3.9-2.fc29.x86_64  | Group      | dnf-ci-fedora     |
+        | Install | lame-0:3.100-4.fc29.x86_64      | Group      | dnf-ci-fedora     |
+        | Install | setup-0:2.12.1-1.fc29.noarch    | Dependency | dnf-ci-fedora     |
+        | Install | lame-libs-0:3.100-4.fc29.x86_64 | Dependency | dnf-ci-fedora     |
+        | Install | dnf-ci-testgroup                | User       | dnf-ci-thirdparty |
 
 
 @bz1845800
@@ -35,12 +35,22 @@ Scenario: history info for installing a group when there are upgrades
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "group install dnf-ci-testgroup"
    Then the exit code is 0
-    And History info should match
-        | Key           | Value                           |
-        | Status        | Ok                              |
-        | Install       | filesystem-0:3.9-2.fc29.x86_64  |
-        | Install       | setup-0:2.12.1-1.fc29.noarch    |
-        | Upgrade       | lame-0:3.100-5.fc29.x86_64      |
-        | Upgrade       | lame-libs-0:3.100-5.fc29.x86_64 |
-        | Replaced      | lame-0:3.100-4.fc29.x86_64      |
-        | Replaced      | lame-libs-0:3.100-4.fc29.x86_64 |
+    And dnf5 transaction items for transaction "last" are
+        | action         | package                         | reason     | repository            |
+        | Install        | filesystem-0:3.9-2.fc29.x86_64  | Group      | dnf-ci-fedora         |
+        | Install        | setup-0:2.12.1-1.fc29.noarch    | Dependency | dnf-ci-fedora         |
+        | Upgrade        | lame-0:3.100-5.fc29.x86_64      | User       | dnf-ci-fedora-updates |
+        | Upgrade        | lame-libs-0:3.100-5.fc29.x86_64 | Dependency | dnf-ci-fedora-updates |
+        | Replaced       | lame-0:3.100-4.fc29.x86_64      | User       | @System               |
+        | Replaced       | lame-libs-0:3.100-4.fc29.x86_64 | Dependency | @System               |
+        | Install        | dnf-ci-testgroup                | User       | dnf-ci-thirdparty     |
+
+
+Scenario: history info for installing an environment
+  Given I use repository "comps-group"
+    And I successfully execute dnf with args "install @no-name-env"
+   Then dnf5 transaction items for transaction "last" are
+        | action  | package                          | reason     | repository  |
+        | Install | test-package-0:1.0-1.fc29.noarch | Group      | comps-group |
+        | Install | test-group                       | Dependency | comps-group |
+        | Install | no-name-env                      | User       | comps-group |

--- a/dnf-behave-tests/dnf/history-view.feature
+++ b/dnf-behave-tests/dnf/history-view.feature
@@ -30,22 +30,19 @@ Scenario: List userinstalled packages
 Scenario: History info
   Given I successfully execute dnf with args "install abcde"
    When I execute dnf with args "install setup"
-   Then History info should match
-        | Key           | Value                           |
-        | Description   | install setup                   |
-        | Status        | Ok                              |
-        | Install       | setup-0:2.12.1-1.fc29.noarch    |
+    Then dnf5 transaction items for transaction "last" are
+        | action  | package                         | reason     | repository        |
+        | Install | setup-0:2.12.1-1.fc29.noarch    | User       | dnf-ci-fedora     |
    When I execute dnf with args "remove abcde"
    Then the exit code is 0
-    And History info should match
-        | Key           | Value                       |
-        | Description   | remove abcde                |
-        | Status        | Ok                          |
-        | Remove        | abcde-0:2.9.2-1.fc29.noarch |
-        | Remove        | flac-0:1.3.2-8.fc29.x86_64  |
-        | Remove        | wget-0:1.19.5-5.fc29.x86_64 |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                         | reason     | repository |
+        | Remove  | abcde-0:2.9.2-1.fc29.noarch     | User       | @System    |
+        | Remove  | flac-0:1.3.2-8.fc29.x86_64      | Clean      | @System    |
+        | Remove  | wget-0:1.19.5-5.fc29.x86_64     | Clean      | @System    |
 
 
+@dnf5
 Scenario: History info in range - transaction merging
   Given I successfully execute dnf with args "install abcde"
   Given I successfully execute dnf with args "remove abcde"
@@ -53,57 +50,68 @@ Scenario: History info in range - transaction merging
    When I use repository "dnf-ci-fedora-updates"
     And I execute dnf with args "update"
    Then the exit code is 0
-    And History info should match
-        | Key           | Value                     |
-        | Return-Code   | Success                   |
-        | Upgrade       | abcde-2.9.3-1.fc29.noarch |
-        | Upgraded      | abcde-2.9.2-1.fc29.noarch |
-        | Upgrade       | flac-1.3.3-3.fc29.x86_64  |
-        | Upgraded      | flac-1.3.2-8.fc29.x86_64  |
-        | Upgrade       | wget-1.19.6-5.fc29.x86_64 |
-        | Upgraded      | wget-1.19.5-5.fc29.x86_64 |
-    And History info "last-1..last" should match
-        | Key           | Value                     |
-        | Return-Code   | Success                   |
-        | Install       | abcde-2.9.3-1.fc29.noarch |
-        | Install       | flac-1.3.3-3.fc29.x86_64  |
-        | Install       | wget-1.19.6-5.fc29.x86_64 |
-    And History info "last-2..last" should match
-        | Key           | Value                     |
-        | Return-Code   | Success                   |
-        | Upgraded      | abcde-2.9.2-1.fc29.noarch |
-        | Upgrade       | abcde-2.9.3-1.fc29.noarch |
-        | Upgraded      | flac-1.3.2-8.fc29.x86_64  |
-        | Upgrade       | flac-1.3.3-3.fc29.x86_64  |
-        | Upgraded      | wget-1.19.5-5.fc29.x86_64 |
-        | Upgrade       | wget-1.19.6-5.fc29.x86_64 |
-    And History info "last-2..last-1" should match
-        | Key           | Value                     |
-        | Return-Code   | Success                   |
-        | Reinstall     | abcde-2.9.2-1.fc29.noarch |
-        | Reinstall     | flac-1.3.2-8.fc29.x86_64  |
-        | Reinstall     | wget-1.19.5-5.fc29.x86_64 |
+    And dnf5 transaction items for transaction "last" are
+        | action   | package                         | reason          | repository            |
+        | Upgrade  | abcde-0:2.9.3-1.fc29.noarch     | User            | dnf-ci-fedora-updates |
+        | Upgrade  | flac-0:1.3.3-3.fc29.x86_64      | Weak Dependency | dnf-ci-fedora-updates |
+        | Upgrade  | wget-0:1.19.6-5.fc29.x86_64     | Dependency      | dnf-ci-fedora-updates |
+        | Replaced | abcde-0:2.9.2-1.fc29.noarch     | User            | @System               |
+        | Replaced | flac-0:1.3.2-8.fc29.x86_64      | Weak Dependency | @System               |
+        | Replaced | wget-0:1.19.5-5.fc29.x86_64     | Dependency      | @System               |
+    And dnf5 transaction items for transaction "last-1..last" are
+        | action   | package                         | reason          | repository            |
+        | Upgrade  | abcde-0:2.9.3-1.fc29.noarch     | User            | dnf-ci-fedora-updates |
+        | Upgrade  | flac-0:1.3.3-3.fc29.x86_64      | Weak Dependency | dnf-ci-fedora-updates |
+        | Upgrade  | wget-0:1.19.6-5.fc29.x86_64     | Dependency      | dnf-ci-fedora-updates |
+        | Replaced | abcde-0:2.9.2-1.fc29.noarch     | User            | @System               |
+        | Replaced | flac-0:1.3.2-8.fc29.x86_64      | Weak Dependency | @System               |
+        | Replaced | wget-0:1.19.5-5.fc29.x86_64     | Dependency      | @System               |
+        | Install  | abcde-0:2.9.2-1.fc29.noarch     | User            | dnf-ci-fedora         |
+        | Install  | wget-0:1.19.5-5.fc29.x86_64     | Dependency      | dnf-ci-fedora         |
+        | Install  | flac-0:1.3.2-8.fc29.x86_64      | Weak Dependency | dnf-ci-fedora         |
+    And dnf5 transaction items for transaction "last-2..last" are
+        | action   | package                         | reason          | repository            |
+        | Upgrade  | abcde-0:2.9.3-1.fc29.noarch     | User            | dnf-ci-fedora-updates |
+        | Upgrade  | flac-0:1.3.3-3.fc29.x86_64      | Weak Dependency | dnf-ci-fedora-updates |
+        | Upgrade  | wget-0:1.19.6-5.fc29.x86_64     | Dependency      | dnf-ci-fedora-updates |
+        | Replaced | abcde-0:2.9.2-1.fc29.noarch     | User            | @System               |
+        | Replaced | flac-0:1.3.2-8.fc29.x86_64      | Weak Dependency | @System               |
+        | Replaced | wget-0:1.19.5-5.fc29.x86_64     | Dependency      | @System               |
+        | Install  | abcde-0:2.9.2-1.fc29.noarch     | User            | dnf-ci-fedora         |
+        | Install  | wget-0:1.19.5-5.fc29.x86_64     | Dependency      | dnf-ci-fedora         |
+        | Install  | flac-0:1.3.2-8.fc29.x86_64      | Weak Dependency | dnf-ci-fedora         |
+        | Remove   | abcde-0:2.9.2-1.fc29.noarch     | User            | @System               |
+        | Remove   | flac-0:1.3.2-8.fc29.x86_64      | Clean           | @System               |
+        | Remove   | wget-0:1.19.5-5.fc29.x86_64     | Clean           | @System               |
+    And dnf5 transaction items for transaction "last-2..last-1" are
+        | action   | package                         | reason          | repository            |
+        | Install  | abcde-0:2.9.2-1.fc29.noarch     | User            | dnf-ci-fedora         |
+        | Install  | wget-0:1.19.5-5.fc29.x86_64     | Dependency      | dnf-ci-fedora         |
+        | Install  | flac-0:1.3.2-8.fc29.x86_64      | Weak Dependency | dnf-ci-fedora         |
+        | Remove   | abcde-0:2.9.2-1.fc29.noarch     | User            | @System               |
+        | Remove   | flac-0:1.3.2-8.fc29.x86_64      | Clean           | @System               |
+        | Remove   | wget-0:1.19.5-5.fc29.x86_64     | Clean           | @System               |
 
 
 @dnf5
 Scenario: History info of package
   Given I successfully execute dnf with args "install abcde"
   Given I successfully execute dnf with args "remove abcde"
-   Then History info "last-1" should match
-        | Key           | Value                       |
-        | Status        | Ok                          |
-        | Install       | abcde-0:2.9.2-1.fc29.noarch |
-        | Install       | wget-0:1.19.5-5.fc29.x86_64 |
-        | Install       | flac-0:1.3.2-8.fc29.x86_64  |
-    And History info "last" should match
-        | Key           | Value                       |
-        | Status        | Ok                          |
-        | Remove        | abcde-0:2.9.2-1.fc29.noarch |
-        | Remove        | flac-0:1.3.2-8.fc29.x86_64  |
-        | Remove        | wget-0:1.19.5-5.fc29.x86_64 |
+   Then dnf5 transaction items for transaction "last-1" are
+        | action  | package                     | reason          | repository    |
+        | Install | abcde-0:2.9.2-1.fc29.noarch | User            | dnf-ci-fedora |
+        | Install | wget-0:1.19.5-5.fc29.x86_64 | Dependency      | dnf-ci-fedora |
+        | Install | flac-0:1.3.2-8.fc29.x86_64  | Weak Dependency | dnf-ci-fedora |
+    And dnf5 transaction items for transaction "last" are
+        | action  | package                         | reason     | repository |
+        | Remove  | abcde-0:2.9.2-1.fc29.noarch     | User       | @System    |
+        | Remove  | flac-0:1.3.2-8.fc29.x86_64      | Clean      | @System    |
+        | Remove  | wget-0:1.19.5-5.fc29.x86_64     | Clean      | @System    |
 
 
-@dnf5
+# @dnf5
+# This is a test for listing transactions by package, this is not yet implemented in dnf5.
+# Transaction commands need a --contains-pkgs option
 Scenario: history info aaa (nonexistent package)
    When I execute dnf with args "history info aaa"
    Then the exit code is 1
@@ -113,7 +121,9 @@ Scenario: history info aaa (nonexistent package)
         """
 
 
-@dnf5
+# @dnf5
+# This is a test for listing transactions by package, this is not yet implemented in dnf5.
+# Transaction commands need a --contains-pkgs option
 Scenario: history info aaa (nonexistent package)
   Given I successfully execute dnf with args "install abcde"
    When I execute dnf with args "history info aaa"

--- a/dnf-behave-tests/dnf/steps/history.py
+++ b/dnf-behave-tests/dnf/steps/history.py
@@ -188,8 +188,6 @@ def step_impl(context, id):
             res = transaction_item_re.match(line)
             if res is not None:
                 found.append(res.groups())
-            else:
-                break
 
     if found != expected:
         print_lines_diff(expected, found)

--- a/dnf-behave-tests/dnf/steps/history.py
+++ b/dnf-behave-tests/dnf/steps/history.py
@@ -80,6 +80,8 @@ def step_impl(context, history_range=None):
     assert_history_list(context, context.cmd_stdout)
 
 
+#TODO(amatej): This should be removed once the step is no longer used in transaction-sr/replay.feature.
+#              The step is duplicate of 'dnf5 transaction items for transaction "last" are'.
 @behave.then('History info should match')
 @behave.then('History info "{spec}" should match')
 def step_impl(context, spec=None):


### PR DESCRIPTION
There were two steps for checking `history info` -> simplify to only one.

Also fixes couple additional problems:
- disables tests for filtering transactions by pkg name
- fixes tests for checking history of group operations

Requires: https://github.com/rpm-software-management/dnf5/pull/737