### PR TITLE
Update group-mark test for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/group-mark.feature
+++ b/dnf-behave-tests/dnf/group-mark.feature
@@ -1,22 +1,19 @@
-Feature: Testing group mark
+@dnf5
+Feature: Testing group marking via group install/remove --no-packages
 
-# DNF-CI-Testgroup structure:
+# dnf-ci-testgroup structure:
 #   mandatory: filesystem (requires setup)
 #   default: lame (requires lame-libs)
 #   optional: flac
 #   conditional: wget, requires filesystem-content
 
-# @dnf5
-# TODO(nsella) different stdout
-Scenario: Mark group as installed
+Scenario: Mark group as installed (using group install --no-packages)
   Given I use repository "dnf-ci-thirdparty"
     And I use repository "dnf-ci-fedora"
-   When I execute dnf with args "group list DNF-CI-Testgroup"
+   When I execute dnf with args "group list dnf-ci-testgroup"
    Then the exit code is 0
-    And stdout contains "Available Groups"
-    And stdout contains "DNF-CI-Testgroup"
-    And stdout does not contain "Installed Groups"
-   When I execute dnf with args "group mark install DNF-CI-Testgroup"
+    And stdout contains "dnf-ci-testgroup.*no"
+   When I execute dnf with args "group install --no-packages dnf-ci-testgroup"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                           |
@@ -25,19 +22,15 @@ Scenario: Mark group as installed
         | absent        | lame-0:3.100-4.fc29.x86_64        |
         | absent        | lame-libs-0:3.100-4.fc29.x86_64   |
         | group-install | DNF-CI-Testgroup                  |
-   When I execute dnf with args "group list DNF-CI-Testgroup"
+   When I execute dnf with args "group list dnf-ci-testgroup"
    Then the exit code is 0
-    And stdout does not contain "Available Groups"
-    And stdout contains "DNF-CI-Testgroup"
-    And stdout contains "Installed Groups"
+    And stdout contains "dnf-ci-testgroup.*yes"
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "mark" for command "group"
-Scenario: unMark group as installed
+Scenario: Unmark group as installed (using group remove --no-packages)
   Given I use repository "dnf-ci-thirdparty"
     And I use repository "dnf-ci-fedora"
-   When I execute dnf with args "group mark install DNF-CI-Testgroup"
+   When I execute dnf with args "group install --no-packages dnf-ci-testgroup"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                           |
@@ -46,12 +39,10 @@ Scenario: unMark group as installed
         | absent        | lame-0:3.100-4.fc29.x86_64        |
         | absent        | lame-libs-0:3.100-4.fc29.x86_64   |
         | group-install | DNF-CI-Testgroup                  |
-   When I execute dnf with args "group list DNF-CI-Testgroup"
+   When I execute dnf with args "group list dnf-ci-testgroup"
    Then the exit code is 0
-    And stdout does not contain "Available Groups"
-    And stdout contains "DNF-CI-Testgroup"
-    And stdout contains "Installed Groups"
-   When I execute dnf with args "group mark remove DNF-CI-Testgroup"
+    And stdout contains "dnf-ci-testgroup.*yes"
+   When I execute dnf with args "group remove --no-packages dnf-ci-testgroup"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                           |
@@ -60,8 +51,6 @@ Scenario: unMark group as installed
         | absent        | lame-0:3.100-4.fc29.x86_64        |
         | absent        | lame-libs-0:3.100-4.fc29.x86_64   |
         | group-remove  | DNF-CI-Testgroup                  |
-   When I execute dnf with args "group list DNF-CI-Testgroup"
+   When I execute dnf with args "group list dnf-ci-testgroup"
    Then the exit code is 0
-    And stdout contains "Available Groups"
-    And stdout contains "DNF-CI-Testgroup"
-    And stdout does not contain "Installed Groups"
+    And stdout contains "dnf-ci-testgroup.*no"


### PR DESCRIPTION
Marking groups as installed/removed has changed (instead of mark subcommand, it is now done using group install/remove --no-packages), the test group-mark.feature needs to be updated.