### PR TITLE
Add 'Warning: skipped PGP checks...' to expected outputs

### DIFF
--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -499,6 +499,8 @@ Scenario: Install an environment with a nonexistent group
     And stderr is
        """
        No match for group from environment: nonexistent-group
+
+       Warning: skipped PGP checks for 1 package(s).
        """
 
 
@@ -516,6 +518,8 @@ Scenario: Install an environment using @^environment syntax
     And stderr is
        """
        No match for group from environment: nonexistent-group
+
+       Warning: skipped PGP checks for 1 package(s).
        """
 
 

--- a/dnf-behave-tests/dnf/distro-sync.feature
+++ b/dnf-behave-tests/dnf/distro-sync.feature
@@ -126,6 +126,8 @@ Scenario: distro-sync list of packages with --skip-unavailable, one of them is n
     And stderr is
     """
     No match for argument: nosuchpkg
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action        | Package                                   |
@@ -159,6 +161,8 @@ Scenario: distro-sync list of packages with --skip-unavailable, one of them is n
     And stderr is
     """
     Packages for argument 'dwm' available, but not installed.
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action        | Package                                   |

--- a/dnf-behave-tests/dnf/downgrade.feature
+++ b/dnf-behave-tests/dnf/downgrade.feature
@@ -122,6 +122,8 @@ Scenario: Downgrade list of packages with --skip-unavailable, one of them is not
     And stderr is
     """
     No match for argument: nosuchpkg
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action    | Package                    |
@@ -149,6 +151,8 @@ Scenario: Downgrade list of packages with --skip-unavailable, one of them is not
     And stderr is
     """
     Packages for argument 'abcde' available, but not installed.
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action    | Package                    |
@@ -180,6 +184,8 @@ Scenario: Downgrade mixture of not available/not installed/not downgradable/down
     No match for argument: nosuchpkg
     The lowest available version of the "wget.x86_64" package is already installed, cannot downgrade it.
     Packages for argument 'abcde' available, but not installed.
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action    | Package                    |

--- a/dnf-behave-tests/dnf/download-source.feature
+++ b/dnf-behave-tests/dnf/download-source.feature
@@ -109,7 +109,10 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I delete directory "/{context.dnf.repos[dnf-ci-fedora].path}/noarch"
  When I execute dnf with args "--setopt=keepcache=true install setup"
  Then the exit code is 0
-  And stderr is empty
+  And stderr is
+  """
+  Warning: skipped PGP checks for 1 package(s).
+  """
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |
@@ -126,7 +129,10 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I delete directory "/{context.dnf.repos[dnf-ci-fedora].path}/noarch"
  When I execute dnf with args "install setup"
  Then the exit code is 0
-  And stderr is empty
+  And stderr is
+  """
+  Warning: skipped PGP checks for 1 package(s).
+  """
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |

--- a/dnf-behave-tests/dnf/install-file-conflicts.feature
+++ b/dnf-behave-tests/dnf/install-file-conflicts.feature
@@ -15,5 +15,6 @@ Scenario: An error is reported when a package with a file conflict is tried to b
     And stderr is
     """
     Transaction failed: Rpm transaction failed.
+    Warning: skipped PGP checks for 1 package(s).
       - file /usr/lib/package/conflicting-file from install of package-two-0:1.0-1.x86_64 conflicts with file from package package-one-0:1.0-1.x86_64
     """

--- a/dnf-behave-tests/dnf/install-non-existent.feature
+++ b/dnf-behave-tests/dnf/install-non-existent.feature
@@ -44,6 +44,8 @@ Scenario: Install an existent and an non-existent package with --skip-unavailabl
     And stderr is
     """
     No match for argument: non-existent-package
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action        | Package                                   |

--- a/dnf-behave-tests/dnf/install-xml-base.feature
+++ b/dnf-behave-tests/dnf/install-xml-base.feature
@@ -26,7 +26,10 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I use repository "dnf-ci-fedora"
  When I execute dnf with args "--setopt=keepcache=true install setup"
  Then the exit code is 0
-  And stderr is empty
+  And stderr is
+  """
+  Warning: skipped PGP checks for 1 package(s).
+  """
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |
@@ -42,7 +45,10 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I use repository "dnf-ci-fedora" as http
  When I execute dnf with args "install setup"
  Then the exit code is 0
-  And stderr is empty
+  And stderr is
+  """
+  Warning: skipped PGP checks for 1 package(s).
+  """
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |
@@ -59,7 +65,10 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
  When I execute dnf with args "install setup"
  Then file "/{context.dnf.repos[dnf-ci-fedora].path}/noarch/setup-2.12.1-1.fc29.noarch.rpm" exists
   And the exit code is 0
-  And stderr is empty
+  And stderr is
+  """
+  Warning: skipped PGP checks for 1 package(s).
+  """
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |

--- a/dnf-behave-tests/dnf/obsoletes.feature
+++ b/dnf-behave-tests/dnf/obsoletes.feature
@@ -296,6 +296,7 @@ Scenario: Obsoleted package is not installed when group contains both obsoleter 
         | group-install | Obsoleter and obsoleted               |
     And stderr is
     """
+    Warning: skipped PGP checks for 1 package(s).
     """
 
 

--- a/dnf-behave-tests/dnf/reinstall.feature
+++ b/dnf-behave-tests/dnf/reinstall.feature
@@ -70,6 +70,8 @@ Scenario: Reinstall list of packages with --skip-unavailable, one of them is not
     And stderr is
     """
     No match for argument: nosuchpkg
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action        | Package                                   |
@@ -93,6 +95,8 @@ Scenario: Reinstall list of packages with --skip-unavailable, one of them is not
     And stderr is
     """
     Packages for argument 'abcde' available, but not installed.
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action        | Package                                   |

--- a/dnf-behave-tests/dnf/upgrade.feature
+++ b/dnf-behave-tests/dnf/upgrade.feature
@@ -80,6 +80,8 @@ Scenario: Upgrade list of packages with --skip-unavailable, one of them is not a
     And stderr is
     """
     No match for argument: nosuchpkg
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action        | Package                                   |
@@ -107,6 +109,8 @@ Scenario: Upgrade list of packages with --skip-unavailable, one of them is not i
     And stderr is
     """
     Packages for argument 'dwm' available, but not installed.
+
+    Warning: skipped PGP checks for 1 package(s).
     """
     And Transaction is following
         | Action        | Package                                   |


### PR DESCRIPTION
https://github.com/rpm-software-management/dnf5/pull/697 adds a warning message when any PGP checks are skipped by `gpgcheck=false`. Some tests need to be updated to expect that warning on stderr.

Part of https://github.com/rpm-software-management/dnf5/issues/617