### PR TITLE
Remove stderr test step from install-xml-base.feature

### DIFF
--- a/dnf-behave-tests/dnf/install-xml-base.feature
+++ b/dnf-behave-tests/dnf/install-xml-base.feature
@@ -26,10 +26,6 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I use repository "dnf-ci-fedora"
  When I execute dnf with args "--setopt=keepcache=true install setup"
  Then the exit code is 0
-  And stderr is
-  """
-  Warning: skipped PGP checks for 1 package(s).
-  """
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |
@@ -45,10 +41,6 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I use repository "dnf-ci-fedora" as http
  When I execute dnf with args "install setup"
  Then the exit code is 0
-  And stderr is
-  """
-  Warning: skipped PGP checks for 1 package(s).
-  """
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |
@@ -65,10 +57,6 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
  When I execute dnf with args "install setup"
  Then file "/{context.dnf.repos[dnf-ci-fedora].path}/noarch/setup-2.12.1-1.fc29.noarch.rpm" exists
   And the exit code is 0
-  And stderr is
-  """
-  Warning: skipped PGP checks for 1 package(s).
-  """
   And Transaction is following
       | Action        | Package                                  |
       | install       | setup-0:2.12.1-1.fc29.noarch             |


### PR DESCRIPTION
The warning on stderr is not important for the test result and there is
a difference between dnf5 and dnf5daemon-client behavior - dnfdaemon
does not print the warning on stderr.
Without this step we can keep the same scenarios for both dnf5 and
dnf5daemon-client.