### PR TITLE
Test printing nested exceptions in error messages

### DIFF
--- a/dnf-behave-tests/dnf/error_messages.feature
+++ b/dnf-behave-tests/dnf/error_messages.feature
@@ -26,3 +26,13 @@ Scenario: Repository option 'proxy_username' is set but not 'proxy_password'
    When I execute dnf with args "repoquery abcde"
    Then the exit code is 1
     And stderr contains "'proxy_username' is set but not 'proxy_password'"
+
+@dnf5
+Scenario: Nested exception is printed when max parallel downloads are exceeded
+  Given I use repository "dnf-ci-fedora"
+    And I configure dnf with
+        | key                    | value  |
+        | max_parallel_downloads | 500    |
+   When I execute dnf with args "up"
+   Then the exit code is 1
+    And stderr contains "Librepo error: Bad value of LRO_MAXPARALLELDOWNLOADS."


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/819.