### PR TITLE
dnf-4-stack: `upgrade --security` doesn't upgrade packages with resolved advisories

### DIFF
--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -347,3 +347,21 @@ Scenario: use collections and advisories with duplicate names/ids from different
         | upgrade       | B-0:2-2.x86_64 |
         | upgrade       | C-0:2-2.x86_64 |
         | upgrade       | D-0:2-2.x86_64 |
+
+
+@bz2212838
+# This test relies on a specific order of hardcoded libsolv ids for architectures. If it is changed and i686 has lower id than x86_64
+# it will no longer test anything (always passing) because used installed Query will be in the correct order automatically.
+Scenario: Do not upgrade packages with resolved security advisories when multiple arches are present
+  Given I use repository "security-upgrade"
+    # First install i686 arch so that the package has lower libsolv id which puts it before the x86_64 package in the installed Query.
+    And I successfully execute dnf with args "install libnsl-1-1.i686"
+    And I successfully execute dnf with args "install libnsl-1-1.x86_64"
+    # During advisory query filtering the packages have to be sorted by name and arch (effectively reversing the order here)
+    # otherwise advisory for libnsl-1-1 will not be detected as resolved and it will upgrade the packages.
+   When I execute dnf with args "upgrade --security"
+   Then transaction is empty
+    And stderr is
+        """
+        No security updates needed, but 1 update available
+        """

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-1-1.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-1-1.i686.spec
@@ -1,0 +1,16 @@
+Name:           libnsl
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-1-1.spec
@@ -1,0 +1,16 @@
+Name:           libnsl
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-2-2.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-2-2.i686.spec
@@ -1,0 +1,16 @@
+Name:           libnsl
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-2-2.spec
@@ -1,0 +1,16 @@
+Name:           libnsl
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
@@ -163,4 +163,24 @@
             </collection>
         </pkglist>
     </update>
+
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-99</id>
+        <title>upgrade all packages in all archs</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>When WIP</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="libnsl" version="1" release="1" epoch="0" arch="i686" src="https://the.url/the.package.rpm">
+                    <filename>libnsl-1-1.i686.rpm</filename>
+                </package>
+                <package name="libnsl" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>libnsl-1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
 </updates>


### PR DESCRIPTION
`upgrade --security` doesn't upgrade packages with resolved advisories when present in multiple architectures.

This test relies on libsolv ids a lot which makes it harder to understand and more fragile.

For: https://github.com/rpm-software-management/libdnf/pull/1606