### PR TITLE
Add kernel-core to needs-restarting package list

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
+++ b/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
@@ -21,6 +21,7 @@ Scenario: Update core packages
           Core libraries or services have been updated since boot-up:
             * glibc
             * kernel
+            * kernel-core
 
           Reboot is required to fully utilize these updates.
           More information: https://access.redhat.com/solutions/27943


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf-plugins-core/pull/502