### PR TITLE
Fix error message: fakeuname is in test-utils COPR

### DIFF
--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -94,7 +94,7 @@ def i_fake_kernel_release(context, release):
     """
     assert os.path.exists('/usr/bin/fakeuname'), (
         'Fakeuname binary must be installed (provided by fakeuname from '
-        'rpmsoftwaremanagement/dnf-nightly copr repo)')
+        'rpmsoftwaremanagement/test-utils copr repo)')
     context.fake_kernel_release = "fakeuname {} ".format(release)
 
 


### PR DESCRIPTION
The `fakeuname` package is now in the `rpmsoftwaremanagement/test-utils` COPR, not `rpmsoftwaremanagement/dnf-nightly`.