### PR TITLE
Adjust upgrade-to test for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/upgrade-to.feature
+++ b/dnf-behave-tests/dnf/upgrade-to.feature
@@ -1,9 +1,8 @@
-# @dnf5
-# TODO(nsella) Unknown argument "upgrade-to" for command "microdnf"
-Feature: Upgrade-to for one package
+@dnf5
+Feature: Upgrade one package to a specific version
 
 
-Scenario: Upgrade-to specific version
+Scenario: Upgrade to a specific version
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install flac"
    Then the exit code is 0
@@ -12,7 +11,7 @@ Scenario: Upgrade-to specific version
         | install       | flac-0:1.3.2-8.fc29.x86_64                |
 
   Given I use repository "dnf-ci-fedora-updates"
-  When I execute dnf with args "upgrade-to flac-0:1.3.3-2.fc29"
+  When I execute dnf with args "upgrade flac-0:1.3.3-2.fc29"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                   |


### PR DESCRIPTION
`upgrade-to` is not supported in dnf5, instead `upgrade <specific-version>` is used. Test upgrade-to.feature has to be adjusted.