### PR TITLE
Add comment for dnf5 transition

### DIFF
--- a/dnf-behave-tests/dnf/upgrade-cached.feature
+++ b/dnf-behave-tests/dnf/upgrade-cached.feature
@@ -1,3 +1,4 @@
+# TODO (emrakova): dnf5: has to be updated when localization is resolved
 # destructive because it creates/overwrites /usr/share/locale/de/LC_MESSAGES/dnf.mo file
 @destructive
 Feature: Upgrade packages already downloaded to the cache


### PR DESCRIPTION
upgrade-cached test currently fails for dnf5 due to localization. It has to be adjusted when localization is resolved for dnf5, related comment has been added.