### PR TITLE
Update ci-host's `dnf install` steps

### DIFF
--- a/.github/workflows/ci-host.yml
+++ b/.github/workflows/ci-host.yml
@@ -34,10 +34,13 @@ jobs:
           RUN dnf -y install dnf-plugins-core
           RUN dnf -y copr enable rpmsoftwaremanagement/rpm-gitoverlay
           RUN dnf -y install rpm-gitoverlay fuse-overlayfs parallel podman wget clang-tools-extra
+          # needed for dnf5's ccache builds
+          RUN dnf -y builddep https://raw.githubusercontent.com/rpm-software-management/dnf5/main/dnf5.spec
+          RUN dnf -y builddep --define="with_clang true" \
+           https://raw.githubusercontent.com/rpm-software-management/dnf5/main/dnf5.spec
+          RUN dnf -y install ccache
           # needed for pre-commit hooks
           RUN dnf -y install git python3-pip rpmlint
-          # needed for moving of PIDs in integration-tests
-          RUN dnf -y install procps-ng
           RUN dnf clean all  # remove dnf cache to make the image smaller
           EOF
 


### PR DESCRIPTION
CI-Host Container now installs buildrequires.
Needed for DNF5's build with ccache.

The requirement for procps-ng is removed since
it is installed during builddep steps.

required for https://github.com/rpm-software-management/dnf5/pull/879