### PR TITLE
dnf5: Enable needs-restarting tests

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
+++ b/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
@@ -1,3 +1,4 @@
+@dnf5
 @bz1639468
 Feature: Reboot hint
 
@@ -5,8 +6,12 @@ Background:
     Given I enable plugin "needs_restarting"
       And I use repository "dnf-ci-fedora"
       And I move the clock backward to "before boot-up"
-      And I execute dnf with args "install lame kernel basesystem glibc wget"
-      And I move the clock forward to "2 hours"
+      And I execute dnf with args "install lame kernel basesystem glibc wget lz4"
+      And I move the clock forward to "the present"
+      # Boot time is measured down to the second, so sleep for one second so
+      # the time packages are installed is at least one second after container
+      # boot
+      And I sleep for "1" seconds
       And I use repository "dnf-ci-fedora-updates"
 
 @bz1913962
@@ -14,30 +19,50 @@ Scenario: Update core packages
     Given I execute dnf with args "upgrade kernel basesystem"
       And I execute dnf with args "upgrade glibc"
       And I execute dnf with args "upgrade lame wget"
-     When I execute dnf with args "needs-restarting -r"
+     When I execute dnf with args "needs-restarting"
      Then the exit code is 1
       And stdout is
           """
+          <REPOSYNC>
           Core libraries or services have been updated since boot-up:
             * glibc
             * kernel
+            * kernel-core
 
           Reboot is required to fully utilize these updates.
           More information: https://access.redhat.com/solutions/27943
           """
 
+@bz1913962
+Scenario: Install a package with an associated reboot_suggested advisory
+    Given I execute dnf with args "upgrade --advisory=FEDORA-2999:003-03 \*"
+     When I execute dnf with args "needs-restarting"
+     Then the exit code is 1
+      And stdout is
+          """
+          <REPOSYNC>
+          Core libraries or services have been updated since boot-up:
+            * lz4
+
+          Reboot is required to fully utilize these updates.
+          More information: https://access.redhat.com/solutions/27943
+          """
 
 Scenario: Update non-core packages only
     Given I execute dnf with args "upgrade lame basesystem wget"
-     When I execute dnf with args "needs-restarting -r"
+     When I execute dnf with args "needs-restarting"
      Then the exit code is 0
       And stdout is
           """
+          <REPOSYNC>
           No core libraries or services have been updated since boot-up.
           Reboot should not be necessary.
           """
 
+Scenario: -r short option (no-op for compatibility with DNF 4)
+     When I execute dnf with args "needs-restarting -r"
+     Then the exit code is 0
 
-Scenario: Long option form
+Scenario: --reboothint long option (no-op for compatibility with DNF 4)
      When I execute dnf with args "needs-restarting --reboothint"
      Then the exit code is 0

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-updates/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-updates/updateinfo.xml
@@ -44,6 +44,27 @@
       </collection>
     </pkglist>
   </update>
+  <update from="secresponseteam@foo.bar" status="final" type="enhancement" version="3">
+    <id>FEDORA-2999:003-03</id>
+    <title>lz4 enhacements</title>
+    <issued date="2019-01-17 00:00:00"/>
+    <updated date="2019-01-17 00:00:00"/>
+    <severity>Moderate</severity>
+    <summary>summary_1</summary>
+    <description>Enhance some stuff, reboot_suggested=True</description>
+    <references>
+        <reference href="https://foobar/foobarupdate_1" id="1" type="self" title="update_1"/>
+    </references>
+    <pkglist>
+      <collection short="named collection">
+        <name>Bar component</name>
+        <package name="lz4" version="1.8.2" release="2.fc29" epoch="0" arch="x86_64" src="lz4-0:1.8.2-2.fc29.x86_64.rpm">
+          <filename>lz4-0:1.8.2-2.fc29.x86_64.rpm</filename>
+          <reboot_suggested>True</reboot_suggested>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
   <update from="secresponseteam@foo.bar" status="final" type="bugfix" version="3">
     <id>FEDORA-2019-348e185000</id>
     <title>kernel bug fix</title>


### PR DESCRIPTION
Update the needs-restarting tests for DNF 5 and add a test for recommending a reboot when a package has an associated reboot_suggested advisory.

Requires https://github.com/rpm-software-management/dnf5/pull/887

For https://github.com/rpm-software-management/dnf5/issues/743