### PR TITLE
Removal of a not-installed group does not fail

### DIFF
--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -655,3 +655,14 @@ Scenario: dnf can list installed groups even without their xml definitions prese
     Repositories         : @System
     Default packages     : test-package
     """
+
+# https://github.com/rpm-software-management/dnf5/issues/917
+@dnf5
+Scenario: Remove group that is not installed
+ Given I use repository "dnf-ci-thirdparty"
+  When I execute dnf with args "group remove dnf-ci-testgroup"
+  Then the exit code is 0
+   And stderr is
+   """
+   No groups to remove for argument: dnf-ci-testgroup
+   """


### PR DESCRIPTION
Test for: https://github.com/rpm-software-management/dnf5/issues/917
Requires: https://github.com/rpm-software-management/dnf5/pull/1013