### PR TITLE
Test that dnf cannot install source rpm

### DIFF
--- a/dnf-behave-tests/dnf/install-dependencies.feature
+++ b/dnf-behave-tests/dnf/install-dependencies.feature
@@ -1,6 +1,4 @@
-# @dnf5
-# TODO(nsella) transaction table output disabled
-# TODO(nsella) different stderr
+@dnf5
 Feature: Tests for install with dependencies
 
 
@@ -14,9 +12,10 @@ Scenario: Best candidates have conflicting dependencies
         | install       | foo-0:1.0-1.fc29.x86_64           |
         | install       | bar-0:1.0-1.fc29.x86_64           |
         | install-dep   | lib-0:1.0-1.fc29.x86_64           |
-        | conflict      | lib-0:2.0-1.fc29.x86_64           |
-        | broken        | foo-0:2.0-1.fc29.x86_64           |
-    And stderr contains "cannot install both lib-2.0-1.fc29.x86_64 and lib-1.0-1.fc29.x86_64"
+        # dnf5 currently does not report packages skipped due to conflict / broken deps
+        #        | conflict      | lib-0:2.0-1.fc29.x86_64           |
+        #        | broken        | foo-0:2.0-1.fc29.x86_64           |
+    And stderr contains "cannot install both lib-.\.0-1\.fc29\.x86_64 and lib-.\.0-1\.fc29\.x86_64"
     And stderr contains "package foo-2.0-1.fc29.x86_64 requires lib-2.0, but none of the providers can be installed"
     And stderr contains "package bar-1.0-1.fc29.x86_64 requires lib-1.0, but none of the providers can be installed"
     And stderr contains "cannot install the best candidate for the job"

--- a/dnf-behave-tests/dnf/install-exclude.feature
+++ b/dnf-behave-tests/dnf/install-exclude.feature
@@ -1,15 +1,14 @@
+@dnf5
 Feature: Install RPMs with --exclude
 
 
-@dnf5
 Scenario: Install an RPM that is excluded
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem --exclude filesystem"
    Then the exit code is 1
     And Transaction is empty
 
-# @dnf5
-# TODO(nsella) different stderr
+
 @bz1756473
 Scenario: Install an RPM that requires excluded RPM
   Given I use repository "dnf-ci-fedora"
@@ -18,14 +17,13 @@ Scenario: Install an RPM that requires excluded RPM
     And Transaction is empty
     And stderr is
     """
-    Error: 
-     Problem: package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed
+    Failed to resolve the transaction:
+    Problem: package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed
       - conflicting requests
       - package setup-2.12.1-1.fc29.noarch is filtered out by exclude filtering
     """
 
 
-@dnf5
 Scenario: Install RPMs while excluding part of them
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup filesystem --exclude filesystem"
@@ -33,7 +31,6 @@ Scenario: Install RPMs while excluding part of them
     And Transaction is empty
 
 
-@dnf5
 Scenario: Install RPMs while excluding part of them (strict=false)
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup filesystem --exclude filesystem --setopt=strict=false"
@@ -43,7 +40,6 @@ Scenario: Install RPMs while excluding part of them (strict=false)
         | install       | setup-0:2.12.1-1.fc29.noarch          |
 
 
-@dnf5
 Scenario: Install RPMs while excluding another RPM
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install filesystem --exclude glibc"

--- a/dnf-behave-tests/dnf/install-fails.feature
+++ b/dnf-behave-tests/dnf/install-fails.feature
@@ -1,32 +1,28 @@
+@dnf5
 Feature: Installing attemps fail
 
-# @dnf5
-# TODO(nsella) different stderr
 @bz1568965
 Scenario: Report all missing dependencies
-  Given I use repository "dnf-ci-thirdparty"
+   Given I use repository "dnf-ci-thirdparty"
     When I execute dnf with args "install SuperRipper anitras-dance"
     Then stderr contains "nothing provides abcde needed by SuperRipper-1.0-1.x86_64"
     Then stderr contains "nothing provides nodejs needed by anitras-dance-1.0-1.x86_64"
 
-# @dnf5
-# TODO(nsella) different exit code
 @bz1599774
 Scenario: Report error when installing empty file
-   Given I execute "touch empty.rpm" in "{context.dnf.installroot}/"
+   Given I set working directory to "{context.dnf.installroot}"
+     And I execute "touch empty.rpm"
     When I execute dnf with args "install empty.rpm"
     Then the exit code is 1
      And stderr is
      """
-     Can not load RPM file: empty.rpm.
-     Could not open: empty.rpm
+     Failed to load RPM "empty.rpm": empty.rpm: not a rpm
      """
 
-# @dnf5
-# TODO(nsella) different exit code
 @bz1616321
 Scenario: Report error when installing text file
-   Given I create file "invalid.rpm" with
+   Given I set working directory to "{context.dnf.installroot}"
+     And I create file "invalid.rpm" with
          """
          this is not rpm
          """
@@ -34,18 +30,14 @@ Scenario: Report error when installing text file
     Then the exit code is 1
      And stderr is
      """
-     Can not load RPM file: invalid.rpm.
-     Could not open: invalid.rpm
+     Failed to load RPM "invalid.rpm": invalid.rpm: not a rpm
      """
 
-# @dnf5
-# TODO(nsella) different stdout
 @bz1599774
 Scenario: Report error when installing non-existing RPM file
     When I execute dnf with args "install no_such_file.rpm"
     Then the exit code is 1
      And stderr is
      """
-     Can not load RPM file: no_such_file.rpm.
-     Could not open: no_such_file.rpm
+     Failed to access RPM "no_such_file.rpm": No such file or directory
      """

--- a/dnf-behave-tests/dnf/install-fails.feature
+++ b/dnf-behave-tests/dnf/install-fails.feature
@@ -41,3 +41,13 @@ Scenario: Report error when installing non-existing RPM file
      """
      Failed to access RPM "no_such_file.rpm": No such file or directory
      """
+
+Scenario: Cannot install source rpm
+   Given I use repository "simple-base"
+    When I execute dnf with args "install vagare.src"
+    Then the exit code is 1
+     And stderr is
+     """
+     Failed to resolve the transaction:
+     Argument 'vagare.src' matches only source packages.
+     """

--- a/dnf-behave-tests/dnf/install-obsoletes.feature
+++ b/dnf-behave-tests/dnf/install-obsoletes.feature
@@ -1,7 +1,7 @@
+@dnf5
 Feature: Install an obsoleted RPM
 
 
-@dnf5
 Scenario: Install an obsoleted RPM
   Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install glibc-profile"
@@ -17,7 +17,6 @@ Scenario: Install an obsoleted RPM
         | Install | glibc-profile-0:2.3.1-10.x86_64 | User       | dnf-ci-thirdparty |
 
 
-@dnf5
 Scenario: Install an obsoleted RPM when the obsoleting RPM is available
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-thirdparty"
@@ -88,8 +87,6 @@ Scenario: Upgrading obsoleted package by its obsoleter keeps userinstalled=false
         """
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "mark" for command "microdnf"
 @bz1672618
 Scenario: Upgrading obsoleted package by its obsoleter keeps userinstalled=false (with --nobest)
   Given I use repository "dnf-ci-thirdparty"
@@ -98,15 +95,11 @@ Scenario: Upgrading obsoleted package by its obsoleter keeps userinstalled=false
     And Transaction is following
         | Action        | Package                                   |
         | install       | glibc-profile-0:2.3.1-10.x86_64           |
-   When I execute dnf with args "mark remove glibc-profile"
+   When I execute dnf with args "mark dependency glibc-profile"
    Then the exit code is 0
-   When I execute dnf with args "history userinstalled"
-   Then the exit code is 1
+   When I execute dnf with args "repoquery --userinstalled"
+   Then the exit code is 0
     And stdout is empty
-    And stderr is
-        """
-        Error: No packages to list
-        """
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "upgrade --nobest"
    Then the exit code is 0
@@ -119,16 +112,10 @@ Scenario: Upgrading obsoleted package by its obsoleter keeps userinstalled=false
         | install-dep   | glibc-common-0:2.28-9.fc29.x86_64         |
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
         | obsoleted     | glibc-profile-0:2.3.1-10.x86_64           |
-   When I execute dnf with args "history userinstalled"
-   Then the exit code is 1
+   When I execute dnf with args "repoquery --userinstalled"
+   Then the exit code is 0
     And stdout is empty
-    And stderr is
-        """
-        Error: No packages to list
-        """
 
-# @dnf5
-# TODO(nsella) Unknown argument "mark" for command "microdnf"
 Scenario: Install obsoleting package and inherit the best reason - user
   Given I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install glibc-profile"
@@ -136,15 +123,11 @@ Scenario: Install obsoleting package and inherit the best reason - user
     And Transaction is following
         | Action        | Package                                   |
         | install       | glibc-profile-0:2.3.1-10.x86_64           |
-   When I execute dnf with args "mark remove glibc-profile"
+   When I execute dnf with args "mark dependency glibc-profile"
    Then the exit code is 0
-   When I execute dnf with args "history userinstalled"
-   Then the exit code is 1
+   When I execute dnf with args "repoquery --userinstalled"
+   Then the exit code is 0
     And stdout is empty
-    And stderr is
-        """
-        Error: No packages to list
-        """
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install glibc-0:2.28-9.fc29.x86_64"
    Then the exit code is 0
@@ -157,10 +140,9 @@ Scenario: Install obsoleting package and inherit the best reason - user
         | install-dep   | glibc-common-0:2.28-9.fc29.x86_64         |
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
         | obsoleted     | glibc-profile-0:2.3.1-10.x86_64           |
-   When I execute dnf with args "history userinstalled"
+   When I execute dnf with args "repoquery --userinstalled"
    Then the exit code is 0
     And stdout is
         """
-        Packages installed by user
-        glibc-2.28-9.fc29.x86_64
+        glibc-0:2.28-9.fc29.x86_64
         """

--- a/dnf-behave-tests/dnf/install-provides.feature
+++ b/dnf-behave-tests/dnf/install-provides.feature
@@ -1,8 +1,8 @@
+@dnf5
 Feature: Install RPMs by provides
 
 
 @dnf5daemon
-@dnf5
 Scenario: Install an RPM by provide that equals to e:v-r
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install 'filesystem = 0:3.9-2.fc29'"
@@ -14,7 +14,6 @@ Scenario: Install an RPM by provide that equals to e:v-r
 
 
 @dnf5daemon
-@dnf5
 Scenario: Install an RPM by provide that is greater than e:vr
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install 'filesystem > 0:3.9-2'"
@@ -26,7 +25,6 @@ Scenario: Install an RPM by provide that is greater than e:vr
 
 
 @dnf5daemon
-@dnf5
 Scenario: Install an RPM by provide that is greater than e:vr without space
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install 'filesystem >0:3.9-2'"
@@ -38,7 +36,6 @@ Scenario: Install an RPM by provide that is greater than e:vr without space
 
 
 @dnf5daemon
-@dnf5
 Scenario: Install an RPM by provide that is greater or equal to e:vr
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install 'filesystem >= 0:3.9-2'"
@@ -50,7 +47,6 @@ Scenario: Install an RPM by provide that is greater or equal to e:vr
 
 
 @dnf5daemon
-@dnf5
 Scenario: Install an RPM by provide that is lower than e:vr
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
@@ -67,7 +63,6 @@ Scenario: Install an RPM by provide that is lower than e:vr
 
 
 @dnf5daemon
-@dnf5
 Scenario: Install an RPM by provide that is lower or equal to e:vr
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
@@ -84,7 +79,6 @@ Scenario: Install an RPM by provide that is lower or equal to e:vr
 
 
 @dnf5daemon
-@dnf5
 Scenario: I can install an RPM by $provide where $provide is key
   Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "install webclient"
@@ -94,9 +88,6 @@ Scenario: I can install an RPM by $provide where $provide is key
         | install       | wget-0:1.19.5-5.fc29.x86_64               |
 
 
-# @dnf5
-# TODO(nsella) rpmdb check fail
-# No match for argument: /var/db/
 Scenario Outline: I can install an RPM by <provide type>
   Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "install <provide> "
@@ -120,7 +111,6 @@ Examples:
         | directory provide            | /var/db/         |
 
 @dnf5daemon
-@dnf5
 Scenario: Install package using binary name
 #  wget provides binary wget-bivary, but it is not explicitly in provides
   Given I use repository "dnf-ci-fedora"


### PR DESCRIPTION
Also enables bunch of install-* tests for dnf5.

Requires: https://github.com/rpm-software-management/dnf5/pull/1041