### PR TITLE
Tests for sharing root metadata cache

### DIFF
--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -557,9 +557,7 @@ Scenario: Packages that are part of another installed group are not removed
         | group-remove  | Test Group    |
 
 
-# @dnf5
-# TODO(jkolarik): Cache files are now created with root-only mask
-# TODO(jkolarik): Enable after resolving the https://github.com/rpm-software-management/dnf5/issues/1000
+@dnf5
 # destructive because it can create a new user on the system
 @bz2030255
 @destructive

--- a/dnf-behave-tests/dnf/shared-root-cache.feature
+++ b/dnf-behave-tests/dnf/shared-root-cache.feature
@@ -1,0 +1,42 @@
+# destructive because it can create a new user on the system
+@destructive
+@dnf5
+Feature: Testing functionality related to sharing root metadata cache to users
+
+Background:
+  Given I use repository "dnf-ci-fedora"
+    # unprivileged user will need access to enter installroot and read files there
+    And I successfully execute "chmod go+rwx {context.dnf.installroot}"
+    # prepare a directory for the user's cache
+    And I create directory "/{context.dnf.installroot}/var/cache/dnf-user"
+    And I successfully execute "chmod 777 {context.dnf.installroot}/var/cache/dnf-user"
+    And I successfully execute dnf with args "makecache"
+   Then stdout matches line by line
+   """
+   Updating and loading repositories:
+    dnf-ci-fedora test repository .*
+   Repositories loaded.
+   Metadata cache created.
+   """
+
+
+Scenario: Root cache is shared when user metadata are empty
+   When I execute dnf with args "makecache --setopt=system_cachedir={context.dnf.installroot}/var/cache/dnf --setopt=cachedir={context.dnf.installroot}/var/cache/dnf-user" as an unprivileged user
+   Then stdout matches line by line
+   """
+   Updating and loading repositories:
+   Repositories loaded.
+   Metadata cache created.
+   """
+
+
+Scenario: Root cache is not shared when the user doesn't have permissions
+   When I successfully execute "chmod 700 {context.dnf.installroot}/var/cache/dnf"
+    And I execute dnf with args "makecache --setopt=system_cachedir={context.dnf.installroot}/var/cache/dnf --setopt=cachedir={context.dnf.installroot}/var/cache/dnf-user" as an unprivileged user
+   Then stdout matches line by line
+   """
+   Updating and loading repositories:
+    dnf-ci-fedora test repository .*
+   Repositories loaded.
+   Metadata cache created.
+   """


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/1051.