### PR TITLE
fix bash equal operator for strings

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -13,7 +13,7 @@ prepare:
     - name: Checkout PR branch if packit call is from ci-dnf-stack
       how: shell
       script: |
-        if [ "$PACKIT_UPSTREAM_NAME" -eq "ci-dnf-stack" ]; then \
+        if [ "$PACKIT_UPSTREAM_NAME" == "ci-dnf-stack" ]; then \
           git -C $TMT_PLANS_DATA/ci-dnf-stack remote add pull-request $PACKIT_SOURCE_URL \
           git -C $TMT_PLANS_DATA/ci-dnf-stack fetch pull-request \
           git -C $TMT_PLANS_DATA/ci-dnf-stack checkout --track pull-request/$PACKIT_SOURCE_BRANCH


### PR DESCRIPTION
`-eq` is for numeric comparisons. replacing with `==`