### PR TITLE
builddep: test BuildRequires: python3dist(build[foo])

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/builddep.feature
+++ b/dnf-behave-tests/dnf/plugins-core/builddep.feature
@@ -180,3 +180,12 @@ Scenario: Builddep using macros with source rpm
      When I execute dnf with args "builddep -D 'dummy_param 1' {context.dnf.fixturesdir}/repos/dnf-ci-thirdparty/src/SuperRipper-1.0-1.src.rpm"
      Then the exit code is 0
       And stderr contains "Warning: -D or --define arguments have no meaning for source rpm packages."
+
+@dnf5
+Scenario: Builddep where package BuildRequires a pkg spec that contains glob characters
+    Given I use repository "builddep"
+     When I execute dnf with args "builddep requires-glob"
+     Then the exit code is 0
+      And Transaction is following
+          | Action        | Package                    |
+          | install       | provides-glob-0:1-1.x86_64 |

--- a/dnf-behave-tests/fixtures/specs/builddep/provides-glob-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/builddep/provides-glob-1-1.spec
@@ -1,0 +1,18 @@
+Name:           provides-glob
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Provides a pkg spec that contains glob characters
+
+Provides:       python3dist(build[foo])
+
+%description
+This package is part of testing builddep
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/builddep/requires-glob-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/builddep/requires-glob-1-1.spec
@@ -1,0 +1,18 @@
+Name:           requires-glob
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        BuildRequires a pkg spec that contains glob characters
+
+BuildRequires:  python3dist(build[foo])
+
+%description
+This package is part of testing builddep
+
+%files
+
+%changelog


### PR DESCRIPTION
For https://github.com/rpm-software-management/dnf5/issues/1084

Requires https://github.com/rpm-software-management/dnf5/pull/1088 or https://github.com/rpm-software-management/dnf5/pull/1085.