### PR TITLE
Test makecache as unprivileged user without system state

### DIFF
--- a/dnf-behave-tests/dnf/unprivileged.feature
+++ b/dnf-behave-tests/dnf/unprivileged.feature
@@ -1,0 +1,19 @@
+@destructive
+@no_installroot
+Feature: test dnf5 as unprivileged user
+
+
+@dnf5
+Scenario: unprivileged user can create a cache even without system state
+  Given I use repository "simple-base"
+    # Give user permissions to access cache
+    And I create directory "/{context.dnf.installroot}/var/cache/dnf"
+    And I successfully execute "chmod 777 {context.dnf.installroot}/var/cache/dnf"
+    And I delete directory "/usr/lib/sysimage/libdnf5"
+   When I execute dnf with args "makecache" as an unprivileged user
+   Then the exit code is 0
+    And stdout is
+        """
+        <REPOSYNC>
+        Metadata cache created.
+        """


### PR DESCRIPTION
Test makecache as unprivileged user without system state

For: https://github.com/rpm-software-management/dnf5/pull/1097