### PR TITLE
Enable tests for protected-packages

### DIFF
--- a/dnf-behave-tests/dnf/environment.py
+++ b/dnf-behave-tests/dnf/environment.py
@@ -49,10 +49,6 @@ class DNFContext(object):
             }
         }
 
-        # Since protected_packages don't work in installroot override host configuration
-        if not no_installroot:
-            self.config["[main]"]["protected_packages"] = ","
-
         self.tempdir = tempfile.mkdtemp(prefix="dnf_ci_tempdir_")
         # some tests need to be run inside the installroot, it can be forced
         # per scenario by using @force_installroot decorator

--- a/dnf-behave-tests/dnf/protected-packages.feature
+++ b/dnf-behave-tests/dnf/protected-packages.feature
@@ -1,10 +1,7 @@
+@dnf5
 Feature: Protected packages
 
-
-# @dnf5
-# TODO(nsella) different stderr
-@tier1
-Scenario: Package protected via setopt cannot be removed
+Background:
   Given I use repository "dnf-ci-fedora"
     And I execute dnf with args "install filesystem"
    Then the exit code is 0
@@ -12,38 +9,31 @@ Scenario: Package protected via setopt cannot be removed
         | Action        | Package                               |
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install-dep   | setup-0:2.12.1-1.fc29.noarch          |
+
+@tier1
+Scenario: Package protected via setopt cannot be removed
    When I execute dnf with args "remove filesystem --setopt=protected_packages=filesystem"
    Then the exit code is 1
     And Transaction is empty
     And stderr contains "Problem: The operation would result in removing the following protected packages: filesystem"
 
 
-# @dnf5
-# TODO(nsella) different stderr
 Scenario: Package with protected dependency via setopt cannot be removed
-  Given I use repository "dnf-ci-fedora"
-    And I execute dnf with args "install filesystem"
-   Then the exit code is 0
-    And Transaction is following
-        | Action        | Package                               |
-        | install       | filesystem-0:3.9-2.fc29.x86_64        |
-        | install-dep   | setup-0:2.12.1-1.fc29.noarch          |
    When I execute dnf with args "remove filesystem --setopt=protected_packages=setup"
    Then the exit code is 1
     And Transaction is empty
     And stderr contains "Problem: The operation would result in removing the following protected packages: setup"
 
 
-# TODO: make protected packages work in installroots first
-#Scenario: Package protected via a configuration file cannot be removed
-#  Given I create and substitute file "/etc/dnf/protected.d/filesystem.conf" with
-#        """
-#        filesystem
-#        """
-#   When I execute dnf with args "remove filesystem"
-#   Then the exit code is 1
-#    And Transaction is empty
-#    And stderr contains "Problem: The operation would result in removing the following protected packages: filesystem"
+Scenario: Package protected via a configuration file cannot be removed
+  Given I create and substitute file "/etc/dnf/protected.d/filesystem.conf" with
+        """
+        filesystem
+        """
+   When I execute dnf with args "remove filesystem"
+   Then the exit code is 1
+    And Transaction is empty
+    And stderr contains "Problem: The operation would result in removing the following protected packages: filesystem"
 
 
 # TODO: Removal of DNF itself


### PR DESCRIPTION
Additional changases are related to implementation of support of protected-packages in installroot

Requires: https://github.com/rpm-software-management/dnf5/pull/1110