### PR TITLE
Enable tests for enabling default module streams

### DIFF
--- a/dnf-behave-tests/dnf/module/defaults-streams.feature
+++ b/dnf-behave-tests/dnf/module/defaults-streams.feature
@@ -5,6 +5,7 @@ Background:
     And I use repository "dnf-ci-fedora"
 
 
+@dnf5
 @bz1657213
 Scenario: The default stream is enabled when requiring module is enabled
    When I execute dnf with args "module enable meson:master"

--- a/dnf-behave-tests/dnf/module/defaults.feature
+++ b/dnf-behave-tests/dnf/module/defaults.feature
@@ -5,6 +5,7 @@ Background:
     And I use repository "dnf-ci-fedora"
 
 
+@dnf5
 Scenario: The default stream is used when enabling a module
    When I execute dnf with args "module enable nodejs"
    Then the exit code is 0

--- a/dnf-behave-tests/dnf/module/enable.feature
+++ b/dnf-behave-tests/dnf/module/enable.feature
@@ -5,6 +5,7 @@ Background:
   Given I use repository "dnf-ci-fedora-modular"
 
 
+@dnf5
 Scenario Outline: Enable a module stream by <modulespec-type>
    When I execute dnf with args "module enable <modulespec>"
    Then the exit code is 0


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf5/pull/1152