### PR TITLE
Adjust versionlock locking tests to dnf5

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/versionlock-exclude.feature
+++ b/dnf-behave-tests/dnf/plugins-core/versionlock-exclude.feature
@@ -1,22 +1,17 @@
+@dnf5
 Feature: Tests excluding capabilities of the versionlock plugin
 
 
 Background: Set up versionlock infrastructure in the installroot
-  Given I enable plugin "versionlock"
-  # plugins do not honor installroot when searching their configuration
-  # following steps are merely to set up versionlock plugin inside installroot
-  And I configure dnf with
-    | key            | value                                     |
-    | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
-  And I create and substitute file "/etc/dnf/plugins/versionlock.conf" with
+  Given I create file "/etc/dnf/versionlock.toml" with
     """
-    [main]
-    enabled = 1
-    locklist = {context.dnf.installroot}/etc/dnf/plugins/versionlock.list
-    """
-  And I create file "/etc/dnf/plugins/versionlock.list" with
-    """
-    !wget-0:1.19.6-5.fc29.*
+    version = "1.0"
+    [[packages]]
+    name = "wget"
+    [[packages.conditions]]
+    key = "evr"
+    comparator = "!="
+    value = "0:1.19.6-5.fc29"
     """
   # check that both excluded and newer versions of the package are available
   Given I use repository "dnf-ci-fedora"
@@ -25,6 +20,7 @@ Background: Set up versionlock infrastructure in the installroot
    Then the exit code is 0
     And stdout is
     """
+    <REPOSYNC>
     wget-0:1.19.5-5.fc29.src
     wget-0:1.19.5-5.fc29.x86_64
     wget-0:1.19.6-5.fc29.src

--- a/dnf-behave-tests/dnf/plugins-core/versionlock-list.feature
+++ b/dnf-behave-tests/dnf/plugins-core/versionlock-list.feature
@@ -1,79 +1,21 @@
+@dnf5
 Feature: Tests missing or misconfigured versionlock.list file in versionlock plugin
 
 
 Background: Set up versionlock infrastructure in the installroot
-  Given I enable plugin "versionlock"
-  # plugins do not honor installroot when searching their configuration
-  # all the next steps are merely to set up versionlock plugin inside installroot
-  And I configure dnf with
-    | key            | value                                     |
-    | pluginconfpath | {context.dnf.installroot}/etc/dnf/plugins |
-  And I create and substitute file "/etc/dnf/plugins/versionlock.conf" with
-    """
-    [main]
-    enabled = 1
-    locklist = {context.dnf.installroot}/etc/dnf/plugins/versionlock.list
-    """
-  And I create file "/etc/dnf/plugins/versionlock.list" with
+  Given I create file "/etc/dnf/versionlock.toml" with
     """
     """
-  # check that both locked and newer versions of the package are available
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-updates"
 
-
-Scenario: dnf will fail if versionlock.list file is missing
-  Given I delete file "/etc/dnf/plugins/versionlock.list"
-  When I execute dnf with args "check-update"
-  Then the exit code is 1
-
-
-Scenario: dnf will fail if versionlock.list path is missing from conf
-  Given I create file "/etc/dnf/plugins/versionlock.conf" with
-    """
-    [main]
-    enabled=1
-    """
-  When I execute dnf with args "check-update"
-  Then the exit code is 1
-
-
-Scenario Outline: dnf versionlock <option> <package> will fail if versionlock.list file is missing
-  Given I delete file "/etc/dnf/plugins/versionlock.list"
-  When I execute dnf with args "versionlock <option> <package>"
-  Then the exit code is 1
-
-Examples:
-        | option  | package |
-        | list    |         |
-        | delete  | abcde   |
-        | add     | abcde   |
-        | exclude | abcde   |
-
-
 Scenario: dnf versionlock clear will create empty file if versionlock.list is missing
-  Given I delete file "/etc/dnf/plugins/versionlock.list"
+  Given I delete file "/etc/dnf/versionlock.toml"
   When I execute dnf with args "versionlock clear"
   Then the exit code is 0
-  And file "/etc/dnf/plugins/versionlock.list" exists
-  And file "/etc/dnf/plugins/versionlock.list" contents is
+  And file "/etc/dnf/versionlock.toml" exists
+  And file "/etc/dnf/versionlock.toml" contents is
     """
+    packages = []
+    version = "1.0"
     """
-
-
-Scenario Outline: dnf versionlock <option> <package> will fail if versionlock.list path is missing from conf
-  Given I create file "/etc/dnf/plugins/versionlock.conf" with
-    """
-    [main]
-    enabled=1
-    """
-  When I execute dnf with args "versionlock <option> <package>"
-  Then the exit code is 1
-
-Examples:
-        | option    | package |
-        | list      |         |
-        | clear     |         |
-        | add       | abcde   |
-        | delete    | abcde   |
-        | exclude   | abcde   |


### PR DESCRIPTION
- change config format to new versionlock.toml format
- drop test for different patterns of locked versions. Globs are not
  supported any more.
- version pattern (1.3.*) test changed to proper versions interval
  (>=1.3 && < 1.4)

Requires: https://github.com/rpm-software-management/dnf5/pull/1121