### PR TITLE
Update actions versions and output method

### DIFF
--- a/.github/actions/copr-build/action.yml
+++ b/.github/actions/copr-build/action.yml
@@ -61,4 +61,4 @@ runs:
 
         # convert newlines to spaces (output variable assignment below doesn't support newlines)
         PACKAGE_URLS="$(tr '\n' ' ' < rpmlist)"
-        echo "::set-output name=package-urls::$PACKAGE_URLS"
+        echo "package-urls=$PACKAGE_URLS" >> $GITHUB_OUTPUT

--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -28,7 +28,7 @@ runs:
         # printed, Github won't hide it anymore.
         COPR_USER=${{inputs.copr-user}}
         if [ "${{inputs.fail-without-copr}}" = true -a -z "$COPR_USER" ]; then echo "COPR_USER secret is required to run the CI."; exit 1; fi
-        echo "::set-output name=copr-user::$COPR_USER"
+        echo "copr-user=$COPR_USER" >> $GITHUB_OUTPUT
 
         if [ "${{inputs.fail-without-copr}}" = true -a -z "${{inputs.copr-api-token}}" ]; then echo "COPR_API_TOKEN secret is required to run the CI."; exit 1; fi
         mkdir -p "$HOME/.config"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         - /var/lib/mycontainer:/var/lib/containers
     steps:
       - name: Check out sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.sha}}  # check out the PR HEAD
           fetch-depth: 0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
             variant: -sanitizers
     steps:
       - name: Check out sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup CI
         id: setup-ci

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/rpm-software-management/dnf-ci-host
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install pre-commit
       run: pip install pre-commit
     - name: State to use Workspace Dir


### PR DESCRIPTION
Updates actions/checkout@v4 to the latest major version to drop deprecated nodejs version, and replace deprecated `::set-output` method with the [current method](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).

This solves the warnings:

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

and

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/