### PR TITLE
Logic rework of fmf files and add dnf4 build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 # Example Usage:
 # $ podman build --build-arg TYPE=distro -t ci-dnf-stack -f Dockerfile
 # $ podman run --net none -it ci-dnf-stack behave dnf
+#
+# Build for DNF4
+# $ podman build --build-arg DNF=dnf -t ci-dnf-stack -f Dockerfile
+#
+# Build for a specific Fedora version
+# $ podman build --build-arg BASE=fedora:38 -t ci-dnf-stack -f Dockerfile
 
 ARG BASE=fedora:39
 FROM $BASE
 
 ENV LANG C.UTF-8
 ARG TYPE=nightly
+ARG DNF
 
 # disable deltas and weak deps
 RUN set -x && \
@@ -24,16 +31,18 @@ RUN set -x && \
 
 # enable dnf5
 RUN set -x && \
-    dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
-    dnf -y install dnf5-plugins; \
-    # run upgrade before distro-sync in case there is a new version in dnf-nightly that has a new dependency
-    dnf5 -y upgrade; \
-    dnf5 -y distro-sync --repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly;
+    if [ $DNF == "dnf5" ]; then \
+        dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
+        dnf -y install dnf5-plugins; \
+        # run upgrade before distro-sync in case there is a new version in dnf-nightly that has a new dependency
+        dnf5 -y upgrade; \
+        dnf5 -y distro-sync --repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly; \
+    fi
 
 RUN set -x && \
     if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then \
-       dnf5 -y copr enable $COPR; \
-       dnf5 -y install $COPR_RPMS; \
+       $DNF -y copr enable $COPR; \
+       $DNF -y install $COPR_RPMS; \
     fi
 
 # copy test suite
@@ -41,14 +50,14 @@ COPY ./dnf-behave-tests/ /opt/ci/dnf-behave-tests
 
 # install test suite dependencies
 RUN set -x && \
-    dnf5 -y builddep /opt/ci/dnf-behave-tests/requirements.spec && \
+    $DNF -y builddep /opt/ci/dnf-behave-tests/requirements.spec && \
     pip3 install -r /opt/ci/dnf-behave-tests/requirements.txt
 
 # install local RPMs if available
 COPY ./rpms/ /opt/ci/rpms/
 RUN rm /opt/ci/rpms/*-{devel,debuginfo,debugsource}*.rpm; \
     if [ -n "$(find /opt/ci/rpms/ -maxdepth 1 -name '*.rpm' -print -quit)" ]; then \
-        dnf5 -y install /opt/ci/rpms/*.rpm --disableplugin=local; \
+        $DNF -y install /opt/ci/rpms/*.rpm --disableplugin=local; \
     fi
 
 # create directory for dbus daemon socket

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # $ podman build --build-arg TYPE=distro -t ci-dnf-stack -f Dockerfile
 # $ podman run --net none -it ci-dnf-stack behave dnf
 #
-# Build for DNF4
-# $ podman build --build-arg DNF=dnf -t ci-dnf-stack -f Dockerfile
+# To build for DNF5 be sure to use the dnf5 suite
+# $ podman -s dnf5 build -t ci-dnf-stack -f Dockerfile
 #
 # Build for a specific Fedora version
 # $ podman build --build-arg BASE=fedora:38 -t ci-dnf-stack -f Dockerfile
@@ -13,7 +13,9 @@ FROM $BASE
 
 ENV LANG C.UTF-8
 ARG TYPE=nightly
-ARG DNF
+
+ARG BUILD_WITH
+ENV DNF=${BUILD_WITH:-dnf}
 
 # disable deltas and weak deps
 RUN set -x && \

--- a/container-test
+++ b/container-test
@@ -420,6 +420,11 @@ class BehaveRunner(object):
         if self.command_line_args.base is not None:
             command += ['--build-arg', 'BASE={}'.format(self.command_line_args.base)]
 
+        if self.command_line_args.suite == "dnf5":
+            command += ['--build-arg', 'BUILD_WITH=dnf5']
+        else:
+            command += ['--build-arg', 'BUILD_WITH=dnf']
+
         command += ['-t', self.command_line_args.container]
         command += ['-f', self.command_line_args.docker_file, PROGPATH]
 

--- a/plans/dnf4/integration/behave-createrepo_c.fmf
+++ b/plans/dnf4/integration/behave-createrepo_c.fmf
@@ -1,0 +1,8 @@
+summary: Run Behave Test Suite - CREATEREPO_C
+tag: createrepo_c
+execute:
+    how: tmt
+    script: |
+        $TMT_PLANS_DATA/ci-dnf-stack/container-test \
+        --suite createrepo_c \
+        -c dnf4-testing-container run

--- a/plans/dnf4/integration/behave-dnf.fmf
+++ b/plans/dnf4/integration/behave-dnf.fmf
@@ -1,0 +1,9 @@
+summary: Run Behave Test Suite - DNF
+tag: dnf
+execute:
+    how: tmt
+    script: |
+        $TMT_PLANS_DATA/ci-dnf-stack/container-test \
+        --suite dnf \
+        -c dnf4-testing-container run
+

--- a/plans/dnf4/main.fmf
+++ b/plans/dnf4/main.fmf
@@ -1,0 +1,18 @@
+summary: Prepare the DNF4 environment
+
+prepare+:
+    - name: Checkout DNF4 branch
+      how: shell
+      script: |
+        if [ "$PACKIT_UPSTREAM_NAME" == "dnf" ]; then
+            git -C $TMT_PLANS_DATA/ci-dnf-stack checkout dnf-4-stack
+        fi
+
+    - name: Build DNF4 testing container
+      how: shell
+      script: |
+        $TMT_PLANS_DATA/ci-dnf-stack/container-test \
+        -c dnf4-testing-container build \
+        --base $( echo "$@distro" | tr '-' ':') \
+        --container-arg="--env=COPR=$PACKIT_COPR_PROJECT" \
+        --container-arg="--env=COPR_RPMS=$PACKIT_COPR_RPMS"

--- a/plans/dnf5/integration/behave-createrepo_c.fmf
+++ b/plans/dnf5/integration/behave-createrepo_c.fmf
@@ -5,4 +5,4 @@ execute:
     script: |
         $TMT_PLANS_DATA/ci-dnf-stack/container-test \
         --suite createrepo_c \
-        run
+        -c dnf5-testing-container run

--- a/plans/dnf5/integration/behave-dnf5.fmf
+++ b/plans/dnf5/integration/behave-dnf5.fmf
@@ -3,6 +3,7 @@ tag: dnf5
 execute:
     how: tmt
     script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test run \
+        $TMT_PLANS_DATA/ci-dnf-stack/container-test \
+        -c dnf5-testing-container run \
         --tags dnf5 \
         --command dnf5

--- a/plans/dnf5/integration/behave-dnf5daemon.fmf
+++ b/plans/dnf5/integration/behave-dnf5daemon.fmf
@@ -3,6 +3,7 @@ tag: dnf5daemon
 execute:
     how: tmt
     script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test run \
+        $TMT_PLANS_DATA/ci-dnf-stack/container-test \
+        -c dnf5-testing-container run \
         --tags dnf5daemon \
         --command dnf5daemon-client

--- a/plans/dnf5/main.fmf
+++ b/plans/dnf5/main.fmf
@@ -1,0 +1,12 @@
+summary: Prepare the DNF5 environment
+
+prepare+:
+    - name: Build DNF5 testing container
+      how: shell
+      script: |
+        $TMT_PLANS_DATA/ci-dnf-stack/container-test \
+        -c dnf5-testing-container build \
+        --base $( echo "$@distro" | tr '-' ':') \
+        --container-arg="--env=COPR=$PACKIT_COPR_PROJECT" \
+        --container-arg="--env=COPR_RPMS=$PACKIT_COPR_RPMS"
+

--- a/plans/dnf5/main.fmf
+++ b/plans/dnf5/main.fmf
@@ -5,6 +5,7 @@ prepare+:
       how: shell
       script: |
         $TMT_PLANS_DATA/ci-dnf-stack/container-test \
+        --suite dnf5 \
         -c dnf5-testing-container build \
         --base $( echo "$@distro" | tr '-' ':') \
         --container-arg="--env=COPR=$PACKIT_COPR_PROJECT" \

--- a/plans/integration/behave-dnf.fmf
+++ b/plans/integration/behave-dnf.fmf
@@ -1,7 +1,0 @@
-summary: Run Behave Test Suite - DNF
-tag: dnf
-execute:
-    how: tmt
-    script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test run
-

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,6 +1,6 @@
-summary: Prepare CI DNF Stack
+summary: Prepare Tests
 
-tag: integration
+tag: all
 
 prepare:
     - name: Install packages to build fedora container
@@ -21,11 +21,3 @@ prepare:
           git -C $TMT_PLANS_DATA/ci-dnf-stack checkout --track pull-request/$PACKIT_SOURCE_BRANCH
           git -C $TMT_PLANS_DATA/ci-dnf-stack rebase $PACKIT_TARGET_BRANCH
         fi
-
-    - name: Build testing container
-      how: shell
-      script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test build \
-        --base $( echo "$@distro" | tr '-' ':') \
-        --container-arg="--env=COPR=$PACKIT_COPR_PROJECT" \
-        --container-arg="--env=COPR_RPMS=$PACKIT_COPR_RPMS"


### PR DESCRIPTION
### **DON'T MERGE**

Needs to be tested against:

- [ ] [dnf](https://github.com/rpm-software-management/dnf/pull/2034)
- [ ] [libdnf](https://github.com/rpm-software-management/libdnf/pull/1639)
- [ ] [createrepo_c](https://github.com/rpm-software-management/createrepo_c/pull/417)
- [ ] dnf5

_(green checkmark when they are tested against this branch)_

This rework will:
- implement the inheritance in the `prepare` steps of tmt plans
- add `BUILD_WITH` variable in the Dockerfile to specify using dnf/dnf5

### Build with `dnf`/`dnf5`

```bash
./container-test -s dnf5 build
```

Will pass `--build-arg="BUILD_WITH=dnf5"` to the wrapper

### New tmt structure

Use `tmt plans show --verbose` to see the full plans and how the steps are inherited for each test run

```
plans/
├── dnf4
│   ├── integration
│   │   ├── behave-createrepo_c.fmf
│   │   └── behave-dnf.fmf
│   └── main.fmf
├── dnf5
│   ├── integration
│   │   ├── behave-createrepo_c.fmf
│   │   ├── behave-dnf5daemon.fmf
│   │   └── behave-dnf5.fmf
│   └── main.fmf
└── main.fmf
```
