### PR TITLE
Tests for optional filelists metadata

### DIFF
--- a/dnf-behave-tests/dnf/clean-cachefiles.feature
+++ b/dnf-behave-tests/dnf/clean-cachefiles.feature
@@ -20,10 +20,8 @@ Background: Fill the cache
    \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/filelists\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
-   \./simple-base-filenames\.solvx
    \./simple-base\.solv
    """
 
@@ -65,10 +63,8 @@ Scenario: Cached packages cleanup (dnf clean packages)
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/filelists\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
-   \./simple-base-filenames\.solvx
    \./simple-base\.solv
    """
 
@@ -84,7 +80,6 @@ Scenario: Database cached cleanup (dnf clean dbcache)
    \./simple-base-[0-9a-f]{16}/packages
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
    \./simple-base-[0-9a-f]{16}/repodata
-   \./simple-base-[0-9a-f]{16}/repodata/filelists\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/primary\.xml\.zst
    \./simple-base-[0-9a-f]{16}/repodata/repomd\.xml
    """

--- a/dnf-behave-tests/dnf/microdnf/upgrade-provides.feature
+++ b/dnf-behave-tests/dnf/microdnf/upgrade-provides.feature
@@ -68,20 +68,6 @@ Scenario: Upgrade an RPM by file provide
         | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
 
 @bz1905471
-Scenario: Upgrade an RPM by file provide that is directory
-  Given I use repository "dnf-ci-fedora-updates"
-   When I execute microdnf with args "upgrade /var/db"
-   Then the exit code is 0
-    And microdnf transaction is
-        | Action        | Package                                   |
-        | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
-        | upgraded      | glibc-0:2.28-9.fc29.x86_64                |
-        | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
-        | upgraded      | glibc-common-0:2.28-9.fc29.x86_64         |
-        | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
-        | upgraded      | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-
-@bz1905471
 Scenario: Upgrade an RPM by file provide containing wildcards
   Given I use repository "dnf-ci-fedora-updates"
    When I execute microdnf with args "upgrade /etc/ld*.conf"

--- a/dnf-behave-tests/dnf/optional-metadata.feature
+++ b/dnf-behave-tests/dnf/optional-metadata.feature
@@ -1,0 +1,89 @@
+Feature: Tests for optional metadata loading functionality
+
+
+Background:
+  Given I use repository "dnf-ci-fedora"
+    And I successfully execute dnf with args "makecache"
+    And I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
+   Then stdout matches line by line
+    """
+    \.
+    \./dnf-ci-fedora-[0-9a-f]{16}
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/primary\.xml\.*
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/repomd\.xml
+    \./dnf-ci-fedora\.solv
+    \./expired_repos\.json
+    """
+
+
+Scenario: Optional metadata are loaded when explicitly requested by the option
+  Given I successfully execute dnf with args "makecache --setopt=optional_metadata_types=filelists"
+   When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
+   Then stdout matches line by line
+    """
+    \.
+    \./dnf-ci-fedora-[0-9a-f]{16}
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/filelists\.xml\.zst
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/primary\.xml\.*
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/repomd\.xml
+    \./dnf-ci-fedora-filenames\.solvx
+    \./dnf-ci-fedora\.solv
+    \./expired_repos\.json
+    """
+
+
+Scenario: Invalid metadata type is ignored when processing the option
+  Given I successfully execute dnf with args "makecache --setopt=optional_metadata_types=abcdef"
+   When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
+   Then stdout matches line by line
+    """
+    \.
+    \./dnf-ci-fedora-[0-9a-f]{16}
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/primary\.xml\.*
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/repomd\.xml
+    \./dnf-ci-fedora\.solv
+    \./expired_repos\.json
+    """
+
+
+Scenario: Optional metadata are loaded when requested by command
+  Given I successfully execute dnf with args "provides basesystem"
+   When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
+   Then stdout matches line by line
+    """
+    \.
+    \./dnf-ci-fedora-[0-9a-f]{16}
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/filelists\.xml\.zst
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/primary\.xml\.*
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/repomd\.xml
+    \./dnf-ci-fedora-filenames\.solvx
+    \./dnf-ci-fedora\.solv
+    \./expired_repos\.json
+    """
+
+
+Scenario: Operation returns an error when metadata are not present in cacheonly mode
+  Given I execute dnf with args "provides basesystem --cacheonly"
+   Then the exit code is 1
+    And stderr contains "Error: Cache-only enabled but no cache for 'dnf-ci-fedora'"
+
+
+Scenario: Filelists metadata are loaded when filepath spec is provided
+  Given I successfully execute dnf with args "repoquery /some/file"
+   When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
+   Then stdout matches line by line
+    """
+    \.
+    \./dnf-ci-fedora-[0-9a-f]{16}
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/filelists\.xml\.zst
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/primary\.xml\.*
+    \./dnf-ci-fedora-[0-9a-f]{16}/repodata/repomd\.xml
+    \./dnf-ci-fedora-filenames\.solvx
+    \./dnf-ci-fedora\.solv
+    \./expired_repos\.json
+    """

--- a/dnf-behave-tests/dnf/repoquery/deps.feature
+++ b/dnf-behave-tests/dnf/repoquery/deps.feature
@@ -39,6 +39,16 @@ Scenario: repoquery --requires --resolve NAME
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
+      """
+
+Scenario: repoquery --requires --resolve NAME with file deps
+ When I execute dnf with args "repoquery --requires --resolve middle1 --setopt=optional_metadata_types=filelists"
+ Then the exit code is 0
+  And stdout is
+      """
+      bottom1-1:2.0-1.x86_64
+      bottom2-1:1.0-1.x86_64
+      bottom3-1:2.0-1.x86_64
       bottom4-1:1.0-1.x86_64
       """
 
@@ -50,7 +60,6 @@ Scenario: repoquery --requires --resolve NAMEGLOB
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
-      bottom4-1:1.0-1.x86_64
       """
 
 Scenario: repoquery --requires --resolve --recursive NAME
@@ -61,7 +70,6 @@ Scenario: repoquery --requires --resolve --recursive NAME
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
-      bottom4-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       middle2-1:2.0-1.x86_64
       """
@@ -73,7 +81,6 @@ Scenario: repoquery --requires --resolve --recursive NAME-VERSION
       """
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
-      bottom4-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       middle2-1:2.0-1.x86_64
       """
@@ -88,7 +95,6 @@ Scenario: repoquery --requires --resolve --recursive --tree NAME-VERSION
        \_ middle1-1:2.0-1.x86_64 [3: /a/bottom4-file, bottom2 = 1:1.0-1, bottom1-prov2 >= 2.0]
        |   \_ bottom1-1:2.0-1.x86_64 [0: ]
        |   \_ bottom2-1:1.0-1.x86_64 [0: ]
-       |   \_ bottom4-1:1.0-1.x86_64 [0: ]
        \_ middle2-1:2.0-1.x86_64 [1: bottom1-prov3 <= 1.2]
        |   \_ bottom1-1:2.0-1.x86_64 [0: ]
       """
@@ -289,15 +295,25 @@ Scenario: repoquery --whatrequires NEVRA
       """
 
 @bz1782906
-# This fails with dnf5 because it doesn't load filelists by default
+# Filelists need to be loaded explicitly
 Scenario: repoquery --whatrequires NAME (file provide)
- When I execute dnf with args "repoquery --whatrequires bottom4"
+ When I execute dnf with args "repoquery --whatrequires bottom4 --setopt=optional_metadata_types=filelists"
  Then the exit code is 0
   And stdout is
       """
       <REPOSYNC>
       middle1-1:2.0-1.x86_64
       middle3-1:1.0-1.x86_64
+      """
+
+# Filelists are loaded automatically
+Scenario: repoquery --whatrequires NAME (filename provide)
+ When I execute dnf with args "repoquery --whatrequires /a/bottom4-file"
+ Then the exit code is 0
+  And stdout is
+      """
+      <REPOSYNC>
+      middle1-1:2.0-1.x86_64
       """
 
 @dnf5

--- a/dnf-behave-tests/dnf/zchunk.feature
+++ b/dnf-behave-tests/dnf/zchunk.feature
@@ -75,9 +75,6 @@ Given I copy repository "simple-base" for modification
   And exactly 2 HTTP GET requests should match:
       | path                      |
       | /repodata/primary.xml.zck |
-  And exactly 2 HTTP GET request should match:
-      | path                        |
-      | /repodata/filelists.xml.zck |
 
 
 # @dnf5
@@ -107,37 +104,8 @@ Given I copy repository "simple-base" for modification
   And exactly 2 HTTP GET requests should match:
       | path                      |
       | /repodata/primary.xml.zck |
-  And exactly 2 HTTP GET request should match:
-      | path                        |
-      | /repodata/filelists.xml.zck |
 
 
-@use.with_dnf=4
-@not.with_dnf=5
-Scenario: using mirror wihtout ranges supports and zchunk results in only two GET requests per file (the first try is with range specified)
-Given I copy repository "simple-base" for modification
-  And I generate repodata for repository "simple-base" with extra arguments "--zck"
-  And I use repository "simple-base" as http
-  And I configure dnf with
-      | key    | value |
-      | zchunk | True |
-  And I start capturing outbound HTTP requests
- When I execute dnf with args "install labirinto"
- Then the exit code is 0
-  And Transaction is following
-      | Action        | Package                       |
-      | install       | labirinto-0:1.0-1.fc29.x86_64 |
-  And exactly 2 HTTP GET requests should match:
-      | path                      |
-      | /repodata/primary.xml.zck |
-  And exactly 2 HTTP GET request should match:
-      | path                        |
-      | /repodata/filelists.xml.zck |
-
-
-@dnf5
-@not.with_dnf=4
-# dnf5 doesn't require filelists.xml here -> there are no GET requests for it
 Scenario: using mirror wihtout ranges supports and zchunk results in only two GET requests for primary (the first try is with range specified)
 Given I copy repository "simple-base" for modification
   And I generate repodata for repository "simple-base" with extra arguments "--zck"


### PR DESCRIPTION
Basic tests for optional filelists metadata functionality taken and reworked from the existing dnf5 tests.
Also adjusted the existing dnf4 tests depending on filelists functionality.

Requires: https://github.com/rpm-software-management/libdnf/pull/1642.