### PR TITLE
Tests for a user hint on transaction file dependency failure

### DIFF
--- a/dnf-behave-tests/dnf/filelists-suggestions.feature
+++ b/dnf-behave-tests/dnf/filelists-suggestions.feature
@@ -1,0 +1,23 @@
+Feature: Tests for user output suggestions related to filelists metadata
+
+
+Scenario: Manual loading of filelists metadata is suggested when a file dependency cannot be resolved
+  Given I use repository "filedeps"
+   When I execute dnf with args "install filedep-package"
+   Then the exit code is 1
+    And stdout matches line by line
+    """
+    <REPOSYNC>
+    (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages or '--setopt=optional_metadata_types=filelists' to load additional filelists metadata)
+    """
+
+
+Scenario: Manual loading of filelists metadata is not suggested when filelists are already loaded
+  Given I use repository "filedeps"
+   When I execute dnf with args "install filedep-nonexist --setopt=optional_metadata_types=filelists"
+   Then the exit code is 1
+    And stdout matches line by line
+    """
+    <REPOSYNC>
+    (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
+    """

--- a/dnf-behave-tests/fixtures/specs/filedeps/filedep-dependency-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/filedeps/filedep-dependency-1.0.spec
@@ -1,0 +1,20 @@
+Name:           filedep-dependency
+Version:        1.0
+Release:        1%{?dist}
+Summary:        A dummy package providing a file.
+
+License:        GPLv2+ and Public Domain
+URL:            https://url.com/
+
+BuildArch:      noarch
+
+%description
+
+%install
+mkdir -p %{buildroot}/dummy
+touch %{buildroot}/dummy/file
+
+%files
+/dummy/file
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/filedeps/filedep-nonexist-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/filedeps/filedep-nonexist-1.0.spec
@@ -1,0 +1,16 @@
+Name:           filedep-nonexist
+Version:        1.0
+Release:        1%{?dist}
+Summary:        A dummy package with a non-existing file dependency.
+
+License:        GPLv2+ and Public Domain
+URL:            https://url.com/
+
+BuildArch:      noarch
+Requires:       /dummy/file2
+
+%description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/filedeps/filedep-package-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/filedeps/filedep-package-1.0.spec
@@ -1,0 +1,16 @@
+Name:           filedep-package
+Version:        1.0
+Release:        1%{?dist}
+Summary:        A dummy package with a file dependency.
+
+License:        GPLv2+ and Public Domain
+URL:            https://url.com/
+
+BuildArch:      noarch
+Requires:       /dummy/file
+
+%description
+
+%files
+
+%changelog


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf/pull/2026.