### PR TITLE
Adjusted dnf repolist tests for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/repolist-disabled.feature
+++ b/dnf-behave-tests/dnf/repolist-disabled.feature
@@ -1,4 +1,5 @@
-Feature: Repolist when all repositories are disabled
+@dnf5
+Feature: Repo list (alias repolist) when all repositories are disabled
 
 Background:
   Given I use repository "dnf-ci-fedora" with configuration
@@ -6,33 +7,27 @@ Background:
         | enabled | 0     |
 
 
-@dnf5
 Scenario: Repolist without arguments
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout is empty
 
 
-@dnf5
-Scenario: Repolist with "enabled"
-   When I execute dnf with args "repolist enabled"
+Scenario: Repo list with "--enabled"
+   When I execute dnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout is empty
 
 
-# @dnf5
-# TODO(nsella) different stdout
-Scenario: Repolist with "disabled"
-   When I execute dnf with args "repolist disabled"
+Scenario: Repo list with "--disabled"
+   When I execute dnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora"
 
 
-# @dnf5
-# TODO(nsella) different stdout
-Scenario: Repolist with "all"
+Scenario: Repo list with "--all"
   Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "repolist all"
+   When I execute dnf with args "repo list --all"
    Then the exit code is 0
     And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora test repository\s+disabled"
     And stdout contains "dnf-ci-fedora-updates\s+dnf-ci-fedora-updates test repository\s+enabled"

--- a/dnf-behave-tests/dnf/repolist-no-repos.feature
+++ b/dnf-behave-tests/dnf/repolist-no-repos.feature
@@ -1,31 +1,30 @@
-# @dnf5
-# TODO(nsella) different stdout
-Feature: Repolist when there are no repositories
+@dnf5
+Feature: Repo list (alias repolist) when there are no repositories
 
 
 Scenario: Repolist without arguments
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout is empty
-    And stderr contains "No repositories available"
+    And stderr is empty
 
 
-Scenario: Repolist with "enabled"
-   When I execute dnf with args "repolist enabled"
+Scenario: Repo list with "--enabled"
+   When I execute dnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout is empty
-    And stderr contains "No repositories available"
+    And stderr is empty
 
 
-Scenario: Repolist with "disabled"
-   When I execute dnf with args "repolist disabled"
+Scenario: Repo list with "--disabled"
+   When I execute dnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout is empty
-    And stderr contains "No repositories available"
+    And stderr is empty
 
 
-Scenario: Repolist with "all"
-   When I execute dnf with args "repolist all"
+Scenario: Repo list with "--all"
+   When I execute dnf with args "repo list --all"
    Then the exit code is 0
     And stdout is empty
-    And stderr contains "No repositories available"
+    And stderr is empty

--- a/dnf-behave-tests/dnf/repolist.feature
+++ b/dnf-behave-tests/dnf/repolist.feature
@@ -1,4 +1,5 @@
-Feature: Repolist
+@dnf5
+Feature: Repo list (alias repolist)
 
 
 Background: Using repositories dnf-ci-fedora and dnf-ci-thirdparty-updates
@@ -22,18 +23,9 @@ Scenario: Repolist without arguments
     And stdout does not contain "dnf-ci-thirdparty\s+dnf-ci-thirdparty"
 
 
-Scenario: Repolist with "enabled"
-   When I execute dnf with args "repolist enabled"
-   Then the exit code is 0
-    And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora"
-    And stdout contains "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"
-    And stdout does not contain "dnf-ci-fedora-updates"
-    And stdout does not contain "dnf-ci-thirdparty\s+dnf-ci-thirdparty"
-
-
 @dnf5daemon
-Scenario: Repolist with "--enabled"
-   When I execute dnf with args "repolist --enabled"
+Scenario: Repo list with "--enabled"
+   When I execute dnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora"
     And stdout contains "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"
@@ -41,8 +33,8 @@ Scenario: Repolist with "--enabled"
     And stdout does not contain "dnf-ci-thirdparty\s+dnf-ci-thirdparty"
 
 
-Scenario: Repolist with "disabled"
-   When I execute dnf with args "repolist disabled"
+Scenario: Repo list with "--disabled"
+   When I execute dnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout contains "dnf-ci-fedora-updates\s+dnf-ci-fedora-updates"
     And stdout contains "dnf-ci-thirdparty\s+dnf-ci-thirdparty"
@@ -50,87 +42,10 @@ Scenario: Repolist with "disabled"
     And stdout does not contain "dnf-ci-thirdparty-updates"
 
 
-Scenario: Repolist with "all"
-   When I execute dnf with args "repolist all"
+Scenario: Repo list with "--all"
+   When I execute dnf with args "repo list --all"
    Then the exit code is 0
     And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora test repository\s+enabled"
     And stdout contains "dnf-ci-fedora-updates\s+dnf-ci-fedora-updates test repository\s+disabled"
     And stdout contains "dnf-ci-thirdparty\s+dnf-ci-thirdparty test repository\s+disabled"
     And stdout contains "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates test repository\s+enabled"
-
-
-Scenario: Repolist in verbose mode without arguments
-  Given I set dnf command to "dnf"
-   When I execute dnf with args "repolist --verbose"
-   Then the exit code is 0
-    And stdout matches line by line
-"""
-DNF version: .*
-cachedir: .*
-Repo-id            : dnf-ci-fedora
-Repo-name          : dnf-ci-fedora test repository
-Repo-revision      : 1550000000
-Repo-updated       : .*
-Repo-pkgs          : 289
-Repo-available-pkgs: 289
-Repo-size          : 2\.[0-9] M
-Repo-baseurl       : .*/fixtures/repos/dnf-ci-fedora
-Repo-expire        : .*
-Repo-filename      : .*/etc/yum.repos.d/dnf-ci-fedora.repo
-
-Repo-id            : dnf-ci-thirdparty-updates
-Repo-name          : dnf-ci-thirdparty-updates test repository
-Repo-revision      : 1550000000
-Repo-updated       : .*
-Repo-pkgs          : 6
-Repo-available-pkgs: 6
-Repo-size          : 3[0-9] k
-Repo-baseurl       : .*/fixtures/repos/dnf-ci-thirdparty-updates
-Repo-expire        : .*
-Repo-filename      : .*/etc/yum.repos.d/dnf-ci-thirdparty-updates.repo
-Total packages: 295
-"""
-
-@bz1812682
-Scenario: Repolist with -d 6
-#  -d with 6 or higher is similar to --verbose option
-  Given I set dnf command to "yum"
-   When I execute dnf with args "-d 6 repolist"
-   Then the exit code is 0
-    And stdout matches line by line
-"""
-YUM version: .*
-cachedir: .*
-Repo-id            : dnf-ci-fedora
-Repo-name          : dnf-ci-fedora test repository
-Repo-revision      : 1550000000
-Repo-updated       : .*
-Repo-pkgs          : 289
-Repo-available-pkgs: 289
-Repo-size          : 2\.[0-9] M
-Repo-baseurl       : .*/fixtures/repos/dnf-ci-fedora
-Repo-expire        : .*
-Repo-filename      : .*/etc/yum.repos.d/dnf-ci-fedora.repo
-
-Repo-id            : dnf-ci-thirdparty-updates
-Repo-name          : dnf-ci-thirdparty-updates test repository
-Repo-revision      : 1550000000
-Repo-updated       : .*
-Repo-pkgs          : 6
-Repo-available-pkgs: 6
-Repo-size          : 3[0-9] k
-Repo-baseurl       : .*/fixtures/repos/dnf-ci-thirdparty-updates
-Repo-expire        : .*
-Repo-filename      : .*/etc/yum.repos.d/dnf-ci-thirdparty-updates.repo
-Total packages: 295
-"""
-
-@bz2066334
-Scenario: Repolist in verbose mode with manual repository having no cpeid
-  Given I use repository "manual-test"
-    And I copy repository "manual-test" for modification
-    And I generate repodata for repository "manual-test" with extra arguments "--distro RHEL8"
-    And I use repository "manual-test"
-   When I execute dnf with args "repolist --verbose"
-   Then the exit code is 0
-    And stderr does not contain "Error: basic_string"


### PR DESCRIPTION
The following tests for dnf repolist (repo list) have been adjusted for dnf5:
dnf/repolist.feature, dnf/repolist-no-repos.feature, dnf/repolist-disabled.feature

Note: 
1. just minimal updates have been done, no other changes (like substituting "stdout contains" for the whole output matching)
2. the behavior has been changed significantly and should be properly documented on https://dnf5.readthedocs.io/en/latest/changes.html, see also https://github.com/rpm-software-management/dnf5/issues/1225

