### PR TITLE
Add back installing of `procps-ng` to ci-host

### DIFF
--- a/.github/workflows/ci-host.yml
+++ b/.github/workflows/ci-host.yml
@@ -43,6 +43,8 @@ jobs:
           # glibc-langpack-en is installed as a workaround
           # see https://bugzilla.redhat.com/show_bug.cgi?id=2239860
           RUN dnf -y install git python3-pip rpmlint glibc-langpack-en
+          # needed for moving of PIDs in integration-tests
+          RUN dnf -y install procps-ng
           RUN dnf clean all  # remove dnf cache to make the image smaller
           EOF
 


### PR DESCRIPTION
This is needed for https://github.com/rpm-software-management/ci-dnf-stack/pull/1299 it was removed by https://github.com/rpm-software-management/ci-dnf-stack/pull/1385 however it seems that whatever was pulling it in in dnf5.spec no longer does.

We need to explicitly state the requirement for it.