### PR TITLE
Fix test for installing through provide of installonly pkg

### DIFF
--- a/dnf-behave-tests/dnf/installonly.feature
+++ b/dnf-behave-tests/dnf/installonly.feature
@@ -328,14 +328,9 @@ Scenario: Do not bypass installonly limit (2) when installing kernel-core throug
     And I use repository "dnf-ci-fedora-updates-testing"
     When I execute dnf with args "install kernel-core-uname-r"
    Then the exit code is 0
-   # For some reason libsolv installs kernel and kernel-modules, while this is desired behavior it is
-   # somewhat confusing. There is no requirement for it. If in the future libsolv is changed to install
-   # only kernel-core it is still valid.
     And Transaction is following
         | Action        | Package                                  |
-        | install       | kernel-0:4.20.6-300.fc29.x86_64          |
         | install-dep   | kernel-core-0:4.20.6-300.fc29.x86_64     |
-        | install-dep   | kernel-modules-0:4.20.6-300.fc29.x86_64  |
         | unchanged     | kernel-0:4.19.15-300.fc29.x86_64    |
         | unchanged     | kernel-core-0:4.19.15-300.fc29.x86_64    |
         | unchanged     | kernel-modules-0:4.19.15-300.fc29.x86_64    |
@@ -353,14 +348,9 @@ Scenario: Do not bypass installonly limit (default 3) when installing kernel-cor
     And I successfully execute dnf with args "install kernel-3.0.0"
     When I execute dnf with args "install kernel-core-uname-r"
    Then the exit code is 0
-   # For some reason libsolv installs kernel and kernel-modules, while this is desired behavior it is
-   # somewhat confusing. There is no requirement for it. If in the future libsolv is changed to install
-   # only kernel-core it is still valid.
     And Transaction is following
         | Action        | Package                               |
-        | install       | kernel-0:4.0.0-1.fc29.x86_64          |
         | install-dep   | kernel-core-0:4.0.0-1.fc29.x86_64     |
-        | install-dep   | kernel-modules-0:4.0.0-1.fc29.x86_64  |
         | unchanged     | kernel-0:2.0.0-1.fc29.x86_64    |
         | unchanged     | kernel-core-0:2.0.0-1.fc29.x86_64    |
         | unchanged     | kernel-modules-0:2.0.0-1.fc29.x86_64    |


### PR DESCRIPTION
Since version 0.7.29 (currently unreleased) libsolv is improved and no longer tries to install unrequested pacakges.