### PR TITLE
Test upgrading kernel when over installonly limit with custom kernel

### DIFF
--- a/dnf-behave-tests/dnf/installonly.feature
+++ b/dnf-behave-tests/dnf/installonly.feature
@@ -407,3 +407,21 @@ Scenario: Do not bypass installonly limit (default 3) when installing kernel-cor
         | remove-dep    | kernel-0:1.0.0-1.fc29.x86_64         |
         | remove        | kernel-core-0:1.0.0-1.fc29.x86_64    |
         | remove-dep    | kernel-modules-0:1.0.0-1.fc29.x86_64 |
+
+
+@dnf5
+@bz2263675
+Scenario: Handle over-limit custom kernel without installonlypkg(kernel) provide
+  Given I drop repository "dnf-ci-fedora"
+    And I use repository "kernel-custom"
+    And I successfully execute dnf with args "install kernel-6.5.10"
+    And I successfully execute dnf with args "install kernel-6.5.12"
+    And I successfully execute dnf with args "install kernel-6.6.3"
+    And I execute rpm with args "-i {context.dnf.fixturesdir}/repos/kernel-custom/x86_64/kernel-6.7.0+-7.x86_64.rpm"
+   When I execute dnf with args "upgrade 'kernel*'"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                         |
+        | install       | kernel-0:6.7.4-200.fc29.x86_64  |
+        | remove        | kernel-0:6.5.10-300.fc29.x86_64 |
+        | remove        | kernel-0:6.5.12-300.fc29.x86_64 |

--- a/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.5.10-300.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.5.10-300.fc29.spec
@@ -1,0 +1,19 @@
+Name:           kernel
+Epoch:          0
+Version:        6.5.10
+Release:        300.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+
+%description
+The kernel meta package
+
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.5.12-300.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.5.12-300.fc29.spec
@@ -1,0 +1,19 @@
+Name:           kernel
+Epoch:          0
+Version:        6.5.12
+Release:        300.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+
+%description
+The kernel meta package
+
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.6.3-200.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.6.3-200.fc29.spec
@@ -1,0 +1,19 @@
+Name:           kernel
+Epoch:          0
+Version:        6.6.3
+Release:        200.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+
+%description
+The kernel meta package
+
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.7.0+-7.spec
+++ b/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.7.0+-7.spec
@@ -1,0 +1,17 @@
+Name:           kernel
+Epoch:          0
+Version:        6.7.0+
+Release:        7
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel, without installonlypkg(kernel) provide
+
+%description
+The kernel meta package, without installonlypkg(kernel) provide
+
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.7.4-200.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/kernel-custom/kernel-6.7.4-200.fc29.spec
@@ -1,0 +1,19 @@
+Name:           kernel
+Epoch:          0
+Version:        6.7.4
+Release:        200.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+
+%description
+The kernel meta package
+
+
+%files
+
+%changelog


### PR DESCRIPTION
Custom kernel doesn't contain `installonlypkg(kernel)` provide but provides `kernel`. libdnf needs to be able to handle such a situation even if the custom kernel is installed over limit.

https://bugzilla.redhat.com/show_bug.cgi?id=2263675