### PR TITLE
Tests for dnf5daemon enable/disable repo functionality

### DIFF
--- a/dnf-behave-tests/dnf/dnf5daemon/repo-enable-disable.feature
+++ b/dnf-behave-tests/dnf/dnf5daemon/repo-enable-disable.feature
@@ -1,0 +1,36 @@
+@dnf5daemon
+Feature: Enable/disable repo functionality for dnf5daemon
+
+
+Background:
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+
+
+Scenario: Disable existing repositories
+  Given I execute dnf with args "repo disable dnf-ci-fedora dnf-ci-fedora-updates"
+   Then the exit code is 0
+   When I execute dnf with args "repolist"
+   Then stdout is empty
+
+
+Scenario: Enable disabled repositories
+  Given I execute dnf with args "repo disable dnf-ci-fedora dnf-ci-fedora-updates"
+   Then the exit code is 0
+   When I execute dnf with args "repo enable dnf-ci-fedora-updates"
+   Then the exit code is 0
+   When I execute dnf with args "repolist"
+   Then stdout is
+    """
+    repo id               repo name
+    dnf-ci-fedora-updates dnf-ci-fedora-updates test repository
+    """
+
+
+Scenario: Enable non-existing repositories
+  Given I execute dnf with args "repo enable unknown-repo1 dnf-ci-fedora unknown-repo2"
+   Then the exit code is 1
+    And stderr is
+    """
+    [org.rpm.dnf.v0.rpm.Repo.NoMatchingIdError] No matching repositories found for following ids: unknown-repo1,unknown-repo2
+    """


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf5/pull/1266.