### PR TITLE
Tests for changes of history rollback transactions merging

### DIFF
--- a/dnf-behave-tests/dnf/history-rollback-same-package.feature
+++ b/dnf-behave-tests/dnf/history-rollback-same-package.feature
@@ -1,0 +1,39 @@
+Feature: Transaction history rollback between states with the same version of a package installed
+
+
+Background:
+  Given I use repository "dnf-ci-fedora"
+    And I successfully execute dnf with args "install flac"
+
+
+# https://github.com/rpm-software-management/dnf/issues/2031
+@GH-2031
+Scenario: Rollback removal and installation of the same package
+  Given I successfully execute dnf with args "remove flac"
+    And I successfully execute dnf with args "install flac"
+    And I successfully execute dnf with args "history list"
+   Then stdout is history list
+        | Id | Command | Action  | Altered |
+        | 3  |         | Install | 1       |
+        | 2  |         | Removed | 1       |
+        | 1  |         | Install | 1       |
+  Given I successfully execute dnf with args "history rollback 1"
+   Then Transaction is empty
+
+
+# https://issues.redhat.com/browse/RHEL-17494
+@RHEL-17494
+Scenario: Two rollbacks of the package upgrade
+  Given I use repository "dnf-ci-fedora-updates"
+    And I successfully execute dnf with args "upgrade flac"
+    And I successfully execute dnf with args "history list"
+   Then stdout is history list
+        | Id | Command | Action  | Altered |
+        | 2  |         | Upgrade | 1       |
+        | 1  |         | Install | 1       |
+  Given I successfully execute dnf with args "history rollback 1"
+   Then Transaction is following
+        | Action        | Package                   |
+        | downgrade     | flac-1.3.2-8.fc29.x86_64  |
+  Given I successfully execute dnf with args "history rollback 1"
+   Then Transaction is empty

--- a/dnf-behave-tests/dnf/history-view.feature
+++ b/dnf-behave-tests/dnf/history-view.feature
@@ -77,9 +77,6 @@ Scenario: History info in range - transaction merging
     And History info "last-2..last-1" should match
         | Key           | Value                     |
         | Return-Code   | Success                   |
-        | Reinstall     | abcde-2.9.2-1.fc29.noarch |
-        | Reinstall     | flac-1.3.2-8.fc29.x86_64  |
-        | Reinstall     | wget-1.19.5-5.fc29.x86_64 |
 
 
 Scenario: History info of package


### PR DESCRIPTION
- Add tests for history rollback between states with the same version of a package installed.
- Adjust history view merging test to match the new behavior

Requires: https://github.com/rpm-software-management/libdnf/pull/1644