### PR TITLE
update repolist tests for containers for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/repolist-container.feature
+++ b/dnf-behave-tests/dnf/repolist-container.feature
@@ -1,6 +1,7 @@
+@dnf5
 @no_installroot
 @destructive
-Feature: Repolist
+Feature: Repo list (alias repolist) for containers
 
 
 Background: Using repositories dnf-ci-fedora and dnf-ci-thirdparty-updates
@@ -25,8 +26,8 @@ Scenario: Repolist without arguments
       """
 
 
-Scenario: Repolist with "--enabled"
-   When I execute microdnf with args "repolist --enabled"
+Scenario: Repo list with "--enabled"
+   When I execute microdnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout is
       """
@@ -36,8 +37,8 @@ Scenario: Repolist with "--enabled"
       """
 
 
-Scenario: Repolist with "--disabled"
-   When I execute microdnf with args "repolist --disabled"
+Scenario: Repo list with "--disabled"
+   When I execute microdnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout is
       """
@@ -47,8 +48,8 @@ Scenario: Repolist with "--disabled"
       """
 
 
-Scenario: Repolist with "--all"
-   When I execute microdnf with args "repolist --all"
+Scenario: Repo list with "--all"
+   When I execute microdnf with args "repo list --all"
    Then the exit code is 0
     And stdout is
       """
@@ -60,23 +61,20 @@ Scenario: Repolist with "--all"
       """
 
 
-Scenario: Repolist with "--enabled --disabled"
-   When I execute microdnf with args "repolist --enabled --disabled"
-   Then the exit code is 0
-    And stdout is
+Scenario: Repo list with "--enabled --disabled"
+   When I execute microdnf with args "repo list --enabled --disabled"
+   Then the exit code is 2
+    And stdout is empty
+    And stderr is
       """
-      repo id                   repo name                                   status
-      dnf-ci-fedora             dnf-ci-fedora test repository              enabled
-      dnf-ci-fedora-updates     dnf-ci-fedora-updates test repository     disabled
-      dnf-ci-thirdparty         dnf-ci-thirdparty test repository         disabled
-      dnf-ci-thirdparty-updates dnf-ci-thirdparty-updates test repository  enabled
+      "--disabled" not allowed together with named argument "--enabled". Add "--help" for more information about the arguments.
       """
 
 
 # Tests for "--disablerepo" and "--enablerepo" including wildcards support
 @bz1781420
 Scenario: Disable all repos and then enable "dnf-ci-fedora-updates" repo
-   When I execute microdnf with args "repolist --disablerepo=* --enablerepo=dnf-ci-fedora-updates --all"
+   When I execute microdnf with args "repo list --disablerepo=* --enablerepo=dnf-ci-fedora-updates --all"
    Then the exit code is 0
     And stdout is
       """
@@ -89,7 +87,7 @@ Scenario: Disable all repos and then enable "dnf-ci-fedora-updates" repo
 
 
 Scenario: Disable "dnf-ci-thirdparty*" repos and enable "dnf-ci-fedora*" repos
-   When I execute microdnf with args "repolist --disablerepo=dnf-ci-thirdparty* --enablerepo=dnf-ci-fedora* --all"
+   When I execute microdnf with args "repo list --disablerepo=dnf-ci-thirdparty* --enablerepo=dnf-ci-fedora* --all"
    Then the exit code is 0
     And stdout is
       """
@@ -102,7 +100,7 @@ Scenario: Disable "dnf-ci-thirdparty*" repos and enable "dnf-ci-fedora*" repos
 
 
 Scenario: Only "*-updates" repos are enabled
-   When I execute microdnf with args "repolist --disablerepo=* --enablerepo=*-updates --all"
+   When I execute microdnf with args "repo list --disablerepo=* --enablerepo=*-updates --all"
    Then the exit code is 0
     And stdout is
       """
@@ -115,7 +113,7 @@ Scenario: Only "*-updates" repos are enabled
 
 
 Scenario: Test '?' wildcard. Only "dnf-ci-fedora-updates" repo is enabled
-   When I execute microdnf with args "repolist --disablerepo=* --enablerepo=dnf-ci-??????-* --all"
+   When I execute microdnf with args "repo list --disablerepo=* --enablerepo=dnf-ci-??????-* --all"
    Then the exit code is 0
     And stdout is
       """

--- a/dnf-behave-tests/dnf/repolist-disabled-container.feature
+++ b/dnf-behave-tests/dnf/repolist-disabled-container.feature
@@ -1,6 +1,7 @@
+@dnf5
 @no_installroot
 @destructive
-Feature: Repolist when all repositories are disabled
+Feature: Repo list (alias repolist) for containers, all repos are disabled
 
 
 Background:
@@ -15,14 +16,14 @@ Scenario: Repolist without arguments
     And stdout is empty
 
 
-Scenario: Repolist with "--enabled"
-   When I execute microdnf with args "repolist --enabled"
+Scenario: Repo list with "--enabled"
+   When I execute microdnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout is empty
 
 
-Scenario: Repolist with "--disabled"
-   When I execute microdnf with args "repolist --disabled"
+Scenario: Repo list with "--disabled"
+   When I execute microdnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout is
       """
@@ -31,8 +32,8 @@ Scenario: Repolist with "--disabled"
       """
 
 
-Scenario: Repolist with "--all"
-   When I execute microdnf with args "repolist --all"
+Scenario: Repo list with "--all"
+   When I execute microdnf with args "repo list --all"
    Then the exit code is 0
     And stdout is
       """
@@ -41,11 +42,11 @@ Scenario: Repolist with "--all"
       """
 
 
-Scenario: Repolist with "--enabled --disabled"
-   When I execute microdnf with args "repolist --enabled --disabled"
-   Then the exit code is 0
-    And stdout is
+Scenario: Repo list with "--disabled --enabled"
+   When I execute microdnf with args "repo list --disabled --enabled"
+   Then the exit code is 2
+    And stdout is empty
+    And stderr is
       """
-      repo id       repo name                       status
-      dnf-ci-fedora dnf-ci-fedora test repository disabled
+      "--enabled" not allowed together with named argument "--disabled". Add "--help" for more information about the arguments.
       """


### PR DESCRIPTION
renamed:    microdnf/repolist.feature -> repolist-container.feature
renamed:    microdnf/repolist-disabled.feature -> repolist-disabled-container.feature
and updated for dnf5

Notes:
* microdnf alias instead of dnf is called intentionally
* scenarios with both --enable and --disable options have been changed to reflect current dnf5/microdnf behavior
* alias "repolist" in some scenarios is used intentionally
* tags no_installroot and destructive are used intentionally

The updated tests passed when run on a testing machine with dnf5-5.1.13-20240229004616.10.gc6d67a81.fc39
