### PR TITLE
Update API python tests to use current (non-deprecated) API

### DIFF
--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -486,7 +486,7 @@ config.cachedir = os.path.join(config.installroot, 'var/cache/yum')
 vars.set('releasever', '{context.dnf.releasever}')
 vars.set('basearch', 'x86_64')
 
-base.load_config_from_file()
+base.load_config()
 
 base.setup()
 


### PR DESCRIPTION
This will be required after: https://github.com/rpm-software-management/dnf5/pull/1292