### PR TITLE
get_dnf5_cmd: Do not set "reposdir" and "config_file_path"

### DIFF
--- a/dnf-behave-tests/dnf/environment.py
+++ b/dnf-behave-tests/dnf/environment.py
@@ -235,8 +235,6 @@ class DNFContext(object):
         for key,value in setopts.items():
             result.append("--setopt={0}={1}".format(key, value))
 
-        result.append("--setopt=reposdir=%s" % self.installroot + "/etc/yum.repos.d")
-        result.append("--setopt=config_file_path=%s" % self.installroot + "/etc/dnf/dnf.conf")
         result.append("--setopt=cachedir=%s" % self.installroot + "/var/cache/dnf")
 
         return result


### PR DESCRIPTION
They are taken from installroot by default.
Setting it explicitly via the CLI will hide the default behavior. And it changes the behavior if dnf.conf is not present.

Moreover, it is more compatible with DNF4 tests. `get_dnf4_cmd` does not set "reposdir" and "config_file_path".