### PR TITLE
Add missing require for python3-dnf-plugin-pre-transaction-actions

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -50,6 +50,7 @@ BuildRequires:  dnf-plugins-core
 BuildRequires:  dnf-utils
 BuildRequires:  python3-dnf-plugin-modulesync
 BuildRequires:  python3-dnf-plugin-post-transaction-actions
+BuildRequires:  python3-dnf-plugin-pre-transaction-actions
 BuildRequires:  python3-dnf-plugin-versionlock
 BuildRequires:  python3-dnf-plugins-core
 BuildRequires:  python3-dnf-plugin-leaves


### PR DESCRIPTION
Since https://github.com/rpm-software-management/ci-dnf-stack/pull/1459 the tests require the pre-transaction plugin.