### PR TITLE
Adjust repoquery --upgrades test

### DIFF
--- a/dnf-behave-tests/dnf/repoquery/main.feature
+++ b/dnf-behave-tests/dnf/repoquery/main.feature
@@ -673,7 +673,6 @@ Given I successfully execute dnf with args "install bottom-a1-1.0"
       """
       <REPOSYNC>
       bottom-a1-1:2.0-1.noarch
-      bottom-a1-1:2.0-1.src
       """
 
 @dnf5
@@ -695,7 +694,6 @@ Given I successfully execute dnf with args "install bottom-a1-1.0 bottom-a3-1.0"
       """
       <REPOSYNC>
       bottom-a1-1:2.0-1.noarch
-      bottom-a1-1:2.0-1.src
       """
 
 @dnf5


### PR DESCRIPTION
Newly dnf5 does not return src packages in the query.filter_upgrades()
results.

Requires: https://github.com/rpm-software-management/dnf5/pull/1310