### PR TITLE
update scenarios for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/config-repos-overrides.feature
+++ b/dnf-behave-tests/dnf/config-repos-overrides.feature
@@ -24,7 +24,7 @@ Scenario: Test the overrides in "/usr/share/dnf5/repos.override.d"
       [dnf-ci-fedora-updates]
       enabled=1
       """
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout does not contain "dnf-ci-fedora\s+dnf-ci-fedora"
     And stdout does not contain "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"
@@ -43,7 +43,7 @@ Scenario: The conf file in "/etc/dnf/repos.override.d" hides the file of the sam
       [dnf-ci-thirdparty]
       enabled=1
       """
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora"
     And stdout contains "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"
@@ -75,7 +75,7 @@ Scenario: The configuration files are applied in alphabetical order by their nam
       [dnf-ci-fedora]
       enabled=0
       """
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout does not contain "dnf-ci-fedora\s+dnf-ci-fedora"
     And stdout does not contain "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"
@@ -92,7 +92,7 @@ Scenario: Test globs in repoid
       [d?f-[a-c]i-fed*]
       enabled=1
       """
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout contains "dnf-ci-fedora\s+dnf-ci-fedora"
     And stdout does not contain "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"
@@ -113,7 +113,7 @@ Scenario: Test vars in repoid
       [dnf-ci-${distrib}-updates]
       enabled=1
       """
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout does not contain "dnf-ci-fedora\s+dnf-ci-fedora"
     And stdout does not contain "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"
@@ -138,7 +138,7 @@ Scenario: Test vars in configuration
       [dnf-ci-fedora-updates]
       enabled=${enabled}
       """
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout does not contain "dnf-ci-fedora\s+dnf-ci-fedora"
     And stdout does not contain "dnf-ci-thirdparty-updates\s+dnf-ci-thirdparty-updates"

--- a/dnf-behave-tests/dnf/encoding.feature
+++ b/dnf-behave-tests/dnf/encoding.feature
@@ -1,8 +1,7 @@
 Feature: Test encoding
 
 
-# @dnf5
-# TODO(nsella) different stdout
+@dnf5
 Scenario: UTF-8 characters in .repo filename
   Given I configure dnf with
         | key      | value      |
@@ -12,14 +11,14 @@ Scenario: UTF-8 characters in .repo filename
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora  |
     And I copy file "{context.dnf.installroot}/testrepos/testrepo.repo" to "testrepos/ř.repo"
     And I delete file "/testrepos/testrepo.repo"
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout contains "testrepo\s+testrepo test repository"
     And stderr is empty
 
 
-# @dnf5
-# TODO(nsella) different stderr
+@dnf5
+# dnf5 is OK with that in comparison with dnf4
 @bz1803038
 Scenario: non-UTF-8 characters in .repo filename
   Given I configure dnf with
@@ -30,14 +29,10 @@ Scenario: non-UTF-8 characters in .repo filename
         | baseurl | {context.scenario.repos_location}/dnf-ci-fedora  |
     And I copy file "{context.dnf.installroot}/testrepos/testrepo.repo" to "testrepos/{context.invalid_utf8_char}.repo"
     And I delete file "/testrepos/testrepo.repo"
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
-    And stdout is empty
-    And stderr is
-        """
-        Warning: failed loading '{context.dnf.installroot}/testrepos/\udcfd.repo', skipping.
-        No repositories available
-        """
+    And stdout contains "testrepo\s+testrepo test repository"
+    And stderr is empty
 
 
 # @dnf5
@@ -93,9 +88,7 @@ Scenario: non-UTF-8 character in an option when using corresponding locale
         | install       | dummy-1:1.0-1.x86_64       |
 
 
-# @dnf5
-# TODO(nsella) Unknown argument "--list" for command "repoquery"
-# Requires: https://github.com/rpm-software-management/libdnf/commit/6c2ac6786a423c00750a44805ade0268dd6d19e5
+@dnf5
 @not.with_os=rhel__eq__9
 @bz1893176
 Scenario: non-UTF-8 character in filename in an installed package

--- a/dnf-behave-tests/dnf/failovermethod.feature
+++ b/dnf-behave-tests/dnf/failovermethod.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Test behavior of failovermethod repo config option
 
 @bz2039906
@@ -5,6 +6,6 @@ Scenario: No error in stderr when failovermethod=priority is present in repo con
 Given I configure a new repository "failovermethod" with
       | key             | value         |
       | failovermethod  | priority      |
- When I execute dnf with args "repolist"
+ When I execute dnf with args "repo list"
  Then the exit code is 0
   And stderr is empty

--- a/dnf-behave-tests/dnf/gpg-noeol.feature
+++ b/dnf-behave-tests/dnf/gpg-noeol.feature
@@ -19,10 +19,8 @@ Background: Add repository with gpgcheck=1
    Then the exit code is 1
 
 
-# the scenario is failing with rpm on Fedora 30:
-# rpm --import gpgkeys/keys/dnf-ci-gpg-noeol/dnf-ci-gpg-noeol-public
-# error: gpgkeys/keys/dnf-ci-gpg-noeol/dnf-ci-gpg-noeol-public: key 1 not an armored public key.
-@use.with_os=rhel__ge__8
+# used to be disabled for Fedora due to a rpm failure, 
+# however, it works OK now (F39)
 @bz1733971
 Scenario: Import the GPG key without any EOL characters at EOF
    When I execute rpm with args "--import {context.dnf.fixturesdir}/gpgkeys/keys/dnf-ci-gpg-noeol/dnf-ci-gpg-noeol-public"

--- a/dnf-behave-tests/dnf/installroot.feature
+++ b/dnf-behave-tests/dnf/installroot.feature
@@ -69,27 +69,26 @@ Scenario: Remove package from installroot
         | remove        | water_carbonated-0:1.0-1.x86_64   |
 
 
-# @dnf5
-# TODO(nsella) different stdout
+@dnf5
 @force_installroot
 Scenario: Repolist command in installroot and with a reposdir specified
   Given I use repository "dnf-ci-install-remove"
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout is
         """
-        repo id                         repo name
-        dnf-ci-install-remove           dnf-ci-install-remove test repository
+        repo id               repo name
+        dnf-ci-install-remove dnf-ci-install-remove test repository
         """
   Given I configure a new repository "testrepo" in "{context.dnf.tempdir}/repos.d" with
         | key     | value                                              |
         | baseurl | {context.scenario.repos_location}/dnf-ci-install-remove |
-   When I execute dnf with args "--setopt=reposdir={context.dnf.tempdir}/repos.d repolist"
+   When I execute dnf with args "--setopt=reposdir={context.dnf.tempdir}/repos.d repo list"
    Then the exit code is 0
     And stdout is
         """
-        repo id                         repo name
-        testrepo                        testrepo test repository
+        repo id  repo name
+        testrepo testrepo test repository
         """
 
 
@@ -114,6 +113,10 @@ Scenario: Upgrade package in installroot
 
 # @dnf5
 # TODO(nsella) different stderr
+# (emrakova) in fact, the requested info is not provided:
+# stdout: No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config.
+# stderr: Failed to resolve the transaction: No match for argument: sugar
+# issue: https://github.com/rpm-software-management/dnf5/issues/1325
 @bz1658579
 Scenario: Installroot directory is listed when there are no repos
    When I execute dnf with args "install sugar"

--- a/dnf-behave-tests/dnf/microdnf/config-with-repos.feature
+++ b/dnf-behave-tests/dnf/microdnf/config-with-repos.feature
@@ -1,5 +1,6 @@
-# no bug, PR https://github.com/rpm-software-management/libdnf/pull/882
+@dnf5
 @no_installroot
+# no bug, PR https://github.com/rpm-software-management/libdnf/pull/882
 Feature: Repositories configured in main configuration file
 
 
@@ -22,7 +23,7 @@ Background: Configure repositories in the main configuration file
 
 
 Scenario: Repositories configured only in the main configuration file
-   When I execute microdnf with args "repolist --all"
+   When I execute microdnf with args "repo list --all"
    Then the exit code is 0
     And stdout is
      """
@@ -38,7 +39,7 @@ Scenario: Repositories configured in the main configuration file and in *.repo f
     And I use repository "dnf-ci-fedora-updates" with configuration
         | key     | value |
         | enabled | 0     |
-   When I execute microdnf with args "repolist --all"
+   When I execute microdnf with args "repo list --all"
    Then the exit code is 0
     And stdout is
      """

--- a/dnf-behave-tests/dnf/vars.feature
+++ b/dnf-behave-tests/dnf/vars.feature
@@ -1,5 +1,5 @@
 @dnf5
-Feature: Subtitute variables
+Feature: Substitute variables
 
 
 @bz1651092
@@ -41,7 +41,7 @@ Scenario: Variables arch supports basearch `loongarch64` {}
       name=dnf-ci-test-$distrib test repository
       enabled=0
       """
-   When I execute dnf with args "repolist --disabled --setvar=arch=loongarch64"
+   When I execute dnf with args "repo list --disabled --setvar=arch=loongarch64"
    Then the exit code is 0
     And stdout matches line by line
       """
@@ -62,7 +62,7 @@ Scenario: Variables without {} are substituted in repo id
       name=dnf-ci-test-$distrib test repository
       enabled=0
       """
-   When I execute dnf with args "repolist --disabled"
+   When I execute dnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout matches line by line
       """
@@ -81,7 +81,7 @@ Scenario: Variables with {} are substituted in repo id
       name=dnf-ci-test-${distrib} test repository
       enabled=0
       """
-   When I execute dnf with args "repolist --disabled"
+   When I execute dnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout matches line by line
       """
@@ -93,7 +93,7 @@ Scenario: Variables with {} are substituted in repo id
 Scenario: Using dnf with non-files in /etc/dnf/vars
   Given I create directory "/{context.dnf.installroot}/etc/dnf/vars/troublemaker"
     And I use repository "dnf-ci-fedora"
-   When I execute dnf with args "repolist"
+   When I execute dnf with args "repo list"
    Then the exit code is 0
     And stdout matches line by line
       """


### PR DESCRIPTION
Various scenarios have been updated for dnf5. Primarily, tests that called (but not directly tested) "repolist" have been selected for this update. However, all scenarios that could be currently updated for dnf5 have been updated (not only those with repolist calls).
All updated tests passed when run directly in behave and via container-test for the latest available dnf5.