### PR TITLE
Don't include package download size in test outputs

### DIFF
--- a/dnf-behave-tests/dnf/info.feature
+++ b/dnf-behave-tests/dnf/info.feature
@@ -33,7 +33,7 @@ Scenario: dnf info --extras (installed pkgs, not from known repos)
 Given I drop repository "dnf-ci-fedora"
   And I execute dnf with args "info --extras"
  Then the exit code is 0
-  And stdout is
+  And stdout matches line by line
   """
   <REPOSYNC>
   Extra packages
@@ -118,7 +118,7 @@ Scenario: dnf info setup (when setup is not installed but it is available)
   Version        : 2.12.1
   Release        : 1.fc29
   Architecture   : noarch
-  Download size  : 6.3 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 0.0   B
   Source         : setup-2.12.1-1.fc29.src.rpm
   Repository     : dnf-ci-fedora
@@ -134,7 +134,7 @@ Scenario: dnf info setup (when setup is not installed but it is available)
   Version        : 2.12.1
   Release        : 1.fc29
   Architecture   : src
-  Download size  : 6.9 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 616.0   B
   Repository     : dnf-ci-fedora
   Summary        : A set of system configuration and setup files
@@ -191,7 +191,7 @@ Scenario: info --installed alias packages from all enabled repositories
 @dnf5
 Scenario: dnf info --available setup (when setup is available)
  When I execute dnf with args "info --available setup"
- Then stdout is
+ Then stdout matches line by line
   """
   <REPOSYNC>
   Available packages
@@ -200,7 +200,7 @@ Scenario: dnf info --available setup (when setup is available)
   Version        : 2.12.1
   Release        : 1.fc29
   Architecture   : noarch
-  Download size  : 6.3 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 0.0   B
   Source         : setup-2.12.1-1.fc29.src.rpm
   Repository     : dnf-ci-fedora
@@ -216,7 +216,7 @@ Scenario: dnf info --available setup (when setup is available)
   Version        : 2.12.1
   Release        : 1.fc29
   Architecture   : src
-  Download size  : 6.9 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 616.0   B
   Repository     : dnf-ci-fedora
   Summary        : A set of system configuration and setup files
@@ -233,7 +233,7 @@ Scenario: dnf info setup basesystem (when basesystem is not installed)
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "info setup basesystem"
- Then stdout is
+ Then stdout matches line by line
   """
   <REPOSYNC>
   Installed packages
@@ -258,7 +258,7 @@ Scenario: dnf info setup basesystem (when basesystem is not installed)
   Version        : 11
   Release        : 6.fc29
   Architecture   : noarch
-  Download size  : 6.3 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 0.0   B
   Source         : basesystem-11-6.fc29.src.rpm
   Repository     : dnf-ci-fedora
@@ -266,7 +266,7 @@ Scenario: dnf info setup basesystem (when basesystem is not installed)
   URL            : None
   License        : Public Domain
   Description    : Basesystem defines the components of a basic Fedora system
-                 : (for example, the package installation order to use during bootstrapping).
+                 : \(for example, the package installation order to use during bootstrapping\).
                  : Basesystem should be in every installation of a system, and it
                  : should never be removed.
   Vendor         : 
@@ -276,14 +276,14 @@ Scenario: dnf info setup basesystem (when basesystem is not installed)
   Version        : 11
   Release        : 6.fc29
   Architecture   : src
-  Download size  : 7.0 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 583.0   B
   Repository     : dnf-ci-fedora
   Summary        : The skeleton package which defines a simple Fedora system
   URL            : None
   License        : Public Domain
   Description    : Basesystem defines the components of a basic Fedora system
-                 : (for example, the package installation order to use during bootstrapping).
+                 : \(for example, the package installation order to use during bootstrapping\).
                  : Basesystem should be in every installation of a system, and it
                  : should never be removed.
   Vendor         : 
@@ -293,7 +293,7 @@ Scenario: dnf info setup basesystem (when basesystem is not installed)
   Version        : 2.12.1
   Release        : 1.fc29
   Architecture   : src
-  Download size  : 6.9 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 616.0   B
   Repository     : dnf-ci-fedora
   Summary        : A set of system configuration and setup files
@@ -310,7 +310,7 @@ Scenario: dnf info installed setup basesystem (when basesystem is not installed)
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "info --installed setup basesystem"
- Then stdout is
+ Then stdout matches line by line
   """
   <REPOSYNC>
   Installed packages
@@ -349,7 +349,7 @@ Scenario: dnf info setup basesystem (when both are installed)
  Then the exit code is 0
  When I execute dnf with args "info setup basesystem"
  Then the exit code is 0
-  And stdout is
+  And stdout matches line by line
   """
   <REPOSYNC>
   Installed packages
@@ -365,7 +365,7 @@ Scenario: dnf info setup basesystem (when both are installed)
   URL             : None
   License         : Public Domain
   Description     : Basesystem defines the components of a basic Fedora system
-                  : (for example, the package installation order to use during bootstrapping).
+                  : \(for example, the package installation order to use during bootstrapping\).
                   : Basesystem should be in every installation of a system, and it
                   : should never be removed.
   Vendor          : <NULL>
@@ -391,14 +391,14 @@ Scenario: dnf info setup basesystem (when both are installed)
   Version        : 11
   Release        : 6.fc29
   Architecture   : src
-  Download size  : 7.0 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 583.0   B
   Repository     : dnf-ci-fedora
   Summary        : The skeleton package which defines a simple Fedora system
   URL            : None
   License        : Public Domain
   Description    : Basesystem defines the components of a basic Fedora system
-                 : (for example, the package installation order to use during bootstrapping).
+                 : \(for example, the package installation order to use during bootstrapping\).
                  : Basesystem should be in every installation of a system, and it
                  : should never be removed.
   Vendor         : 
@@ -408,7 +408,7 @@ Scenario: dnf info setup basesystem (when both are installed)
   Version        : 2.12.1
   Release        : 1.fc29
   Architecture   : src
-  Download size  : 6.9 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 616.0   B
   Repository     : dnf-ci-fedora
   Summary        : A set of system configuration and setup files
@@ -472,7 +472,7 @@ Scenario: dnf info --obsoletes
 Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "info --obsoletes"
  Then the exit code is 0
-  And stdout is
+  And stdout matches line by line
   """
   <REPOSYNC>
   Obsoleting packages
@@ -482,13 +482,13 @@ Given I use repository "dnf-ci-fedora-updates"
   Release        : 26.fc29
   Architecture   : x86_64
   Obsoletes      : glibc-0:2.28-9.fc29.x86_64
-  Download size  : 10.7 KiB
+  Download size  : [0-9.]+ KiB
   Installed size : 0.0   B
   Source         : glibc-2.28-26.fc29.src.rpm
   Repository     : dnf-ci-fedora-updates
   Summary        : The GNU libc libraries
   URL            : http://www.gnu.org/software/glibc/
-  License        : LGPLv2+ and LGPLv2+ with exceptions and GPLv2+ and GPLv2+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
+  License        : LGPLv2\+ and LGPLv2\+ with exceptions and GPLv2\+ and GPLv2\+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
   Description    : The glibc package contains standard libraries which are used by
                  : multiple programs on the system. In order to save disk space and
                  : memory, as well as to make upgrading easier, common system code is
@@ -521,7 +521,7 @@ Scenario: dnf info respects repo priorities
         | priority      | 100     |
    When I execute dnf with args "info flac.x86_64"
    Then the exit code is 0
-    And stdout is
+    And stdout matches line by line
     """
     <REPOSYNC>
     Available packages
@@ -530,13 +530,13 @@ Scenario: dnf info respects repo priorities
     Version        : 1.3.2
     Release        : 8.fc29
     Architecture   : x86_64
-    Download size  : 6.5 KiB
+    Download size  : [0-9.]+ KiB
     Installed size : 0.0   B
     Source         : flac-1.3.2-8.fc29.src.rpm
     Repository     : dnf-ci-fedora
     Summary        : An encoder/decoder for the Free Lossless Audio Codec
     URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2+ and GFDL
+    License        : BSD and GPLv2\+ and GFDL
     Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                    : the stream format, reference encoders and decoders in library form,
@@ -557,7 +557,7 @@ Scenario: dnf info --showduplicates info all (even from lower-priority repo)
         | priority      | 100     |
    When I execute dnf with args "info flac.x86_64 --showduplicates"
    Then the exit code is 0
-    And stdout is
+    And stdout matches line by line
     """
     <REPOSYNC>
     Available packages
@@ -566,13 +566,13 @@ Scenario: dnf info --showduplicates info all (even from lower-priority repo)
     Version        : 1.3.2
     Release        : 8.fc29
     Architecture   : x86_64
-    Download size  : 6.5 KiB
+    Download size  : [0-9.]+ KiB
     Installed size : 0.0   B
     Source         : flac-1.3.2-8.fc29.src.rpm
     Repository     : dnf-ci-fedora
     Summary        : An encoder/decoder for the Free Lossless Audio Codec
     URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2+ and GFDL
+    License        : BSD and GPLv2\+ and GFDL
     Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                    : the stream format, reference encoders and decoders in library form,
@@ -588,13 +588,13 @@ Scenario: dnf info --showduplicates info all (even from lower-priority repo)
     Version        : 1.3.3
     Release        : 1.fc29
     Architecture   : x86_64
-    Download size  : 6.5 KiB
+    Download size  : [0-9.]+ KiB
     Installed size : 0.0   B
     Source         : flac-1.3.3-1.fc29.src.rpm
     Repository     : dnf-ci-fedora-updates
     Summary        : An encoder/decoder for the Free Lossless Audio Codec
     URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2+ and GFDL
+    License        : BSD and GPLv2\+ and GFDL
     Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                    : the stream format, reference encoders and decoders in library form,
@@ -610,13 +610,13 @@ Scenario: dnf info --showduplicates info all (even from lower-priority repo)
     Version        : 1.3.3
     Release        : 2.fc29
     Architecture   : x86_64
-    Download size  : 6.5 KiB
+    Download size  : [0-9.]+ KiB
     Installed size : 0.0   B
     Source         : flac-1.3.3-2.fc29.src.rpm
     Repository     : dnf-ci-fedora-updates
     Summary        : An encoder/decoder for the Free Lossless Audio Codec
     URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2+ and GFDL
+    License        : BSD and GPLv2\+ and GFDL
     Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                    : the stream format, reference encoders and decoders in library form,
@@ -632,13 +632,13 @@ Scenario: dnf info --showduplicates info all (even from lower-priority repo)
     Version        : 1.3.3
     Release        : 3.fc29
     Architecture   : x86_64
-    Download size  : 6.5 KiB
+    Download size  : [0-9.]+ KiB
     Installed size : 0.0   B
     Source         : flac-1.3.3-3.fc29.src.rpm
     Repository     : dnf-ci-fedora-updates
     Summary        : An encoder/decoder for the Free Lossless Audio Codec
     URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2+ and GFDL
+    License        : BSD and GPLv2\+ and GFDL
     Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                    : the stream format, reference encoders and decoders in library form,
@@ -661,7 +661,7 @@ Scenario: dnf info doesn't show any available packages when there are no upgrade
     And I successfully execute dnf with args "install flac-1.3.3-1.fc29"
    When I execute dnf with args "info flac.x86_64"
    Then the exit code is 0
-    And stdout is
+    And stdout matches line by line
     """
     <REPOSYNC>
     Installed packages
@@ -675,7 +675,7 @@ Scenario: dnf info doesn't show any available packages when there are no upgrade
     From repository : dnf-ci-fedora-updates
     Summary         : An encoder/decoder for the Free Lossless Audio Codec
     URL             : http://www.xiph.org/flac/
-    License         : BSD and GPLv2+ and GFDL
+    License         : BSD and GPLv2\+ and GFDL
     Description     : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                     : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                     : the stream format, reference encoders and decoders in library form,
@@ -697,7 +697,7 @@ Scenario: dnf info shows available packages when there are upgrades in the highe
     And I successfully execute dnf with args "install flac-1.3.3-1.fc29"
    When I execute dnf with args "info flac.x86_64"
    Then the exit code is 0
-    And stdout is
+    And stdout matches line by line
     """
     <REPOSYNC>
     Installed packages
@@ -711,7 +711,7 @@ Scenario: dnf info shows available packages when there are upgrades in the highe
     From repository : dnf-ci-fedora-updates
     Summary         : An encoder/decoder for the Free Lossless Audio Codec
     URL             : http://www.xiph.org/flac/
-    License         : BSD and GPLv2+ and GFDL
+    License         : BSD and GPLv2\+ and GFDL
     Description     : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                     : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                     : the stream format, reference encoders and decoders in library form,
@@ -728,13 +728,13 @@ Scenario: dnf info shows available packages when there are upgrades in the highe
     Version        : 1.3.3
     Release        : 3.fc29
     Architecture   : x86_64
-    Download size  : 6.5 KiB
+    Download size  : [0-9.]+ KiB
     Installed size : 0.0   B
     Source         : flac-1.3.3-3.fc29.src.rpm
     Repository     : dnf-ci-fedora-updates
     Summary        : An encoder/decoder for the Free Lossless Audio Codec
     URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2+ and GFDL
+    License        : BSD and GPLv2\+ and GFDL
     Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                    : the stream format, reference encoders and decoders in library form,
@@ -756,7 +756,7 @@ Scenario: dnf info doesn't show package with same nevra from lower-priority repo
         | priority      | 100                                      |
    When I execute dnf with args "info flac.x86_64"
    Then the exit code is 0
-    And stdout is
+    And stdout matches line by line
     """
     <REPOSYNC>
     Available packages
@@ -765,13 +765,13 @@ Scenario: dnf info doesn't show package with same nevra from lower-priority repo
     Version        : 1.3.2
     Release        : 8.fc29
     Architecture   : x86_64
-    Download size  : 6.5 KiB
+    Download size  : [0-9.]+ KiB
     Installed size : 0.0   B
     Source         : flac-1.3.2-8.fc29.src.rpm
     Repository     : dnf-ci-fedora
     Summary        : An encoder/decoder for the Free Lossless Audio Codec
     URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2+ and GFDL
+    License        : BSD and GPLv2\+ and GFDL
     Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
                    : the stream format, reference encoders and decoders in library form,


### PR DESCRIPTION
The size sometimes slightly differs and it causes random test failures. The rpm packages are not stored, but built from source each time the container is built, so it's reasonable to expect that package sizes may change.