### PR TITLE
Tests for group info/list commands

### DIFF
--- a/dnf-behave-tests/dnf/comps-group-list.feature
+++ b/dnf-behave-tests/dnf/comps-group-list.feature
@@ -1,0 +1,143 @@
+@dnf5
+@dnf5daemon
+Feature: Tests for group list and info commands
+
+Background: Enable repo and mark a group as installed
+ Given I use repository "comps-group-list"
+ Given I create file "/usr/lib/sysimage/libdnf5/groups.toml" with
+    """
+    version = "1.0"
+
+    [groups]
+
+    [groups.test-group]
+    userinstalled = true
+    """
+
+Scenario: All user visible groups are listed by default (installed group is not duplicated)
+  When I execute dnf with args "group list"
+  Then the exit code is 0
+   And stdout is
+    """
+    <REPOSYNC>
+    ID                   Name        Installed
+    empty-group          Empty group        no
+    no-name-group                           no
+    test-group           Test Group        yes 
+    """
+
+Scenario: I can list also hidden groups
+  When I execute dnf with args "group list --hidden"
+  Then the exit code is 0
+   And stdout is
+    """
+    <REPOSYNC>
+    ID                   Name         Installed
+    empty-group          Empty group         no
+    hidden-group         Hidden group        no
+    no-name-group                            no
+    test-group           Test Group         yes
+    """
+
+Scenario: I can filter listed groups by their ids (hidden groups are included)
+  When I execute dnf with args "group list "hidden-*""
+  Then the exit code is 0
+   And stdout is
+    """
+    <REPOSYNC>
+    ID                   Name         Installed
+    hidden-group         Hidden group        no
+    """
+
+Scenario: I can filter listed groups by their names (hidden groups are included)
+  When I execute dnf with args "group list "* group""
+  Then the exit code is 0
+   And stdout is
+    """
+    <REPOSYNC>
+    ID                   Name         Installed
+    empty-group          Empty group         no
+    hidden-group         Hidden group        no
+    test-group           Test Group         yes
+    """
+
+Scenario: I can list only installed groups
+  When I execute dnf with args "group list --installed"
+  Then the exit code is 0
+   And stdout is
+    """
+    <REPOSYNC>
+    ID                   Name       Installed
+    test-group           Test Group       yes 
+    """
+
+Scenario: I can list only available groups
+  When I execute dnf with args "group list --available"
+  Then the exit code is 0
+   And stdout is
+    """
+    <REPOSYNC>
+    ID                   Name        Installed
+    empty-group          Empty group        no
+    no-name-group                           no
+    test-group           Test Group         no
+    """
+
+Scenario: I can list only groups containing a package
+        When I execute dnf with args "group list --contains-pkgs=test-package"
+  Then the exit code is 0
+   And stdout is
+    """
+    <REPOSYNC>
+    ID                   Name       Installed
+    no-name-group                          no
+    test-group           Test Group       yes
+    """
+
+Scenario: I can get info about all groups (installed group is not duplicated)
+  When I execute dnf with args "group info"
+  Then the exit code is 0
+   And stdout is
+      """
+      <REPOSYNC>
+      Id                   : empty-group
+      Name                 : Empty group
+      Description          : 
+      Installed            : no
+      Order                : 
+      Langonly             : 
+      Uservisible          : yes
+      Repositories         : comps-group-list
+      
+      Id                   : test-group
+      Name                 : Test Group
+      Description          : Test Group description.
+      Installed            : yes
+      Order                : 
+      Langonly             : 
+      Uservisible          : yes
+      Repositories         : @System
+      Mandatory packages   : test-package
+      
+      Id                   : no-name-group
+      Name                 : 
+      Description          : 
+      Installed            : no
+      Order                : 
+      Langonly             : 
+      Uservisible          : yes
+      Repositories         : comps-group-list
+      Mandatory packages   : test-package
+      """
+
+
+Scenario Outline: Info command accepts <option> option
+  When I execute dnf with args "group info <option>"
+  Then the exit code is 0
+
+Examples:
+    | option                |
+    | --hidden              |
+    | --installed           |
+    | --available           |
+    | --contains-pkgs=pkg   |

--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -293,19 +293,12 @@ Scenario: Group remove does not traceback when reason change
 
 @bz1706382
 @dnf5
+@dnf5daemon
 Scenario: Group list
  Given I use repository "dnf-ci-thirdparty"
   When I execute dnf with args "group list"
   Then the exit code is 0
-   And dnf4 stdout is
-    """
-    <REPOSYNC>
-    Available Groups:
-       DNF-CI-Testgroup
-       CQRlib-non-devel
-       SuperRipper-and-deps
-    """
-   And dnf5 stdout is
+   And stdout is
     """
     <REPOSYNC>
     ID                   Name                 Installed
@@ -315,6 +308,7 @@ Scenario: Group list
     """
 
 @dnf5
+@dnf5daemon
 @bz1706382
 Scenario: Group list with arg
  Given I use repository "dnf-ci-thirdparty"
@@ -378,6 +372,7 @@ Scenario: Install an environment with empty name
 
 
 @dnf5
+@dnf5daemon
 Scenario: List and info a group with missing packagelist
   Given I use repository "comps-group-merging"
    When I execute dnf with args "group list"
@@ -457,17 +452,11 @@ Scenario: Merge environment with missing names containg a group with missing nam
 
 
 @dnf5
+@dnf5daemon
 Scenario: Group info with a group that has missing name
   Given I use repository "comps-group"
    When I execute dnf with args "group info no-name-group"
-   Then dnf4 stdout is
-       """
-       <REPOSYNC>
-       Group: <name-unset>
-        Mandatory Packages:
-          test-package
-       """
-    And dnf5 stdout is
+   Then stdout is
        """
        <REPOSYNC>
        Id                   : no-name-group
@@ -583,13 +572,14 @@ Scenario: 'dnf group list -C' works for unprivileged user even when decompressed
 
 
 @dnf5
+@dnf5daemon
 @bz2173929
 Scenario: dnf5 group list: empty output when run for the second time
  Given I use repository "advisories-and-groups"
   When I execute dnf with args "clean metadata"
    And I execute dnf with args "group list"
   Then the exit code is 0
-   And dnf5 stdout is
+   And stdout is
     """
     <REPOSYNC>
     ID                   Name         Installed
@@ -598,7 +588,7 @@ Scenario: dnf5 group list: empty output when run for the second time
     """
   When I execute dnf with args "group list"
   Then the exit code is 0
-   And dnf5 stdout is
+   And stdout is
     """
     <REPOSYNC>
     ID                   Name         Installed

--- a/dnf-behave-tests/fixtures/specs/comps-group-list/comps.xml
+++ b/dnf-behave-tests/fixtures/specs/comps-group-list/comps.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
+<comps>
+  <group>
+   <id>test-group</id>
+   <name>Test Group</name>
+   <description>Test Group description.</description>
+   <packagelist>
+     <packagereq type="mandatory">test-package</packagereq>
+   </packagelist>
+  </group>
+
+  <group>
+   <id>no-name-group</id>
+   <name></name>
+   <description></description>
+   <packagelist>
+     <packagereq type="mandatory">test-package</packagereq>
+   </packagelist>
+  </group>
+
+  <group>
+   <id>hidden-group</id>
+   <name>Hidden group</name>
+   <description></description>
+   <uservisible>false</uservisible>
+   <packagelist>
+     <packagereq type="mandatory">test-package</packagereq>
+   </packagelist>
+  </group>
+
+  <group>
+   <id>empty-group</id>
+   <name>Empty group</name>
+   <description></description>
+   <packagelist>
+   </packagelist>
+  </group>
+
+</comps>


### PR DESCRIPTION
For both dnf5 and dnf5daemon.

Requires: https://github.com/rpm-software-management/dnf5/pull/1352