### PR TITLE
Revert "Add a scenario to test that the alias is not present and dnf5 exits gracefully"

### DIFF
--- a/dnf-behave-tests/dnf/command-aliases.feature
+++ b/dnf-behave-tests/dnf/command-aliases.feature
@@ -50,18 +50,9 @@ Examples:
         | repoquery           | repoquery                    |
         | repoquery           | rq                           |
         | search              | search                       |
+        | search              | se                           |
         | swap                | swap                         |
         | upgrade             | up                           |
         | upgrade             | update                       |
         | upgrade             | upgrade                      |
         | upgrade             | upgrade-minimal              |
-
-@dnf5
-Scenario Outline: "<alias>" is not an alias for "<command>"
-   When I execute dnf with args "<alias>"
-   Then the exit code is 2
-    And stderr contains "Unknown argument \"<alias>\" for command "
-
-Examples:
-        | command             | alias                        |
-        | search              | se                           |


### PR DESCRIPTION
This reverts commit 0a593ebd17a8c73643d5962dcbb33be2c391e667. Since https://github.com/rpm-software-management/dnf5/pull/1376 was merged we need to update the CI otherwise it is failing.