### PR TITLE
Remove test that `se` alias does not exist

### DIFF
--- a/dnf-behave-tests/dnf/command-aliases.feature
+++ b/dnf-behave-tests/dnf/command-aliases.feature
@@ -55,13 +55,3 @@ Examples:
         | upgrade             | update                       |
         | upgrade             | upgrade                      |
         | upgrade             | upgrade-minimal              |
-
-@dnf5
-Scenario Outline: "<alias>" is not an alias for "<command>"
-   When I execute dnf with args "<alias>"
-   Then the exit code is 2
-    And stderr contains "Unknown argument \"<alias>\" for command "
-
-Examples:
-        | command             | alias                        |
-        | search              | se                           |


### PR DESCRIPTION
Given that commit which introduced "se" compatibility alias has been
merged, remove this scenario.
See https://github.com/rpm-software-management/dnf5/commit/b96ee5a2502ba36e22e5368f26e3530d1706afc1