### PR TITLE
Drop enabling of dnf5 plugins

### DIFF
--- a/dnf-behave-tests/dnf/dnf-automatic/reboot.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/reboot.feature
@@ -2,8 +2,7 @@
 Feature: dnf-automatic reboots
 
 Background:
-Given I enable plugin "automatic"
-  And I use repository "simple-base"
+Given I use repository "simple-base"
   And I successfully execute dnf with args "install labirinto"
   And I use repository "simple-updates"
 

--- a/dnf-behave-tests/dnf/dnf-automatic/update.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/update.feature
@@ -3,8 +3,7 @@ Feature: dnf-automatic performs update
 
 
 Background:
-Given I enable plugin "automatic"
-  And I use repository "simple-base"
+Given I use repository "simple-base"
 
 
 Scenario: dnf-automatic can update package

--- a/dnf-behave-tests/dnf/fileprovides.feature
+++ b/dnf-behave-tests/dnf/fileprovides.feature
@@ -2,8 +2,7 @@
 Feature: Adding file provides tests
 
 Scenario: Run repoclosure with already created cache without filelists
-  Given I enable plugin "repoclosure"
-    And I use repository "fileprovides"
+  Given I use repository "fileprovides"
     # We run repoquery --whatprovides to trigger generation of file provides (calling make_provides_ready())
     # This command doesn't require filelists.xml
     And I successfully execute dnf with args "repoquery --whatprovides htop"

--- a/dnf-behave-tests/dnf/plugins-core/builddep-conflicts.feature
+++ b/dnf-behave-tests/dnf/plugins-core/builddep-conflicts.feature
@@ -2,9 +2,6 @@
 @not.with_dnf=4
 Feature: Tests for BuildConflicts support in builddep command
 
-Background: Enable builddep plugin
-  Given I enable plugin "builddep"
-
 
 # `with-build-conflict` package BuildConflicts with `weak-dependency` and
 # BuildRequires `build-requirement-a` which in turn Recommends `weak-dependency`

--- a/dnf-behave-tests/dnf/plugins-core/builddep-modularity.feature
+++ b/dnf-behave-tests/dnf/plugins-core/builddep-modularity.feature
@@ -1,8 +1,7 @@
 Feature: Tests for builddep command on modular system
 
-Background: Enable builddep plugin
-  Given I enable plugin "builddep"
-    And I use repository "dnf-ci-fedora"
+Background:
+  Given I use repository "dnf-ci-fedora"
 
 # dnf-ci-fedora-modular repo:
 #   module ninja:master [d] contains ninja-build-0:1.8.2-4.module_1991+4e5efe2f.x86_64

--- a/dnf-behave-tests/dnf/plugins-core/builddep.feature
+++ b/dnf-behave-tests/dnf/plugins-core/builddep.feature
@@ -1,11 +1,8 @@
-# Unknown argument "builddep" for command "microdnf"
+@dnf5
 Feature: dnf builddep command
 
 
-Background: Enable builddep plugin
-  Given I enable plugin "builddep"
-
-
+@not.with_dnf=5
 Scenario: Dnf builddep can use spec file from a remote location
   Given I use repository "dnf-ci-fedora"
     And I create directory "/remotedir"
@@ -30,7 +27,7 @@ Scenario: Dnf builddep can use spec file from a remote location
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install-dep   | setup-0:2.12.1-1.fc29.noarch          |
 
-@dnf5
+
 Scenario: Builddep with simple dependency (spec)
     Given I use repository "dnf-ci-fedora"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec"
@@ -39,7 +36,7 @@ Scenario: Builddep with simple dependency (spec)
         | Action        | Package                           |
         | install       | lame-libs-0:3.100-4.fc29.x86_64   |
 
-@dnf5
+
 Scenario: Builddep with simple dependency (spec) + define
     Given I use repository "dnf-ci-fedora"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec --define 'buildrequires flac'"
@@ -48,7 +45,7 @@ Scenario: Builddep with simple dependency (spec) + define
         | Action        | Package                           |
         | install       | flac-0:1.3.2-8.fc29.x86_64        |
 
-@dnf5
+
 Scenario: Builddep with simple dependency (srpm)
     Given I use repository "dnf-ci-fedora"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/repos/dnf-ci-thirdparty/src/SuperRipper-1.0-1.src.rpm"
@@ -57,7 +54,7 @@ Scenario: Builddep with simple dependency (srpm)
         | Action        | Package                           |
         | install       | lame-libs-0:3.100-4.fc29.x86_64   |
 
-@dnf5
+
 @not.with_os=rhel__eq__7
 Scenario: Builddep with rich dependency
     Given I use repository "dnf-ci-fedora"
@@ -68,7 +65,7 @@ Scenario: Builddep with rich dependency
         | install       | flac-0:1.3.2-8.fc29.x86_64        |
         | install       | lame-libs-0:3.100-4.fc29.x86_64   |
 
-@dnf5
+
 Scenario: Builddep with simple dependency (files-like provide)
     Given I use repository "dnf-ci-fedora"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec --define 'buildrequires /etc/ld.so.conf'"
@@ -77,7 +74,7 @@ Scenario: Builddep with simple dependency (files-like provide)
         | Action        | Package                           |
         | install       | glibc-0:2.28-9.fc29.x86_64        |
 
-@dnf5
+
 Scenario: Builddep with simple dependency (non-existent)
     Given I use repository "dnf-ci-fedora"
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/specs/dnf-ci-thirdparty/SuperRipper-1.0-1.spec --define 'buildrequires flac = 15'"
@@ -91,7 +88,7 @@ Scenario: Builddep with simple dependency (non-existent)
         --skip-unavailable to skip unavailable packages
       """
 
-@dnf5
+
 @bz1724668
 Scenario: Builddep on SPEC with non-available Source0
  Given I create file "{context.dnf.installroot}/missingSource.spec" with
@@ -124,7 +121,7 @@ Scenario: Builddep on SPEC with non-available Source0
    Failed to parse some inputs.
    """
 
-@dnf5
+
 @bz1758459
 Scenario: I exclude the highest verion of a package and call dnf builddep with --best
   Given I use repository "dnf-ci-fedora-updates"
@@ -148,7 +145,7 @@ Scenario: I exclude the highest verion of a package and call dnf builddep with -
         | Action                | Package                    |
         | install               | flac-0:1.3.3-2.fc29.x86_64 |
 
-@dnf5
+
 @bz1628634
 Scenario: Builddep with unavailable build dependency
     Given I use repository "dnf-ci-fedora"
@@ -171,7 +168,7 @@ Scenario: Builddep with unavailable build dependency
         | Action        | Package                           |
         | install       | lame-libs-0:3.100-4.fc29.x86_64   |
 
-@dnf5
+
 @bz2077820
 Scenario: Builddep using macros with source rpm
     Given I use repository "dnf-ci-fedora"
@@ -179,7 +176,7 @@ Scenario: Builddep using macros with source rpm
      Then the exit code is 0
       And stderr contains "Warning: -D or --define arguments have no meaning for source rpm packages."
 
-@dnf5
+
 Scenario: Builddep where package BuildRequires a pkg spec that contains glob characters
     Given I use repository "builddep"
      When I execute dnf with args "builddep requires-glob"

--- a/dnf-behave-tests/dnf/plugins-core/changelog.feature
+++ b/dnf-behave-tests/dnf/plugins-core/changelog.feature
@@ -2,9 +2,8 @@
 Feature: dnf changelog command
 
 
-Background: Enable changelog plugin
-  Given I enable plugin "changelog"
-    And I use repository "dnf-ci-changelog"
+Background:
+  Given I use repository "dnf-ci-changelog"
 
 
 Scenario: Listing changelogs since given date

--- a/dnf-behave-tests/dnf/plugins-core/copr.feature
+++ b/dnf-behave-tests/dnf/plugins-core/copr.feature
@@ -2,8 +2,7 @@
 Feature: Test the COPR plugin
 
 Background:
-Given I enable plugin "copr"
-  And I create directory "/{context.dnf.tempdir}/copr"
+Given I create directory "/{context.dnf.tempdir}/copr"
   And I start http server "copr" at "{context.dnf.tempdir}/copr"
   And I create and substitute file "//etc/dnf/plugins/copr.conf" with
       """

--- a/dnf-behave-tests/dnf/plugins-core/debug-dump.feature
+++ b/dnf-behave-tests/dnf/plugins-core/debug-dump.feature
@@ -2,8 +2,7 @@ Feature: Test for debug plugin - dumping
 
 
 Scenario: dnf debug-dump dumps file with configuration
-  Given I enable plugin "debug"
-    And I use repository "debug-plugin"
+  Given I use repository "debug-plugin"
     And I successfully execute dnf with args "install kernel-4.19.1 kernel-4.20.1"
    When I execute dnf with args "debug-dump {context.dnf.tempdir}/dump.txt"
    Then the exit code is 0
@@ -52,8 +51,7 @@ Scenario: dnf debug-dump dumps file with configuration
 
 
 Scenario: dnf debug-dump with --norepos skips dumping repositories contents
-  Given I enable plugin "debug"
-    And I use repository "debug-plugin"
+  Given I use repository "debug-plugin"
     And I successfully execute dnf with args "install kernel-4.19.1 kernel-4.20.1"
    When I execute dnf with args "debug-dump --norepos {context.dnf.tempdir}/dump.txt"
    Then the exit code is 0

--- a/dnf-behave-tests/dnf/plugins-core/debug-restore-obsoletes.feature
+++ b/dnf-behave-tests/dnf/plugins-core/debug-restore-obsoletes.feature
@@ -2,8 +2,7 @@ Feature: Test for debug plugin - restoring obsoleted package
 
 
 Scenario: Restoring obsoleted package
-  Given I enable plugin "debug"
-    And I use repository "debug-plugin"
+  Given I use repository "debug-plugin"
     And I successfully execute dnf with args "install test-obsoleted-1"
     And I successfully execute dnf with args "debug-dump {context.dnf.tempdir}/dump.txt"
    When I execute dnf with args "update"

--- a/dnf-behave-tests/dnf/plugins-core/debug-restore.feature
+++ b/dnf-behave-tests/dnf/plugins-core/debug-restore.feature
@@ -2,8 +2,7 @@ Feature: Test for debug plugin - restoring
 
 
 Background: install some packages and create dump file
-  Given I enable plugin "debug"
-    And I use repository "debug-plugin"
+  Given I use repository "debug-plugin"
     And I successfully execute dnf with args "install kernel-4.19.1 kernel-4.20.1"
     And I successfully execute dnf with args "install test-replace-2"
     And I successfully execute dnf with args "debug-dump {context.dnf.tempdir}/dump.txt"

--- a/dnf-behave-tests/dnf/plugins-core/debuginfo-install.feature
+++ b/dnf-behave-tests/dnf/plugins-core/debuginfo-install.feature
@@ -2,7 +2,6 @@ Feature: Tests for the debuginfo-install plugin
 
 Background:
 Given I use repository "debuginfo-install"
-  And I enable plugin "debuginfo-install"
 
 @bz1585137
 Scenario: reports an error for a non-existent package

--- a/dnf-behave-tests/dnf/plugins-core/download-debuginfo.feature
+++ b/dnf-behave-tests/dnf/plugins-core/download-debuginfo.feature
@@ -2,8 +2,7 @@ Feature: dnf download --debuginfo command
 
 
 Background:
-  Given I enable plugin "download"
-    And I set working directory to "{context.dnf.tempdir}"
+  Given I set working directory to "{context.dnf.tempdir}"
 
 
 Scenario: Download a debuginfo for an RPM that doesn't exist

--- a/dnf-behave-tests/dnf/plugins-core/download-source.feature
+++ b/dnf-behave-tests/dnf/plugins-core/download-source.feature
@@ -3,8 +3,7 @@ Feature: dnf download --srpm command
 
 
 Background:
-  Given I enable plugin "download"
-    And I use repository "dnf-ci-fedora" as http
+  Given I use repository "dnf-ci-fedora" as http
     And I set working directory to "{context.dnf.tempdir}"
 
 

--- a/dnf-behave-tests/dnf/plugins-core/enable-plugins.feature
+++ b/dnf-behave-tests/dnf/plugins-core/enable-plugins.feature
@@ -1,8 +1,7 @@
 Feature: Tests for report nonexisting plugin
 
-Background: Enable builddep plugin
-  Given I enable plugin "builddep"
-    And I use repository "dnf-ci-fedora"
+Background:
+  Given I use repository "dnf-ci-fedora"
 
 @bz1673289 @bz1467304
 Scenario: Report nonexisting plugin to disable

--- a/dnf-behave-tests/dnf/plugins-core/groups-manager-errors.feature
+++ b/dnf-behave-tests/dnf/plugins-core/groups-manager-errors.feature
@@ -1,10 +1,6 @@
 Feature: dnf groups-manager command errors
 
 
-Background: Enable groups-manager plugin
-  Given I enable plugin "groups_manager"
-
-
 Scenario: groups-manager reports xml parsing errors
    When I execute dnf with args "groups-manager --load={context.dnf.fixturesdir}/data/groups-manager/comps_syntax_error.xml"
    Then the exit code is 1

--- a/dnf-behave-tests/dnf/plugins-core/groups-manager.feature
+++ b/dnf-behave-tests/dnf/plugins-core/groups-manager.feature
@@ -1,10 +1,6 @@
 Feature: dnf groups-manager command
 
 
-Background: Enable groups-manager plugin
-  Given I enable plugin "groups_manager"
-
-
 Scenario Outline: groups-manager can read <filename> file
   Given I copy file "{context.dnf.fixturesdir}/data/groups-manager/comps_a.xml" to "/{context.dnf.tempdir}/comps_a.xml"
     And I compress file "/{context.dnf.tempdir}/comps_a.xml" using "gz"

--- a/dnf-behave-tests/dnf/plugins-core/modulesync.feature
+++ b/dnf-behave-tests/dnf/plugins-core/modulesync.feature
@@ -5,7 +5,6 @@ Feature: Test for modulesync command
 Background:
   Given I use repository "dnf-ci-fedora-modular"
     And I use repository "dnf-ci-fedora"
-    And I enable plugin "modulesync"
 
 
 Scenario: I can download a module

--- a/dnf-behave-tests/dnf/plugins-core/needs-restarting-conf-files.feature
+++ b/dnf-behave-tests/dnf/plugins-core/needs-restarting-conf-files.feature
@@ -1,8 +1,7 @@
 Feature: Add package to needs-restarting using config files
 
 Background:
-Given I enable plugin "needs_restarting"
-  And I use repository "needs-restarting"
+Given I use repository "needs-restarting"
   And I move the clock backward to "before boot-up"
   And I execute dnf with args "install wget abcde"
   And I move the clock forward to "2 hours"

--- a/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
+++ b/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
@@ -3,8 +3,7 @@
 Feature: Reboot hint
 
 Background:
-    Given I enable plugin "needs_restarting"
-      And I use repository "dnf-ci-fedora"
+    Given I use repository "dnf-ci-fedora"
       And I move the clock backward to "before boot-up"
       And I execute dnf with args "install lame kernel basesystem glibc wget lz4"
       And I move the clock forward to "the present"

--- a/dnf-behave-tests/dnf/plugins-core/offline-upgrade-security-filters.feature
+++ b/dnf-behave-tests/dnf/plugins-core/offline-upgrade-security-filters.feature
@@ -2,8 +2,7 @@ Feature: Test the security filters for offline-upgrade commands
 
 
 Background:
-  Given I enable plugin "system-upgrade"
-    And I use repository "dnf-ci-fedora"
+  Given I use repository "dnf-ci-fedora"
 
 
 @bz1939975

--- a/dnf-behave-tests/dnf/plugins-core/repoclosure.feature
+++ b/dnf-behave-tests/dnf/plugins-core/repoclosure.feature
@@ -3,9 +3,8 @@ Feature: Repoclosure command tests
 
 
 # we need to override the default value for the `best` config option
-Background: Enable builddep plugin
-  Given I enable plugin "repoclosure"
-    And I configure dnf with
+Background:
+  Given I configure dnf with
         | key   | value |
         | best  | False |
 

--- a/dnf-behave-tests/dnf/plugins-core/repomanage.feature
+++ b/dnf-behave-tests/dnf/plugins-core/repomanage.feature
@@ -1,10 +1,6 @@
 Feature: Tests for repomanage command
 
 
-Background:
-Given I enable plugin "repomanage"
-
-
 Scenario: basic functionality of repomanage --new
 Given I copy repository "dnf-ci-thirdparty-updates" for modification
  When I execute dnf with args "repomanage --new {context.dnf.repos[dnf-ci-thirdparty-updates].path}"

--- a/dnf-behave-tests/dnf/plugins-core/reposync-local.feature
+++ b/dnf-behave-tests/dnf/plugins-core/reposync-local.feature
@@ -1,10 +1,6 @@
 Feature: Tests for reposync command with local repository
 
 
-Background:
-  Given I enable plugin "reposync"
-
-
 Scenario: Base functionality of reposync on local repository
   Given I use repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir}"

--- a/dnf-behave-tests/dnf/plugins-core/reposync-xattrs.feature
+++ b/dnf-behave-tests/dnf/plugins-core/reposync-xattrs.feature
@@ -7,10 +7,6 @@
 Feature: Reposync does not re-download the package
 
 
-Background: Enable reposync plugin
-Given I enable plugin "reposync"
-
-
 @bz1931904
 Scenario: Different checksum type does not cause package re-download
 Given I copy repository "simple-base" for modification

--- a/dnf-behave-tests/dnf/plugins-core/reposync.feature
+++ b/dnf-behave-tests/dnf/plugins-core/reposync.feature
@@ -1,10 +1,6 @@
 Feature: Tests for reposync command
 
 
-Background:
-  Given I enable plugin "reposync"
-
-
 Scenario: Base functionality of reposync
   Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir}"

--- a/dnf-behave-tests/dnf/plugins-core/system-upgrade-comps.feature
+++ b/dnf-behave-tests/dnf/plugins-core/system-upgrade-comps.feature
@@ -3,8 +3,7 @@ Feature: Test the system-upgrade plugin with comps
 
 
 Background:
-  Given I enable plugin "system_upgrade"
-    And I use repository "system-upgrade-comps-f$releasever"
+  Given I use repository "system-upgrade-comps-f$releasever"
 
 
 @bz2054235

--- a/dnf-behave-tests/dnf/plugins-core/system-upgrade.feature
+++ b/dnf-behave-tests/dnf/plugins-core/system-upgrade.feature
@@ -2,13 +2,12 @@
 Feature: Test the system-upgrade plugin
 
 Background:
-Given I enable plugin "system_upgrade"
   # Install the initial package versions first, then set the (target)
   # releasever and switch the repositories to http (so that system-upgrade
   # actually downloads the packages instead of using the local path). It is not
   # possible to set up an http server for a repository with two different
   # releasever variations.
-  And I use repository "system-upgrade-f$releasever" with configuration
+Given I use repository "system-upgrade-f$releasever" with configuration
       | key         | value |
       | priority    | 1     |
   And I use repository "system-upgrade-2-f$releasever" with configuration

--- a/dnf-behave-tests/dnf/plugins-path.feature
+++ b/dnf-behave-tests/dnf/plugins-path.feature
@@ -1,8 +1,6 @@
 Feature: Pluginspath and pluginsconfpath test
 
 Scenario: Redirect pluginspath
-  Given I enable plugin "download"
-    And I enable plugin "versionlock"
    When I execute dnf with args "download --help"
    Then the exit code is 0
    When I execute dnf with args "versionlock --help"

--- a/dnf-behave-tests/dnf/plugins-third/swidtags.feature
+++ b/dnf-behave-tests/dnf/plugins-third/swidtags.feature
@@ -3,10 +3,6 @@
 Feature: Smoke test for swidtags dnf plugin
 
 
-Background: Enable the swidtags plugin
-  Given I enable plugin "swidtags"
-
-
 @bz1689178
 Scenario: Run swidtags without command prints usage
    When I execute dnf with args "swidtags"


### PR DESCRIPTION
Since the enable/disable plugin CLI options are now used exclusively for libdnf5 plugins, drop the explicit enabling of any dnf5 plugins, as it will have no effect and could cause issues with warning messages in the output.