### PR TITLE
Enable tests with skipped packages in transaction table

### DIFF
--- a/dnf-behave-tests/dnf/autoremove.feature
+++ b/dnf-behave-tests/dnf/autoremove.feature
@@ -19,7 +19,7 @@ Scenario: Autoremoval of package which became non-required by others
     And Transaction is following
         | Action        | Package                           |
         | upgrade       | SuperRipper-0:1.2-1.x86_64        |
-        #| broken        | SuperRipper-0:1.3-1.x86_64        | # TODO(mblaha) broken packages are not captured in dnf5 transaction
+        | broken        | SuperRipper-0:1.3-1.x86_64        |
    When I execute dnf with args "autoremove"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/dnf/broken-dependencies-report.feature
+++ b/dnf-behave-tests/dnf/broken-dependencies-report.feature
@@ -21,11 +21,9 @@ Scenario: Broken dependencies are reported when strict and best options are off
       - conflicting requests
       - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
     """
-    And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+    And Transaction is following
+        | Action                | Package                           |
+        | broken                | postgresql-9.6.5-1.fc29.x86_64    |
 
 
 @bz2088422
@@ -40,11 +38,9 @@ Scenario: Broken dependencies are reported when strict option is off and best op
       - conflicting requests
       - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
     """
-    And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+    And Transaction is following
+        | Action                | Package                           |
+        | broken                | postgresql-9.6.5-1.fc29.x86_64    |
 
 
 @bz2088422
@@ -59,8 +55,6 @@ Scenario: Broken dependencies are reported when skip-broken and best options are
       - conflicting requests
       - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
     """
-    And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+    And Transaction is following
+        | Action                | Package                           |
+        | broken                | postgresql-9.6.5-1.fc29.x86_64    |

--- a/dnf-behave-tests/dnf/config-best.feature
+++ b/dnf-behave-tests/dnf/config-best.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Config option: best
 
 
@@ -54,7 +55,7 @@ Scenario: When installing with best=1 set in dnf.conf, fail on broken packages, 
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "install glibc -x glibc-common-0:2.28-26.fc29.x86_64"
    Then the exit code is 1
-    And stdout contains "try to add .*'--nobest' to use not only best candidate packages"
+    And stderr contains "  --no-best to not limit the transaction to the best candidates"
 
 
 @bz1670776 @bz1671683

--- a/dnf-behave-tests/dnf/install-dependencies.feature
+++ b/dnf-behave-tests/dnf/install-dependencies.feature
@@ -5,16 +5,15 @@ Feature: Tests for install with dependencies
 @bz1774617
 Scenario: Best candidates have conflicting dependencies
   Given I use repository "install-dependencies"
-   When I execute dnf with args "install foo bar --nobest"
+   When I execute dnf with args "install foo bar --no-best"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                           |
         | install       | foo-0:1.0-1.fc29.x86_64           |
         | install       | bar-0:1.0-1.fc29.x86_64           |
         | install-dep   | lib-0:1.0-1.fc29.x86_64           |
-        # dnf5 currently does not report packages skipped due to conflict / broken deps
-        #        | conflict      | lib-0:2.0-1.fc29.x86_64           |
-        #        | broken        | foo-0:2.0-1.fc29.x86_64           |
+        | conflict      | lib-0:2.0-1.fc29.x86_64           |
+        | broken        | foo-0:2.0-1.fc29.x86_64           |
     And stderr contains "cannot install both lib-.\.0-1\.fc29\.x86_64 and lib-.\.0-1\.fc29\.x86_64"
     And stderr contains "package foo-2.0-1.fc29.x86_64 requires lib-2.0, but none of the providers can be installed"
     And stderr contains "package bar-1.0-1.fc29.x86_64 requires lib-1.0, but none of the providers can be installed"

--- a/dnf-behave-tests/dnf/upgrade.feature
+++ b/dnf-behave-tests/dnf/upgrade.feature
@@ -147,6 +147,7 @@ Scenario: Upgrade all RPMs from multiple repositories with best=False
         | upgrade       | wget-1:1.19.5-5.fc29.x86_64               |
         | upgrade       | SuperRipper-0:1.2-1.x86_64                |
         | upgrade       | abcde-0:2.9.3-1.fc29.noarch               |
+        | broken        | SuperRipper-1.3-1.x86_64                  |
 
 
 @dnf5
@@ -180,6 +181,7 @@ Scenario: Upgrade all RPMs from multiple repositories with best=True
         | upgrade       | wget-1:1.19.5-5.fc29.x86_64               |
         | upgrade       | SuperRipper-0:1.2-1.x86_64                |
         | upgrade       | abcde-0:2.9.3-1.fc29.noarch               |
+        | broken        | SuperRipper-1.3-1.x86_64                  |
     And stderr is
     """
     Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
@@ -198,6 +200,7 @@ Scenario: Print information about skipped packages
     And Transaction is following
         | Action        | Package                                   |
         | upgrade       | SuperRipper-0:1.2-1.x86_64                |
+        | broken        | SuperRipper-1.3-1.x86_64                  |
    Then stderr is
     """
     Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf5/pull/1440