### PR TITLE
Enable `history undo` tests

### DIFF
--- a/dnf-behave-tests/dnf/downgrade.feature
+++ b/dnf-behave-tests/dnf/downgrade.feature
@@ -77,8 +77,8 @@ Scenario: Downgrade a package that was installed via rpm
         | Action    | Package                    |
         | downgrade | flac-0:1.3.3-2.fc29.x86_64 |
    Then package reasons are
-        | Package                  | Reason  |
-        | flac-1.3.3-2.fc29.x86_64 | unknown |
+        | Package                  | Reason        |
+        | flac-1.3.3-2.fc29.x86_64 | External User |
     And package state is
         | package                  | reason        | from_repo             |
         | flac-1.3.3-2.fc29.x86_64 | External User | dnf-ci-fedora-updates |

--- a/dnf-behave-tests/dnf/history-undo-comps.feature
+++ b/dnf-behave-tests/dnf/history-undo-comps.feature
@@ -1,10 +1,11 @@
+@dnf5
 Feature: Transaction history undo - comps
 
 
 Background:
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-thirdparty"
-    And I successfully execute dnf with args "group install DNF-CI-Testgroup"
+    And I successfully execute dnf with args "group install dnf-ci-testgroup"
    Then Transaction is following
         | Action        | Package                           |
         | group-install | DNF-CI-Testgroup                  |
@@ -14,7 +15,7 @@ Background:
         | install-dep   | lame-libs-0:3.100-4.fc29.x86_64   |
     And History is following
         | Id     | Command                               | Action        | Altered   |
-        | 1      | group install DNF-CI-Testgroup        | Install       | 5         |
+        | 1      | group install dnf-ci-testgroup        |               | 5         |
 
 
 @bz1809639
@@ -26,16 +27,16 @@ Scenario: Undo a transaction that installed a group
         | group-remove           | DNF-CI-Testgroup                              |
         | remove                 | filesystem-3.9-2.fc29.x86_64                  |
         | remove                 | lame-0:3.100-4.fc29.x86_64                    |
-        | remove-dep             | lame-libs-0:3.100-4.fc29.x86_64               |
-        | remove-dep             | setup-2.12.1-1.fc29.noarch                    |
+        | remove-unused          | lame-libs-0:3.100-4.fc29.x86_64               |
+        | remove-unused          | setup-2.12.1-1.fc29.noarch                    |
     And History is following
         | Id     | Command                               | Action        | Altered   |
-        | 2      | history undo last                     | Removed       | 5         |
-        | 1      | group install DNF-CI-Testgroup        | Install       | 5         |
+        | 2      | history undo last                     |               | 5         |
+        | 1      | group install dnf-ci-testgroup        |               | 5         |
 
 
 Scenario: Undo a transaction that removed a group
-  Given I successfully execute dnf with args "group remove DNF-CI-Testgroup"
+  Given I successfully execute dnf with args "group remove dnf-ci-testgroup"
    When I execute dnf with args "history undo last"
    Then the exit code is 0
     And Transaction is following
@@ -47,17 +48,30 @@ Scenario: Undo a transaction that removed a group
         | install-dep            | setup-2.12.1-1.fc29.noarch                    |
     And History is following
         | Id     | Command                               | Action        | Altered   |
-        | 3      | history undo last                     | Install       | 5         |
-        | 2      | group remove DNF-CI-Testgroup         | Removed       | 5         |
-        | 1      | group install DNF-CI-Testgroup        | Install       | 5         |
+        | 3      | history undo last                     |               | 5         |
+        | 2      | group remove dnf-ci-testgroup         |               | 5         |
+        | 1      | group install dnf-ci-testgroup        |               | 5         |
 
 
 Scenario: Undo a transaction with a missing group
   Given I drop repository "dnf-ci-thirdparty"
+   # The group is stored in system state (it can always be removed)
    When I execute dnf with args "history undo 1"
+   Then the exit code is 0
+    And Transaction is following
+        | Action                 | Package                                       |
+        | group-remove           | DNF-CI-Testgroup                              |
+        | remove                 | filesystem-3.9-2.fc29.x86_64                  |
+        | remove                 | lame-0:3.100-4.fc29.x86_64                    |
+        | remove-unused          | lame-libs-0:3.100-4.fc29.x86_64               |
+        | remove-unused          | setup-2.12.1-1.fc29.noarch                    |
+   # Undo the last undo (this should install the group again but it is missing)
+   When I execute dnf with args "history undo last"
    Then the exit code is 1
     And stderr is
     """
-    Error: The following problems occurred while running a transaction:
-      Group id 'dnf-ci-testgroup' is not available.
+    Failed to resolve the transaction:
+    No match for argument: dnf-ci-testgroup
+    You can try to add to command line:
+      --skip-unavailable to skip unavailable packages
     """

--- a/dnf-behave-tests/dnf/history-undo-dependant.feature
+++ b/dnf-behave-tests/dnf/history-undo-dependant.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Transaction history undo
 
 @bz1700529
@@ -5,17 +6,23 @@ Scenario: Undo module install with dependent userinstalled package
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-fedora-modular"
    # install module that contains postgresql-server
-   When I execute dnf with args "module install postgresql/server"
-   Then the exit code is 0
-    And Transaction contains
-        | Action                    | Package                                       |
-        | install-group             | postgresql-server-0:9.6.8-1.module_1710+b535a823.x86_64 |
+    And I successfully execute dnf with args "module enable postgresql/server"
+    And I successfully execute dnf with args "install postgresql-server-0:9.6.8-1.module_1710+b535a823.x86_64"
    # install package, that requires postgresql-server
-   When I execute dnf with args "install postgresql-test"
-   Then the exit code is 0
+    And I successfully execute dnf with args "install postgresql-test"
    # try to undo module install transaction
    When I execute dnf with args "history undo last-1"
    # the transaction is not supposed to reinstall required packages, but to fail
    Then the exit code is 1
-    And stdout does not contain "Reinstalling\s+: postgresql-server-9\.6\.8-1\.module_1710\+b535a823"
-    And stderr contains "package postgresql-test-9\.6\.8-1\.module_1710\+b535a823\.x86_64 requires postgresql-server\(x86-64\) = 9\.6\.8-1\.module_1710\+b535a823, but none of the providers can be installed"
+    And stdout is
+    """
+    <REPOSYNC>
+    """
+    And stderr is
+    """
+    Failed to resolve the transaction:
+    Extra package 'postgresql-test-9.6.8-1.module_1710+b535a823.x86_64' (with action 'Remove') which is not present in the stored transaction was pulled into the transaction.
+
+    You can try to add to command line:
+      --ignore-extras to allow extra packages in the transaction
+    """

--- a/dnf-behave-tests/dnf/history-undo-obsoletes.feature
+++ b/dnf-behave-tests/dnf/history-undo-obsoletes.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Transaction history undo with obsoletes
 
 # Package glibc-all-langpacks requires glibc
@@ -30,10 +31,10 @@ Scenario: Undo with obsoletes
     And Transaction is following
         | Action        | Package                                   |
         | remove        | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
-        | remove-dep    | setup-0:2.12.1-1.fc29.noarch              |
+        | remove-unused | setup-0:2.12.1-1.fc29.noarch              |
         | remove        | glibc-0:2.28-9.fc29.x86_64                |
-        | remove-dep    | glibc-common-0:2.28-9.fc29.x86_64         |
-        | remove-dep    | filesystem-0:3.9-2.fc29.x86_64            |
-        | remove-dep    | basesystem-0:11-6.fc29.noarch             |
+        | remove-unused | glibc-common-0:2.28-9.fc29.x86_64         |
+        | remove-unused | filesystem-0:3.9-2.fc29.x86_64            |
+        | remove-unused | basesystem-0:11-6.fc29.noarch             |
         | install       | glibc-profile-0:2.3.1-10.x86_64           |
 

--- a/dnf-behave-tests/dnf/history-undo.feature
+++ b/dnf-behave-tests/dnf/history-undo.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Transaction history undo
 
 
@@ -9,17 +10,17 @@ Scenario: Undoing transactions
   Given I successfully execute dnf with args "install filesystem"
    Then History is following
         | Id     | Command               | Action        | Altered   |
-        | 1      | install filesystem    | Install       | 2         |
+        | 1      | install filesystem    |               | 2         |
    When I execute dnf with args "history undo last"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                    |
-        | remove-dep    | setup-0:2.12.1-1.fc29.noarch               |
+        | remove-unused | setup-0:2.12.1-1.fc29.noarch               |
         | remove        | filesystem-0:3.9-2.fc29.x86_64             |
     And History is following
         | Id     | Command               | Action        | Altered   |
-        | 2      |                       | Removed       | 2         |
-        | 1      |                       | Install       | 2         |
+        | 2      | undo last             |               | 2         |
+        | 1      | install filesystem    |               | 2         |
    When I execute dnf with args "history undo last"
    Then the exit code is 0
     And Transaction is following
@@ -28,21 +29,21 @@ Scenario: Undoing transactions
         | install       | filesystem-0:3.9-2.fc29.x86_64             |
     And History is following
         | Id     | Command               | Action        | Altered   |
-        | 3      |                       | Install       | 2         |
-        | 2      |                       | Removed       | 2         |
-        | 1      |                       | Install       | 2         |
+        | 3      | undo last             |               | 2         |
+        | 2      | undo last             |               | 2         |
+        | 1      | install filesystem    |               | 2         |
    When I execute dnf with args "history undo last-2"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                                    |
-        | remove-dep    | setup-0:2.12.1-1.fc29.noarch               |
+        | remove-unused | setup-0:2.12.1-1.fc29.noarch               |
         | remove        | filesystem-0:3.9-2.fc29.x86_64             |
     And History is following
         | Id     | Command               | Action        | Altered   |
-        | 4      |                       | Removed       | 2         |
-        | 3      |                       | Install       | 2         |
-        | 2      |                       | Removed       | 2         |
-        | 1      |                       | Install       | 2         |
+        | 4      | undo last-2           |               | 2         |
+        | 3      | undo last             |               | 2         |
+        | 2      | undo last             |               | 2         |
+        | 1      | install filesystem    |               | 2         |
 
 
 @1627111
@@ -62,17 +63,19 @@ Scenario: Handle missing packages required for undoing the transaction
         | upgrade       | flac-0:1.3.3-3.fc29.x86_64   |
         | upgrade       | wget-0:1.19.6-5.fc29.x86_64  |
     And History is following
-        | Id     | Command               | Action        | Altered   |
-        | 2      |                       | Upgrade       | 2         |
-        | 1      |                       | Install       | 2         |
+        | Id     | Command               | Action | Altered   |
+        | 2      | update                |        | 4         |
+        | 1      | install wget flac     |        | 2         |
      Then I execute dnf with args "history undo 2"
      Then the exit code is 1
      And Transaction is empty
      And stderr is
      """
-     Error: The following problems occurred while running a transaction:
-       Cannot find rpm nevra "flac-1.3.2-8.fc29.x86_64".
-       Cannot find rpm nevra "wget-1.19.5-5.fc29.x86_64".
+     Failed to resolve the transaction:
+     Cannot perform Install action, no match for: flac-1.3.2-8.fc29.x86_64.
+     Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
+     You can try to add to command line:
+       --skip-unavailable to skip unavailable packages
      """
 
 
@@ -96,9 +99,8 @@ Scenario: Missing packages are skipped if --skip-unavailable is specified
      And Transaction is empty
      And stderr is
      """
-     Warning, the following problems occurred while running a transaction:
-       Cannot find rpm nevra "flac-1.3.2-8.fc29.x86_64".
-       Cannot find rpm nevra "wget-1.19.5-5.fc29.x86_64".
+     Cannot perform Install action, no match for: flac-1.3.2-8.fc29.x86_64.
+     Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
      """
 
 
@@ -108,8 +110,11 @@ Scenario: Undo a transaction with a package that is no longer available
    Then the exit code is 1
     And stderr is
     """
-    Error: The following problems occurred while running a transaction:
-      Cannot find rpm nevra "filesystem-3.9-2.fc29.x86_64".
+    Failed to resolve the transaction:
+    Cannot perform Remove action because 'filesystem-3.9-2.fc29.x86_64' matches only excluded packages.
+    Problem: installed package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed
+      - conflicting requests
+      - problem with installed package
     """
 
 
@@ -119,31 +124,32 @@ Scenario: Undoing a transaction with Reason Change
   Given I successfully execute dnf with args "install filesystem"
    Then History is following
         | Id     | Command               | Action        | Altered   |
-        | 1      | install filesystem    | Install       | 2         |
+        | 1      | install filesystem    |               | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | user            |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
-   When I execute dnf with args "mark group filesystem"
+        | filesystem-3.9-2.fc29.x86_64 | User            |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
+   When I execute dnf with args "mark weak filesystem"
+   Then the exit code is 0
    Then History is following
-        | Id     | Command               | Action        | Altered   |
-        | 2      |                       | Reason Change | 1         |
-        | 1      | install filesystem    | Install       | 2         |
+        | Id     | Command              | Action | Altered   |
+        | 2      | mark weak filesystem |        | 1         |
+        | 1      | install filesystem   |        | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | group           |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
+        | filesystem-3.9-2.fc29.x86_64 | Weak Dependency |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
    When I execute dnf with args "history undo last"
    Then the exit code is 0
     And History is following
-        | Id     | Command               | Action        | Altered   |
-        | 3      |                       | Reason Change | 1         |
-        | 2      |                       | Reason Change | 1         |
-        | 1      |                       | Install       | 2         |
+        | Id     | Command              | Action | Altered   |
+        | 3      | history undo last    |        | 1         |
+        | 2      | mark weak filesystem |        | 1         |
+        | 1      | install filesystem   |        | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | user            |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
+        | filesystem-3.9-2.fc29.x86_64 | User            |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
 
 
 @bz2010259
@@ -152,68 +158,103 @@ Scenario: Undoing an older transaction with Reason Change
   Given I successfully execute dnf with args "install filesystem"
    Then History is following
         | Id     | Command               | Action        | Altered   |
-        | 1      | install filesystem    | Install       | 2         |
+        | 1      | install filesystem    |               | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | user            |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
-   When I execute dnf with args "mark group filesystem"
+        | filesystem-3.9-2.fc29.x86_64 | User            |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
+   When I execute dnf with args "mark weak filesystem"
    Then History is following
         | Id     | Command               | Action        | Altered   |
-        | 2      |                       | Reason Change | 1         |
-        | 1      | install filesystem    | Install       | 2         |
+        | 2      | mark weak filesystem  |               | 1         |
+        | 1      | install filesystem    |               | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | group           |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
+        | filesystem-3.9-2.fc29.x86_64 | Weak Dependency |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
    When I execute dnf with args "install wget"
    Then the exit code is 0
    When I execute dnf with args "history undo last-1"
    Then the exit code is 0
     And History is following
-        | Id     | Command               | Action        | Altered   |
-        | 4      |                       | Reason Change | 1         |
-        | 3      |                       | Install       | 1         |
-        | 2      |                       | Reason Change | 1         |
-        | 1      |                       | Install       | 2         |
+        | Id     | Command               | Action | Altered   |
+        | 4      | history undo last-1   |        | 1         |
+        | 3      | install wget          |        | 1         |
+        | 2      | mark weak filesystem  |        | 1         |
+        | 1      | install filesystem    |        | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | user            |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
-        | wget-1.19.5-5.fc29.x86_64    | user            |
+        | filesystem-3.9-2.fc29.x86_64 | User            |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
+        | wget-1.19.5-5.fc29.x86_64    | User            |
 
 
+@xfail
 @bz2010259
 @bz2053014
 Scenario: Undoing a transaction range with Reason Change
   Given I successfully execute dnf with args "install filesystem"
    Then History is following
         | Id     | Command               | Action        | Altered   |
-        | 1      | install filesystem    | Install       | 2         |
+        | 1      | install filesystem    |               | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | user            |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
-   When I execute dnf with args "mark group filesystem"
+        | filesystem-3.9-2.fc29.x86_64 | User            |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
+   When I execute dnf with args "mark weak filesystem"
    Then History is following
         | Id     | Command               | Action        | Altered   |
-        | 2      |                       | Reason Change | 1         |
-        | 1      | install filesystem    | Install       | 2         |
+        | 2      | mark weak filesystem  |               | 1         |
+        | 1      | install filesystem    |               | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | group           |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
+        | filesystem-3.9-2.fc29.x86_64 | Weak Dependency |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
    When I execute dnf with args "install wget"
    Then the exit code is 0
    When I execute dnf with args "history rollback 1"
    Then the exit code is 0
     And History is following
-        | Id     | Command               | Action        | Altered   |
-        | 4      |                       | C, E          | 2         |
-        | 3      |                       | Install       | 1         |
-        | 2      |                       | Reason Change | 1         |
-        | 1      |                       | Install       | 2         |
+        | Id     | Command              | Action | Altered   |
+        | 4      | history rollback 1   |        | 2         |
+        | 3      | install wget         |        | 1         |
+        | 2      | mark weak filesystem |        | 1         |
+        | 1      | install filesystem   |        | 2         |
     And package reasons are
         | Package                      | Reason          |
-        | filesystem-3.9-2.fc29.x86_64 | user            |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
+        | filesystem-3.9-2.fc29.x86_64 | User            |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
+
+
+Scenario: Undo a downgrade transaction
+  Given I use repository "dnf-ci-fedora-updates"
+    And I successfully execute dnf with args "install wget"
+    And I successfully execute dnf with args "downgrade wget"
+   When I execute dnf with args "history undo last"
+   Then the exit code is 0
+    And Transaction is following
+        | Action  | Package                     |
+        | upgrade | wget-0:1.19.6-5.fc29.x86_64 |
+    And stderr is
+    """
+    Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
+    """
+
+
+Scenario: Undo an upgrade transaction with --skip-unavailable where the orignal package is not available
+  Given I successfully execute dnf with args "install wget"
+    And I use repository "dnf-ci-fedora-updates"
+    And I successfully execute dnf with args "upgrade wget"
+    And I drop repository "dnf-ci-fedora"
+   When I execute dnf with args "history undo last --skip-unavailable"
+   Then the exit code is 0
+    And Transaction is empty
+    And stdout is
+    """
+    <REPOSYNC>
+    Nothing to do.
+    """
+    And stderr is
+    """
+    Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
+    """

--- a/dnf-behave-tests/dnf/history-view.feature
+++ b/dnf-behave-tests/dnf/history-view.feature
@@ -18,12 +18,12 @@ Scenario: List userinstalled packages
         | install-weak  | flac-0:1.3.2-8.fc29.x86_64                |
     And package reasons are
         | Package                      | Reason          |
-        | abcde-2.9.2-1.fc29.noarch    | user            |
-        | basesystem-11-6.fc29.noarch  | user            |
-        | filesystem-3.9-2.fc29.x86_64 | dependency      |
-        | flac-1.3.2-8.fc29.x86_64     | weak-dependency |
-        | setup-2.12.1-1.fc29.noarch   | dependency      |
-        | wget-1.19.5-5.fc29.x86_64    | dependency      |
+        | abcde-2.9.2-1.fc29.noarch    | User            |
+        | basesystem-11-6.fc29.noarch  | User            |
+        | filesystem-3.9-2.fc29.x86_64 | Dependency      |
+        | flac-1.3.2-8.fc29.x86_64     | Weak Dependency |
+        | setup-2.12.1-1.fc29.noarch   | Dependency      |
+        | wget-1.19.5-5.fc29.x86_64    | Dependency      |
 
 
 @dnf5

--- a/dnf-behave-tests/dnf/installonly.feature
+++ b/dnf-behave-tests/dnf/installonly.feature
@@ -185,7 +185,7 @@ Scenario: Do not autoremove kernel after upgrade with --best
    When I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/kernel-core-4.18.16-300.fc29.x86_64.rpm"
    Then package reasons are
         | Package                                | Reason          |
-        | kernel-core-4.18.16-300.fc29.x86_64    | unknown         |
+        | kernel-core-4.18.16-300.fc29.x86_64    | External User   |
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade --best"
    Then the exit code is 0
@@ -193,11 +193,10 @@ Scenario: Do not autoremove kernel after upgrade with --best
         | Action        | Package                               |
         | install       | kernel-core-0:4.19.15-300.fc29.x86_64 |
         | unchanged     | kernel-core-0:4.18.16-300.fc29.x86_64 |
-  #  Also valid result can be unknown reason
     And package reasons are
         | Package                                | Reason          |
-        | kernel-core-4.18.16-300.fc29.x86_64    | unknown         |
-        | kernel-core-4.19.15-300.fc29.x86_64    | unknown         |
+        | kernel-core-4.18.16-300.fc29.x86_64    | External User   |
+        | kernel-core-4.19.15-300.fc29.x86_64    | External User   |
     And package state is
         | package                             | reason        | from_repo             |
         | kernel-core-4.19.15-300.fc29.x86_64 | External User | dnf-ci-fedora-updates |
@@ -216,7 +215,7 @@ Scenario: Do not autoremove kernel after upgrade with --no-best
    When I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/kernel-core-4.18.16-300.fc29.x86_64.rpm"
    Then package reasons are
         | Package                                | Reason          |
-        | kernel-core-4.18.16-300.fc29.x86_64    | unknown         |
+        | kernel-core-4.18.16-300.fc29.x86_64    | External User   |
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade --no-best"
    Then the exit code is 0
@@ -227,8 +226,8 @@ Scenario: Do not autoremove kernel after upgrade with --no-best
   #  Also valid result can be unknown reason
     And package reasons are
         | Package                                | Reason          |
-        | kernel-core-4.18.16-300.fc29.x86_64    | unknown         |
-        | kernel-core-4.19.15-300.fc29.x86_64    | unknown         |
+        | kernel-core-4.18.16-300.fc29.x86_64    | External User   |
+        | kernel-core-4.19.15-300.fc29.x86_64    | External User   |
     And package state is
         | package                             | reason        | from_repo             |
         | kernel-core-4.19.15-300.fc29.x86_64 | External User | dnf-ci-fedora-updates |
@@ -260,8 +259,8 @@ Scenario: Do not remove or change reason after remove of one of installonly pack
    Then the exit code is 0
     And package reasons are
         | Package                                | Reason          |
-        | kernel-core-4.18.16-300.fc29.x86_64    | user            |
-        | kernel-core-4.19.15-300.fc29.x86_64    | user            |
+        | kernel-core-4.18.16-300.fc29.x86_64    | User            |
+        | kernel-core-4.19.15-300.fc29.x86_64    | User            |
     And package state is
         | package                             | reason | from_repo             |
         | kernel-core-4.18.16-300.fc29.x86_64 | User   | dnf-ci-fedora         |
@@ -277,7 +276,7 @@ Scenario: Do not remove or change reason after remove of one of installonly pack
         | unchanged     | kernel-core-0:4.18.16-300.fc29.x86_64 |
     And package reasons are
         | Package                                | Reason          |
-        | kernel-core-4.18.16-300.fc29.x86_64    | user            |
+        | kernel-core-4.18.16-300.fc29.x86_64    | User            |
     And package state is
         | package                             | reason | from_repo             |
         | kernel-core-4.18.16-300.fc29.x86_64 | User   | dnf-ci-fedora         |
@@ -295,8 +294,8 @@ Scenario: Keep reason for installonly packages
 
     And package reasons are
         | Package                                | Reason          |
-        | kernel-core-4.18.16-300.fc29.x86_64    | unknown         |
-        | kernel-core-4.19.15-300.fc29.x86_64    | unknown         |
+        | kernel-core-4.18.16-300.fc29.x86_64    | External User   |
+        | kernel-core-4.19.15-300.fc29.x86_64    | External User   |
   When I execute dnf with args "remove kernel-core-0:4.19.15-300.fc29.x86_64"
    Then the exit code is 0
     And Transaction is following
@@ -305,7 +304,7 @@ Scenario: Keep reason for installonly packages
         | unchanged     | kernel-core-0:4.18.16-300.fc29.x86_64 |
     And package reasons are
         | Package                                | Reason          |
-        | kernel-core-4.18.16-300.fc29.x86_64    | unknown         |
+        | kernel-core-4.18.16-300.fc29.x86_64    | External User   |
     And package state is
         | package | reason | from_repo |
     And dnf5 transaction items for transaction "last" are

--- a/dnf-behave-tests/dnf/module/install-package-ursine.feature
+++ b/dnf-behave-tests/dnf/module/install-package-ursine.feature
@@ -32,7 +32,7 @@ Scenario: I can't reinstall installed non-modular content which is masked by act
     And I successfully execute dnf with args "module enable DnfCiModuleNoDefaults:stable"
    When I execute dnf with args "reinstall wget"
    Then the exit code is 1
-    And stderr contains "Packages for argument 'wget' installed and available, but in a different version => cannot reinstall"
+    And stderr contains "Installed packages for argument 'wget' are not available in repositories in the same version, available versions: wget-1.18.5-5.module.x86_64, cannot reinstall."
 
 
 Scenario: I can remove installed non-modular content

--- a/dnf-behave-tests/dnf/steps/history.py
+++ b/dnf-behave-tests/dnf/steps/history.py
@@ -144,13 +144,9 @@ def step_impl(context, spec=""):
 
 @behave.then('package reasons are')
 def step_impl(context):
-    # we only do the check for dnf4
-    if hasattr(context, "dnf5_mode") and context.dnf5_mode:
-        return
-
     check_context_table(context, ["Package", "Reason"])
 
-    cmd = context.dnf.get_cmd(context) + ["repoquery --qf '%{name}-%{evr}.%{arch},%{reason}' --installed"]
+    cmd = context.dnf.get_cmd(context) + ["repoquery --qf '%{name}-%{evr}.%{arch},%{reason}\n' --installed"]
 
     run_in_context(context, " ".join(cmd))
 

--- a/dnf-behave-tests/dnf/steps/history.py
+++ b/dnf-behave-tests/dnf/steps/history.py
@@ -30,14 +30,13 @@ def assert_history_list(context, cmd_stdout):
             # command column in `history list` output is trimmed to limited space
             # to get full command, we need to ask `history info`
             h_info = parsed_history_info(context, history['id'])
-            if not table['Command'] in h_info.get('Command Line', ''):
+            if not table['Command'] in h_info.get('Description', ''):
                 return False
         return True
 
     check_context_table(context, ["Id", "Command", "Action", "Altered"])
 
-    stdout_lines = cmd_stdout.splitlines()[2:]
-    history = parse_history_list(stdout_lines)
+    history = parse_history_list(cmd_stdout)
 
     table_idx = 0
     for t_line in context.table:

--- a/dnf-behave-tests/dnf/steps/lib/dnf.py
+++ b/dnf-behave-tests/dnf/steps/lib/dnf.py
@@ -309,11 +309,26 @@ def parse_transaction_table_dnf5(context, lines):
     return result
 
 
-def parse_history_list(lines):
+def parse_history_list(history_out):
+    lines = history_out.splitlines()
+    header = lines[0]
+    history_lines = lines[1:]
+
+    # Depending on the data the history list columns have various widths.
+    # Load column layout (starting indices) based on the header.
+    # The header looks like:
+    # "ID Command line    Date and time     Action(s) Altered"
+    column_indices = [0] # ID column starts at first position
+    column_indices.append(header.find("Command line"))
+    column_indices.append(header.find("Date and time"))
+    column_indices.append(header.find("Action"))
+    column_indices.append(header.find("Altered"))
+
     result = []
     labels = ('_line', 'id', 'command', 'date', 'action', 'altered')
-    for line in lines:
-        result.append(dict(zip(labels, [line] + [col.strip() for col in line.split('|')])))
+    for line in history_lines:
+        parts = [line[i:j].strip() for i, j in zip(column_indices, column_indices[1:] + [None])]
+        result.append(dict(zip(labels, [line] + parts)))
     return result
 
 


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf5/pull/1452 and https://github.com/rpm-software-management/dnf5/pull/1454