### PR TITLE
Adjust to error messages containing repo

### DIFF
--- a/dnf-behave-tests/dnf/broken-dependencies-report.feature
+++ b/dnf-behave-tests/dnf/broken-dependencies-report.feature
@@ -16,10 +16,10 @@ Scenario: Broken dependencies are reported when strict and best options are off
    Then the exit code is 0
     And stderr is
     """
-    Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
-      - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
+    Problem: package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires libpq.so.5()(64bit), but none of the providers can be installed
+      - package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests
-      - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
+      - package postgresql-libs-9.6.5-1.fc29.x86_64 from dnf-ci-fedora is filtered out by exclude filtering
     """
     And Transaction is following
         | Action                | Package                           |
@@ -33,10 +33,10 @@ Scenario: Broken dependencies are reported when strict option is off and best op
    Then the exit code is 0
     And stderr is
     """
-    Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
-      - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
+    Problem: package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires libpq.so.5()(64bit), but none of the providers can be installed
+      - package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests
-      - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
+      - package postgresql-libs-9.6.5-1.fc29.x86_64 from dnf-ci-fedora is filtered out by exclude filtering
     """
     And Transaction is following
         | Action                | Package                           |
@@ -50,10 +50,10 @@ Scenario: Broken dependencies are reported when skip-broken and best options are
    Then the exit code is 0
     And stderr is
     """
-    Problem: package postgresql-9.6.5-1.fc29.x86_64 requires libpq.so.5()(64bit), but none of the providers can be installed
-      - package postgresql-9.6.5-1.fc29.x86_64 requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
+    Problem: package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires libpq.so.5()(64bit), but none of the providers can be installed
+      - package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests
-      - package postgresql-libs-9.6.5-1.fc29.x86_64 is filtered out by exclude filtering
+      - package postgresql-libs-9.6.5-1.fc29.x86_64 from dnf-ci-fedora is filtered out by exclude filtering
     """
     And Transaction is following
         | Action                | Package                           |

--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -124,7 +124,15 @@ Scenario: Install and remove group with excluded package dependency
     And I use repository "dnf-ci-fedora"
    When I execute dnf with args "group install --exclude=setup dnf-ci-testgroup"
    Then the exit code is 1
-    And stderr contains "Problem: package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed"
+    And stderr is
+    """
+    Failed to resolve the transaction:
+    Problem: package filesystem-3.9-2.fc29.x86_64 from dnf-ci-fedora requires setup, but none of the providers can be installed
+      - conflicting requests
+      - package setup-2.12.1-1.fc29.noarch from dnf-ci-fedora is filtered out by exclude filtering
+    You can try to add to command line:
+      --skip-broken to skip uninstallable packages
+    """
 
 
 @dnf5

--- a/dnf-behave-tests/dnf/distro-sync.feature
+++ b/dnf-behave-tests/dnf/distro-sync.feature
@@ -182,9 +182,9 @@ Scenario: distro-sync all with a broken dependency and without best
     And stderr is
     """
     Failed to resolve the transaction:
-    Problem: package labirinto-2.0-1.noarch requires labirinto-libs = 2.0-1, but none of the providers can be installed
+    Problem: installed package labirinto-2.0-1.noarch requires labirinto-libs = 2.0-1, but none of the providers can be installed
       - labirinto-libs-2.0-1.noarch does not belong to a distupgrade repository
-      - problem with installed package 
+      - problem with installed package
     You can try to add to command line:
       --skip-broken to skip uninstallable packages
     """

--- a/dnf-behave-tests/dnf/download-binary.feature
+++ b/dnf-behave-tests/dnf/download-binary.feature
@@ -41,9 +41,9 @@ Scenario: Error when failed to resolve dependencies
     Then stderr is
         """
         Failed to resolve the transaction:
-        Problem: package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed
+        Problem: package filesystem-3.9-2.fc29.x86_64 from dnf-ci-fedora requires setup, but none of the providers can be installed
           - conflicting requests
-          - package setup-2.12.1-1.fc29.noarch is filtered out by exclude filtering
+          - package setup-2.12.1-1.fc29.noarch from dnf-ci-fedora is filtered out by exclude filtering
         """
    Then the exit code is 1
 

--- a/dnf-behave-tests/dnf/install-dependencies.feature
+++ b/dnf-behave-tests/dnf/install-dependencies.feature
@@ -14,8 +14,13 @@ Scenario: Best candidates have conflicting dependencies
         | install-dep   | lib-0:1.0-1.fc29.x86_64           |
         | conflict      | lib-0:2.0-1.fc29.x86_64           |
         | broken        | foo-0:2.0-1.fc29.x86_64           |
-    And stderr contains "cannot install both lib-.\.0-1\.fc29\.x86_64 and lib-.\.0-1\.fc29\.x86_64"
-    And stderr contains "package foo-2.0-1.fc29.x86_64 requires lib-2.0, but none of the providers can be installed"
-    And stderr contains "package bar-1.0-1.fc29.x86_64 requires lib-1.0, but none of the providers can be installed"
-    And stderr contains "cannot install the best candidate for the job"
-    And stderr contains "conflicting requests"
+    And stderr is
+    """
+    Problem: cannot install both lib-2.0-1.fc29.x86_64 from install-dependencies and lib-1.0-1.fc29.x86_64 from install-dependencies
+      - package foo-2.0-1.fc29.x86_64 from install-dependencies requires lib-2.0, but none of the providers can be installed
+      - package bar-1.0-1.fc29.x86_64 from install-dependencies requires lib-1.0, but none of the providers can be installed
+      - cannot install the best candidate for the job
+      - conflicting requests
+
+    Warning: skipped PGP checks for 3 package(s).
+    """

--- a/dnf-behave-tests/dnf/install-exclude.feature
+++ b/dnf-behave-tests/dnf/install-exclude.feature
@@ -18,9 +18,9 @@ Scenario: Install an RPM that requires excluded RPM
     And stderr is
     """
     Failed to resolve the transaction:
-    Problem: package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed
+    Problem: package filesystem-3.9-2.fc29.x86_64 from dnf-ci-fedora requires setup, but none of the providers can be installed
       - conflicting requests
-      - package setup-2.12.1-1.fc29.noarch is filtered out by exclude filtering
+      - package setup-2.12.1-1.fc29.noarch from dnf-ci-fedora is filtered out by exclude filtering
     You can try to add to command line:
       --skip-broken to skip uninstallable packages
     """

--- a/dnf-behave-tests/dnf/install-fails.feature
+++ b/dnf-behave-tests/dnf/install-fails.feature
@@ -5,8 +5,8 @@ Feature: Installing attemps fail
 Scenario: Report all missing dependencies
    Given I use repository "dnf-ci-thirdparty"
     When I execute dnf with args "install SuperRipper anitras-dance"
-    Then stderr contains "nothing provides abcde needed by SuperRipper-1.0-1.x86_64"
-    Then stderr contains "nothing provides nodejs needed by anitras-dance-1.0-1.x86_64"
+    Then stderr contains "nothing provides abcde needed by SuperRipper-1.0-1.x86_64 from dnf-ci-thirdparty"
+    Then stderr contains "nothing provides nodejs needed by anitras-dance-1.0-1.x86_64 from dnf-ci-thirdparty"
 
 @bz1599774
 Scenario: Report error when installing empty file

--- a/dnf-behave-tests/dnf/install-remove.feature
+++ b/dnf-behave-tests/dnf/install-remove.feature
@@ -116,7 +116,7 @@ Scenario: Install remove package that requires version >=
 Scenario: Install remove package that requires version >=, not satisfiable
    When I execute dnf with args "install mate"
    Then the exit code is 1
-    And stderr contains "nothing provides water >= 2 needed by mate-1.0-1.x86_64"
+    And stderr contains "nothing provides water >= 2 needed by mate-1.0-1.x86_64 from dnf-ci-install-remove"
 
 
 # both coffee and tea require water

--- a/dnf-behave-tests/dnf/obsoletes.feature
+++ b/dnf-behave-tests/dnf/obsoletes.feature
@@ -308,7 +308,7 @@ Scenario: Both packages are installed when group contains both obsoleter and obs
     And stderr is
     """
     Failed to resolve the transaction:
-    Problem: package PackageD-2.0-1.x86_64 obsoletes PackageC < 2.0 provided by PackageC-1.0-1.x86_64
+    Problem: package PackageD-2.0-1.x86_64 from dnf-ci-obsoletes obsoletes PackageC < 2.0 provided by PackageC-1.0-1.x86_64 from dnf-ci-obsoletes
       - cannot install the best candidate for the job
       - conflicting requests
     You can try to add to command line:

--- a/dnf-behave-tests/dnf/protect-running-kernel.feature
+++ b/dnf-behave-tests/dnf/protect-running-kernel.feature
@@ -70,8 +70,9 @@ Scenario: Running kernel is protected against removal as conflict
     And stderr is
         """
         Failed to resolve the transaction:
-        Problem: problem with installed package 
-          - package dnf-ci-conflict-1.0-1.x86_64 conflicts with dnf-ci-kernel = 1.0-1 provided by dnf-ci-kernel-1.0-1.x86_64
+        Problem: problem with installed package
+          - installed package dnf-ci-kernel-1.0-1.x86_64 conflicts with dnf-ci-kernel = 1.0-1 provided by dnf-ci-conflict-1.0-1.x86_64 from protect-running-kernel
+          - package dnf-ci-conflict-1.0-1.x86_64 from protect-running-kernel conflicts with dnf-ci-kernel = 1.0-1 provided by dnf-ci-kernel-1.0-1.x86_64 from protect-running-kernel
           - conflicting requests
         You can try to add to command line:
           --skip-broken to skip uninstallable packages

--- a/dnf-behave-tests/dnf/resolve-hints.feature
+++ b/dnf-behave-tests/dnf/resolve-hints.feature
@@ -53,7 +53,7 @@ Scenario: --no-best is hinted if the best candidate cannot be installed
     Failed to resolve the transaction:
     No match for argument: DoesNotExist
     Problem: cannot install the best candidate for the job
-      - nothing provides DoesNotExist needed by NoBest-2.0-1.noarch
+      - nothing provides DoesNotExist needed by NoBest-2.0-1.noarch from resolve-hints
     You can try to add to command line:
       --skip-unavailable to skip unavailable packages
       --no-best to not limit the transaction to the best candidates
@@ -68,7 +68,7 @@ Scenario: --no-best is not printed if the option is already present
     Failed to resolve the transaction:
     No match for argument: DoesNotExist
     Problem: cannot install the best candidate for the job
-      - nothing provides DoesNotExist needed by NoBest-2.0-1.noarch
+      - nothing provides DoesNotExist needed by NoBest-2.0-1.noarch from resolve-hints
     You can try to add to command line:
       --skip-unavailable to skip unavailable packages
     """
@@ -81,9 +81,9 @@ Scenario: --allowerasing is hinted on attempt to install conflicting packages
     """
     Failed to resolve the transaction:
     No match for argument: DoesNotExist
-    Problem: problem with installed package 
-      - package ConflictingOne-1.0-1.noarch conflicts with ConflictingTwo provided by ConflictingTwo-1.0-1.noarch
-      - package ConflictingTwo-1.0-1.noarch conflicts with ConflictingOne provided by ConflictingOne-1.0-1.noarch
+    Problem: problem with installed package
+      - installed package ConflictingOne-1.0-1.noarch conflicts with ConflictingTwo provided by ConflictingTwo-1.0-1.noarch from resolve-hints
+      - package ConflictingOne-1.0-1.noarch from resolve-hints conflicts with ConflictingTwo provided by ConflictingTwo-1.0-1.noarch from resolve-hints
       - conflicting requests
     You can try to add to command line:
       --skip-unavailable to skip unavailable packages
@@ -111,7 +111,7 @@ Scenario: filelists metadata is hinted on missing file dependency
     Failed to resolve the transaction:
     No match for argument: DoesNotExist
     Problem: conflicting requests
-      - nothing provides /var/ProvidesFileDep needed by RequiresFileDep-1.0-1.noarch
+      - nothing provides /var/ProvidesFileDep needed by RequiresFileDep-1.0-1.noarch from resolve-hints
     You can try to add to command line:
       --skip-unavailable to skip unavailable packages
       --setopt=optional_metadata_types=filelists to load additional filelists metadata
@@ -137,7 +137,7 @@ Scenario: --skip-broken is hinted on non-installable package
     Failed to resolve the transaction:
     No match for argument: DoesNotExist
     Problem: conflicting requests
-      - nothing provides DoesNotExist needed by RequirementsUnmet-1.0-1.noarch
+      - nothing provides DoesNotExist needed by RequirementsUnmet-1.0-1.noarch from resolve-hints
     You can try to add to command line:
       --skip-unavailable to skip unavailable packages
       --skip-broken to skip uninstallable packages
@@ -151,7 +151,7 @@ Scenario: --skip-broken is not printed if the option is already present
     Failed to resolve the transaction:
     No match for argument: DoesNotExist
     Problem: conflicting requests
-      - nothing provides DoesNotExist needed by RequirementsUnmet-1.0-1.noarch
+      - nothing provides DoesNotExist needed by RequirementsUnmet-1.0-1.noarch from resolve-hints
     You can try to add to command line:
       --skip-unavailable to skip unavailable packages
     """

--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -35,8 +35,8 @@ Given I use repository "security-upgrade-noarch"
  And stderr is
  """
  Failed to resolve the transaction:
- Problem: cannot install both json-c-2-2.noarch and json-c-2-2.x86_64
-   - package bind-libs-lite-2-2.x86_64 requires libjson-c.so.4()(64bit), but none of the providers can be installed
+ Problem: cannot install both json-c-2-2.x86_64 from security-upgrade-noarch and json-c-2-2.noarch from security-upgrade-noarch
+   - package bind-libs-lite-2-2.x86_64 from security-upgrade-noarch requires libjson-c.so.4()(64bit), but none of the providers can be installed
    - cannot install the best update candidate for package json-c-1-1.x86_64
    - cannot install the best update candidate for package bind-libs-lite-1-1.x86_64
  You can try to add to command line:

--- a/dnf-behave-tests/dnf/upgrade.feature
+++ b/dnf-behave-tests/dnf/upgrade.feature
@@ -134,7 +134,7 @@ Scenario: Upgrade all RPMs from multiple repositories with best=False
     And stderr is
     """
     Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
-      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64
+      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
 
     Warning: skipped PGP checks for 7 package(s).
     """
@@ -166,7 +166,7 @@ Scenario: Upgrade all RPMs from multiple repositories with best=True
     """
     Failed to resolve the transaction:
     Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
-      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64
+      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
     You can try to add to command line:
       --no-best to not limit the transaction to the best candidates
     """
@@ -185,7 +185,7 @@ Scenario: Upgrade all RPMs from multiple repositories with best=True
     And stderr is
     """
     Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
-      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64
+      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
  
     Warning: skipped PGP checks for 7 package(s).
     """
@@ -204,7 +204,7 @@ Scenario: Print information about skipped packages
    Then stderr is
     """
     Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
-      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64
+      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
 
     Warning: skipped PGP checks for 1 package(s).
     """


### PR DESCRIPTION
Solver errors now also include the repository from which the problematic
package originates.

Requires: https://github.com/rpm-software-management/dnf5/pull/1464