### PR TITLE
createrepo_c: account for repo sync messages when checking stdout

### DIFF
--- a/dnf-behave-tests/createrepo_c/bad-packages.feature
+++ b/dnf-behave-tests/createrepo_c/bad-packages.feature
@@ -40,6 +40,7 @@ Given I create symlink "/createrepo_c-ci-packages" to file "/{context.scenario.r
   And I execute "dnf --repofrompath=test,{context.scenario.default_tmp_dir}/ --installroot={context.scenario.default_tmp_dir} --disableplugin='*' --repo test repoquery --provides ampersand-provide-package"
   And stdout is
   """
+  <REPOSYNC>
   ampersand-provide-package = 0.2.1-1.fc29
   ampersand-provide-package(x86-64) = 0.2.1-1.fc29
   font(bpgalgetigpl&gnu)


### PR DESCRIPTION
Sometimes repository synchronization messages can be present in `stdout`.