### PR TITLE
microdnf: test for reinstall of pkg with identical Provide and Conflict

### DIFF
--- a/dnf-behave-tests/dnf/microdnf/reinstall6.feature
+++ b/dnf-behave-tests/dnf/microdnf/reinstall6.feature
@@ -1,0 +1,12 @@
+@no_installroot
+Feature: Reinstall
+
+
+Scenario: Reinstall a pkg that has an identical Provide and a Conflict
+  Given I use repository "reinstall-provides-conflict"
+    And I successfully execute microdnf with args "install hello"
+   When I execute microdnf with args "reinstall hello"
+   Then the exit code is 0
+    And RPMDB Transaction is following
+        | Action        | Package                   |
+        | reinstall     | hello-0:1.0-1.fc29.x86_64 |

--- a/dnf-behave-tests/fixtures/specs/reinstall-provides-conflict/hello-1.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/reinstall-provides-conflict/hello-1.0-1.fc29.spec
@@ -1,0 +1,17 @@
+Name: hello
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Conflicts: hello
+Provides: hello
+
+%description
+Description of a pkg that Provides and Conflicts the same capability.
+
+%files
+
+%changelog


### PR DESCRIPTION
Upstream commit: 2559afc99257e2719a97774a92b9b2be047066d4
For: https://issues.redhat.com/browse/RHEL-1454

@kontura, could you please review this rhel-9.5.0 backport of your upstream commit?