### PR TITLE
Remove --duplicates and --oldinstallonly exit with 0 when nothing to remove

### DIFF
--- a/dnf-behave-tests/dnf/installonly.feature
+++ b/dnf-behave-tests/dnf/installonly.feature
@@ -161,6 +161,21 @@ Scenario: Remove all installonly packages but keep the latest and running kernel
         | unchanged       | kernel-core-0:4.18.16-300.fc29.x86_64   |
 
 
+Scenario: When there are no old installonly packages to be removed, exit with 0
+   When I execute dnf with args "remove --oldinstallonly"
+   Then the exit code is 0
+    And Transaction is empty
+    And stderr is empty
+    And stdout is
+        """
+        <REPOSYNC>
+        No old installonly packages found for removal.
+        Dependencies resolved.
+        Nothing to do.
+        Complete!
+        """
+
+
 @dnf5
 @bz1934499
 @bz1921063

--- a/dnf-behave-tests/dnf/remove-duplicates.feature
+++ b/dnf-behave-tests/dnf/remove-duplicates.feature
@@ -52,3 +52,20 @@ Scenario: Remove a duplicate RPM and reinstall an existing RPM when a copy is av
         | Action        | Package                               |
         | reinstall     | flac-0:1.3.3-3.fc29.x86_64            |
         | obsoleted     | flac-0:1.3.3-1.fc29.x86_64            |
+ 
+
+@RHEL-6424
+Scenario: When there are no duplicates to be removed, exit with 0
+   When I execute dnf with args "remove --duplicates"
+   Then the exit code is 0
+    And Transaction is empty
+    And stderr is empty
+    And stdout is
+        """
+        <REPOSYNC>
+        No duplicated packages found for removal.
+        Dependencies resolved.
+        Nothing to do.
+        Complete!
+        """
+


### PR DESCRIPTION
Upstream commit: b77498d9ddaf1fbf99e04060084a91449bfd1ed5
For: https://issues.redhat.com/browse/RHEL-6424
For: https://github.com/rpm-software-management/dnf/pull/2097

@pkratoch, could you please review this rhel-9.5.0 backport of your commit?