### PR TITLE
Add tests for commands that allows to specify nevra forms

### DIFF
--- a/dnf-behave-tests/dnf/install-provides.feature
+++ b/dnf-behave-tests/dnf/install-provides.feature
@@ -11,6 +11,11 @@ Scenario: Install an RPM by provide that equals to e:v-r
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install-dep   | setup-0:2.12.1-1.fc29.noarch          |
 
+@RHEL-5747
+Scenario: Try to install an RPM by provide when provides should be ignored and only RPM name allowed => FAIL
+  Given I use repository "dnf-ci-fedora"
+   When I execute dnf with args "install-n 'filesystem = 0:3.9-2.fc29'"
+   Then the exit code is 1
 
 @dnf5
 Scenario: Install an RPM by provide that is greater than e:vr

--- a/dnf-behave-tests/dnf/remove-provides.feature
+++ b/dnf-behave-tests/dnf/remove-provides.feature
@@ -37,6 +37,20 @@ Examples:
         | <=            | 0:2.28-9.fc29        |
 
 
+@RHEL-5747
+Scenario Outline: Try to remove an RPM by <provide type> when provides should be ignored and only RPM name allowed => FAIL
+   When I execute dnf with args "remove-n <provide>"
+   Then the exit code is 0
+    And Transaction is empty
+
+Examples:
+        | provide type                        | provide               |
+        | provide                             | 'libm.so.6()(64bit)'  |
+        | file provide                        | /etc/ld.so.conf       |
+        | file provide that is directory      | /var/db               |
+        | file provide containing wildcards   | /etc/ld*.conf         |
+
+
 # @dnf5
 # TODO(nsella) different stdout
 Scenario Outline: Remove an RPM by <provide type>

--- a/dnf-behave-tests/dnf/repoquery/files.feature
+++ b/dnf-behave-tests/dnf/repoquery/files.feature
@@ -25,6 +25,17 @@ Given I use repository "repoquery-files"
       """
 
 
+@RHEL-5747
+Scenario: filter by file in primary.xml but force command only search in rpm names -> empty output
+Given I use repository "repoquery-files"
+ When I execute dnf with args "repoquery-n /usr/bin/a-binary"
+ Then the exit code is 0
+  And stdout is
+      """
+      <REPOSYNC>
+      """
+
+
 @bz2276012
 Scenario: filter by file in filelists.xml
 Given I use repository "repoquery-files"


### PR DESCRIPTION
Commands install, remove, autoremove, and repoquery allows specify nevra forms. When nevra forms is specify, commands should ignore provides and file provides.

Related: https://issues.redhat.com/browse/RHEL-5747

Required by: https://github.com/rpm-software-management/dnf/pull/2098