### PR TITLE
rhel-9.5: Add tests for commands that allows to specify nevra forms

### DIFF
--- a/dnf-behave-tests/dnf/install-provides.feature
+++ b/dnf-behave-tests/dnf/install-provides.feature
@@ -11,6 +11,11 @@ Scenario: Install an RPM by provide that equals to e:v-r
         | install       | filesystem-0:3.9-2.fc29.x86_64        |
         | install-dep   | setup-0:2.12.1-1.fc29.noarch          |
 
+@RHEL-5747
+Scenario: Try to install an RPM by provide when provides should be ignored and only RPM name allowed => FAIL
+  Given I use repository "dnf-ci-fedora"
+   When I execute dnf with args "install-n 'filesystem = 0:3.9-2.fc29'"
+   Then the exit code is 1
 
 @dnf5
 Scenario: Install an RPM by provide that is greater than e:vr

--- a/dnf-behave-tests/dnf/remove-provides.feature
+++ b/dnf-behave-tests/dnf/remove-provides.feature
@@ -37,6 +37,20 @@ Examples:
         | <=            | 0:2.28-9.fc29        |
 
 
+@RHEL-5747
+Scenario Outline: Try to remove an RPM by <provide type> when provides should be ignored and only RPM name allowed => FAIL
+   When I execute dnf with args "remove-n <provide>"
+   Then the exit code is 0
+    And Transaction is empty
+
+Examples:
+        | provide type                        | provide               |
+        | provide                             | 'libm.so.6()(64bit)'  |
+        | file provide                        | /etc/ld.so.conf       |
+        | file provide that is directory      | /var/db               |
+        | file provide containing wildcards   | /etc/ld*.conf         |
+
+
 # @dnf5
 # TODO(nsella) different stdout
 Scenario Outline: Remove an RPM by <provide type>

--- a/dnf-behave-tests/dnf/repoquery/files.feature
+++ b/dnf-behave-tests/dnf/repoquery/files.feature
@@ -1,0 +1,14 @@
+@dnf5
+Feature: Repoquery tests working with files
+
+@RHEL-5747
+Scenario: filter by file in primary.xml but force command only search in rpm names -> empty output
+Given I use repository "repoquery-files"
+ When I execute dnf with args "repoquery-n /usr/bin/a-binary"
+ Then the exit code is 0
+  And stdout is
+      """
+      <REPOSYNC>
+      """
+
+

--- a/dnf-behave-tests/fixtures/specs/repoquery-files/a-1.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-files/a-1.0-1.fc29.spec
@@ -1,0 +1,21 @@
+Name: a
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+a description
+
+%install
+mkdir -p %{buildroot}%{_bindir}
+touch %{buildroot}%{_bindir}/a-binary
+touch %{buildroot}/root-file
+
+%files
+%{_bindir}/a-binary
+/root-file
+
+%changelog


### PR DESCRIPTION
Upstream commit: e0e0c5471f6460bf39920004266c0261a3b83dd6
Upstream commit: b26a015927d427c03ea9a9c85dc92daf9ac6fa43
For: https://github.com/rpm-software-management/dnf/pull/2099
For: https://issues.redhat.com/browse/RHEL-38470

@j-mracek, could you please review this rhel-9.5 backport of your commit?

I'm not sure we should add dnf-behave-tests/dnf/repoquery/files.feature because the whole Feature file is marked with "@dnf5".