### PR TITLE
fileprovides: create fileprovides with already present solv files

### DIFF
--- a/dnf-behave-tests/dnf/fileprovides.feature
+++ b/dnf-behave-tests/dnf/fileprovides.feature
@@ -1,0 +1,16 @@
+@dnf5
+Feature: Adding file provides tests
+
+Scenario: Run repoclosure with already created cache without filelists
+  Given I enable plugin "repoclosure"
+    And I use repository "fileprovides"
+    # We run repoquery --whatprovides to trigger generation of file provides (calling make_provides_ready())
+    # This command doesn't require filelists.xml
+    And I successfully execute dnf with args "repoquery --whatprovides htop"
+    # This command requires filelists.xml
+   When I execute dnf with args "repoclosure"
+   Then the exit code is 0
+   Then stdout is
+   """
+   <REPOSYNC>
+   """

--- a/dnf-behave-tests/fixtures/specs/fileprovides/agua-1.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/fileprovides/agua-1.0-1.fc29.spec
@@ -1,0 +1,19 @@
+Name: agua
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+agua description
+
+%install
+mkdir -p %{buildroot}/a/path/to
+touch %{buildroot}/a/path/to/water
+
+%files
+/a/path/to/water
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/fileprovides/planta-1.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/fileprovides/planta-1.0-1.fc29.spec
@@ -1,0 +1,16 @@
+Name: planta
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Requires:      /a/path/to/water
+
+%description
+planta description
+
+%files
+
+%changelog


### PR DESCRIPTION
Since dnf4 now also conditionally load filelists it ran into the same problem as dnf5 here: For: https://github.com/rpm-software-management/dnf5/issues/520 Backport the test.

For: https://github.com/rpm-software-management/libdnf/pull/1670