### PR TITLE
createrepo_c: fix failing bad-packages.feature test with dnf5

### DIFF
--- a/dnf-behave-tests/createrepo_c/bad-packages.feature
+++ b/dnf-behave-tests/createrepo_c/bad-packages.feature
@@ -37,10 +37,9 @@ Given I create symlink "/createrepo_c-ci-packages" to file "/{context.scenario.r
  When I execute createrepo_c with args "--update ." in "/"
  Then the exit code is 0
   And repodata "/repodata" are consistent
-  And I execute "dnf --repofrompath=test,{context.scenario.default_tmp_dir}/ --installroot={context.scenario.default_tmp_dir} --disableplugin='*' --repo test repoquery --provides ampersand-provide-package"
+  And I execute "dnf -q --repofrompath=test,{context.scenario.default_tmp_dir}/ --installroot={context.scenario.default_tmp_dir} --disableplugin='*' --repo test repoquery --provides ampersand-provide-package"
   And stdout is
   """
-  <REPOSYNC>
   ampersand-provide-package = 0.2.1-1.fc29
   ampersand-provide-package(x86-64) = 0.2.1-1.fc29
   font(bpgalgetigpl&gnu)


### PR DESCRIPTION
Since dnf5 becaume default in rawhide this test has been failing. The problem is that dnf5 has different `<REPOSYNC>` compared to dnf4 but this test is not tagged `@dnf5` so on rawhide it tried to parse dnf5 `<REPOSYNC>` as if it was from dnf4.

At the same time the test needs to work also on non-rawhide fedoras with dnf4.

Adding `-q` suppresses the `<REPOSYNC>` and it makes the test work with both dnfs.