### PR TITLE
Report conflicts even with removal of protected packages

### DIFF
--- a/dnf-behave-tests/dnf/upgrade-conflicts.feature
+++ b/dnf-behave-tests/dnf/upgrade-conflicts.feature
@@ -1,0 +1,18 @@
+@dnf5
+Feature: Upgrade with conflicts
+
+Scenario: Conflicts are reported even if the transaction would involve removal of protected packages
+ Given I use repository "upgrade-conflicts"
+   And I successfully execute dnf with args "install diamond-1-1 spade-1-1"
+  When I execute dnf with args "upgrade --setopt=protected_packages=diamond"
+  Then stderr is
+   """
+   Failed to resolve the transaction:
+   Problem: installed package diamond-1-1.x86_64 requires spade = 1-1, but none of the providers can be installed
+     - cannot install both spade-2-1.x86_64 from upgrade-conflicts and spade-1-1.x86_64 from @System
+     - cannot install both spade-2-1.x86_64 from upgrade-conflicts and spade-1-1.x86_64 from upgrade-conflicts
+     - cannot install the best update candidate for package spade-1-1.x86_64
+     - cannot install the best update candidate for package diamond-1-1.x86_64
+   You can try to add to command line:
+     --no-best to not limit the transaction to the best candidates
+   """

--- a/dnf-behave-tests/fixtures/specs/upgrade-conflicts/diamond-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/upgrade-conflicts/diamond-1-1.spec
@@ -1,0 +1,16 @@
+Name: diamond
+Version: 1
+Release: 1
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Requires: spade = 1-1
+
+%description
+diamond description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/upgrade-conflicts/spade-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/upgrade-conflicts/spade-1-1.spec
@@ -1,0 +1,14 @@
+Name: spade
+Version: 1
+Release: 1
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+spade description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/upgrade-conflicts/spade-2-1.spec
+++ b/dnf-behave-tests/fixtures/specs/upgrade-conflicts/spade-2-1.spec
@@ -1,0 +1,14 @@
+Name: spade
+Version: 2
+Release: 1
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+spade 2 description
+
+%files
+
+%changelog


### PR DESCRIPTION
This is an improvement compared to dnf4 which just reports:
```
Error:
 Problem: The operation would result in removing the following protected packages: diamond
```

https://bugzilla.redhat.com/show_bug.cgi?id=2292620