### PR TITLE
Enable several tests for debuginfo-install command

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/debuginfo-install.feature
+++ b/dnf-behave-tests/dnf/plugins-core/debuginfo-install.feature
@@ -3,19 +3,19 @@ Feature: Tests for the debuginfo-install plugin
 Background:
 Given I use repository "debuginfo-install"
 
+@dnf5
 @bz1585137
 Scenario: reports an error for a non-existent package
  When I execute dnf with args "debuginfo-install non-existent-package"
  Then the exit code is 1
-  And stdout is
-      """
-      <REPOSYNC>
-      No match for argument: non-existent-package
-      """
   And stderr is
       """
-      Error: Unable to find a match: non-existent-package
+      Failed to resolve the transaction:
+      No match for argument: non-existent-package
+      You can try to add to command line:
+        --skip-unavailable to skip unavailable packages
       """
+
 
 Scenario: reports an error for a package without debuginfo
  When I execute dnf with args "debuginfo-install nodebug"
@@ -30,6 +30,7 @@ Scenario: reports an error for a package without debuginfo
       Complete!
       """
 
+@dnf5
 Scenario: installs latest version debuginfo for a not-installed package
  When I execute dnf with args "debuginfo-install foo"
  Then the exit code is 0
@@ -38,6 +39,7 @@ Scenario: installs latest version debuginfo for a not-installed package
       | install       | foo-debuginfo-0:2.0-1.x86_64              |
       | install       | foo-debugsource-0:2.0-1.x86_64            |
 
+@dnf5
 @bz1586059 @bz1629412
 Scenario: installs the same version of debuginfo for an installed package
 Given I successfully execute dnf with args "install foo-1.0"
@@ -48,6 +50,7 @@ Given I successfully execute dnf with args "install foo-1.0"
       | install       | foo-debuginfo-0:1.0-1.x86_64              |
       | install       | foo-debugsource-0:1.0-1.x86_64            |
 
+@dnf5
 Scenario: with a -debugsource (or -debuginfo) package as an argument, installed version is not respected
 Given I successfully execute dnf with args "install foo-1.0"
  When I execute dnf with args "debuginfo-install foo-debugsource"
@@ -56,6 +59,7 @@ Given I successfully execute dnf with args "install foo-1.0"
       | Action        | Package                                   |
       | install       | foo-debugsource-0:2.0-1.x86_64            |
 
+@dnf5
 @bz1586059 @bz1629412
 Scenario: installs the requested version of debuginfo even if a different base package is installed
 Given I successfully execute dnf with args "install foo-2.0"
@@ -66,6 +70,7 @@ Given I successfully execute dnf with args "install foo-2.0"
       | install       | foo-debuginfo-0:1.0-1.x86_64              |
       | install       | foo-debugsource-0:1.0-1.x86_64            |
 
+@dnf5
 @bz1586059 @bz1629412
 Scenario: installs the requested version of debuginfo (through a provide) even if a different base package is installed
 Given I successfully execute dnf with args "install baz-1.0"
@@ -76,6 +81,7 @@ Given I successfully execute dnf with args "install baz-1.0"
       | install       | baz-debuginfo-0:2.0-1.x86_64              |
       | install       | baz-debugsource-0:2.0-1.x86_64            |
 
+@dnf5
 Scenario: installs debuginfo when a -debuginfo package is provided
  When I execute dnf with args "debuginfo-install foo-debuginfo"
  Then the exit code is 0
@@ -83,6 +89,7 @@ Scenario: installs debuginfo when a -debuginfo package is provided
       | Action        | Package                                   |
       | install       | foo-debuginfo-0:2.0-1.x86_64              |
       | install-weak  | foo-debugsource-0:2.0-1.x86_64            |
+
 
 @bz1586059 @bz1629412
 Scenario: can't find the version of debuginfo for an installed package
@@ -99,6 +106,7 @@ Given I successfully execute dnf with args "install bar-2.0"
       Complete!
       """
 
+
 Scenario: can't find the requested version of debuginfo (multilib package, architectures can be mixed up)
  When I execute dnf with args "debuginfo-install baz-1.0"
  Then the exit code is 0
@@ -112,6 +120,7 @@ Scenario: can't find the requested version of debuginfo (multilib package, archi
       Complete!
       """
 
+@dnf5
 Scenario: installs debuginfo with the same (secondary) architecture as the installed package
 Given I successfully execute dnf with args "install baz.i686"
  When I execute dnf with args "debuginfo-install baz"
@@ -121,6 +130,7 @@ Given I successfully execute dnf with args "install baz.i686"
       | install       | baz-debuginfo-0:2.0-1.i686                |
       | install       | baz-debugsource-0:2.0-1.i686              |
 
+@dnf5
 Scenario: installs debuginfo for multiple installed architectures
 Given I successfully execute dnf with args "install baz.i686 baz.x86_64"
  When I execute dnf with args "debuginfo-install baz"
@@ -132,6 +142,7 @@ Given I successfully execute dnf with args "install baz.i686 baz.x86_64"
       | install       | baz-debugsource-0:2.0-1.i686              |
       | install       | baz-debugsource-0:2.0-1.x86_64            |
 
+@dnf5
 Scenario: installs debuginfo for the latest version of multiple install-only packages
 Given I successfully execute dnf with args "install kernel-1.0 kernel-2.0"
  When I execute dnf with args "debuginfo-install kernel"
@@ -140,6 +151,7 @@ Given I successfully execute dnf with args "install kernel-1.0 kernel-2.0"
       | Action        | Package                                   |
       | install       | kernel-debuginfo-0:2.0-1.x86_64           |
       | install       | kernel-debugsource-0:2.0-1.x86_64         |
+
 
 Scenario: multiple packages, a glob that doesn't find debuginfo for the installed version
 Given I successfully execute dnf with args "install foo-1.0 bar-2.0"
@@ -156,6 +168,7 @@ Given I successfully execute dnf with args "install foo-1.0 bar-2.0"
       | install       | foo-debuginfo-0:1.0-1.x86_64              |
       | install       | foo-debugsource-0:1.0-1.x86_64            |
 
+@dnf5
 Scenario: a glob with version that overrides what is installed
 Given I successfully execute dnf with args "install foo-1.0 bar-2.0"
  When I execute dnf with args "debuginfo-install foo ba*-1.0"
@@ -167,6 +180,7 @@ Given I successfully execute dnf with args "install foo-1.0 bar-2.0"
       | install       | foo-debuginfo-0:1.0-1.x86_64              |
       | install       | foo-debugsource-0:1.0-1.x86_64            |
 
+@dnf5
 Scenario: a package with a glob in version that overrides what is installed
 Given I successfully execute dnf with args "install bar-2.0"
  When I execute dnf with args "debuginfo-install bar-1.*"
@@ -176,6 +190,7 @@ Given I successfully execute dnf with args "install bar-2.0"
       | install       | bar-debuginfo-0:1.0-1.x86_64              |
       | install       | bar-debugsource-0:1.0-1.x86_64            |
 
+@dnf5
 @bz1586084
 Scenario: packages are upgraded according to the installed version of the base package
 Given I successfully execute dnf with args "install bar-1.0"
@@ -191,6 +206,7 @@ Given I successfully execute dnf with args "install bar-3.0"
       | Action        | Package                                   |
       | upgrade       | bar-debuginfo-0:3.0-1.x86_64              |
       | upgrade       | bar-debugsource-0:3.0-1.x86_64            |
+
 
 @bz1586084
 Scenario: debuginfo is upgraded according to the installed version of the base package, debugsource is not found
@@ -208,6 +224,7 @@ Given I successfully execute dnf with args "install bar-4.0"
       | Action        | Package                                   |
       | upgrade       | bar-debuginfo-0:4.0-1.x86_64              |
 
+@dnf5
 @bz1532378
 Scenario: debugsource is installed even if debuginfo is present on the system
 Given I successfully execute dnf with args "install --setopt=install_weak_deps=False foo-debuginfo"
@@ -217,7 +234,7 @@ Given I successfully execute dnf with args "install --setopt=install_weak_deps=F
       | Action        | Package                                   |
       | install       | foo-debugsource-0:2.0-1.x86_64            |
 
-
+@dnf5
 Scenario: installs latest version debuginfo of parent package for a subpackage
  When I execute dnf with args "debuginfo-install foo-subpackage"
  Then the exit code is 0
@@ -226,6 +243,7 @@ Scenario: installs latest version debuginfo of parent package for a subpackage
       | install       | foo-debuginfo-0:2.0-1.x86_64              |
       | install       | foo-debugsource-0:2.0-1.x86_64            |
 
+@dnf5
 @bz1586059 @bz1629412
 Scenario: installs version of debuginfo for parent package of an installed subpackage
 Given I successfully execute dnf with args "install foo-subpackage-1.0"
@@ -236,6 +254,7 @@ Given I successfully execute dnf with args "install foo-subpackage-1.0"
       | install       | foo-debuginfo-0:1.0-1.x86_64              |
       | install       | foo-debugsource-0:1.0-1.x86_64            |
 
+@dnf5
 @bz1586059 @bz1629412
 Scenario: installs version of debuginfo for parent package of an installed subpackage
 Given I successfully execute dnf with args "install foo-subpackage-1.0"


### PR DESCRIPTION
There are remaining 6 scenario that requires additional reporting functionality.