### PR TITLE
Enable `history redo` tests

### DIFF
--- a/dnf-behave-tests/dnf/history-redo-comps.feature
+++ b/dnf-behave-tests/dnf/history-redo-comps.feature
@@ -1,10 +1,11 @@
+@dnf5
 Feature: Transaction history redo - comps
 
 
 Background:
   Given I use repository "dnf-ci-fedora"
     And I use repository "dnf-ci-thirdparty"
-    And I successfully execute dnf with args "group install DNF-CI-Testgroup"
+    And I successfully execute dnf with args "group install dnf-ci-testgroup"
    Then Transaction is following
         | Action        | Package                           |
         | group-install | DNF-CI-Testgroup                  |
@@ -13,8 +14,8 @@ Background:
         | install-dep   | setup-0:2.12.1-1.fc29.noarch      |
         | install-dep   | lame-libs-0:3.100-4.fc29.x86_64   |
     And History is following
-        | Id     | Command                               | Action        | Altered   |
-        | 1      | group install DNF-CI-Testgroup        | Install       | 5         |
+        | Id     | Command                               | Action | Altered   |
+        | 1      | group install dnf-ci-testgroup        |        | 5         |
 
 
 Scenario: Redo a transaction that installed a group
@@ -27,14 +28,14 @@ Scenario: Redo a transaction that installed a group
         | install-group | lame-0:3.100-4.fc29.x86_64        |
         | install-dep   | lame-libs-0:3.100-4.fc29.x86_64   |
     And History is following
-        | Id     | Command                               | Action        | Altered   |
-        | 3      | history redo 1                        | Install       | 3         |
-        | 2      | remove lame                           | Removed       | 2         |
-        | 1      | group install DNF-CI-Testgroup        | Install       | 5         |
+        | Id     | Command                               | Action | Altered   |
+        | 3      | history redo 1                        |        | 3         |
+        | 2      | remove lame                           |        | 2         |
+        | 1      | group install dnf-ci-testgroup        |        | 5         |
 
 
 Scenario: Redo a transaction that removed a group
-  Given I successfully execute dnf with args "group remove DNF-CI-Testgroup"
+  Given I successfully execute dnf with args "group remove dnf-ci-testgroup"
     And I successfully execute dnf with args "install lame"
    When I execute dnf with args "history redo 2"
    Then the exit code is 0
@@ -43,26 +44,29 @@ Scenario: Redo a transaction that removed a group
         | remove        | lame-0:3.100-4.fc29.x86_64        |
         | remove-unused | lame-libs-0:3.100-4.fc29.x86_64   |
     And History is following
-        | Id     | Command                               | Action        | Altered   |
-        | 4      | history redo 2                        | Removed       | 2         |
-        | 3      | install lame                          | Install       | 2         |
-        | 2      | group remove DNF-CI-Testgroup         | Removed       | 5         |
-        | 1      | group install DNF-CI-Testgroup        | Install       | 5         |
+        | Id     | Command                               | Action | Altered   |
+        | 4      | history redo 2                        |        | 2         |
+        | 3      | install lame                          |        | 2         |
+        | 2      | group remove dnf-ci-testgroup         |        | 5         |
+        | 1      | group install dnf-ci-testgroup        |        | 5         |
 
 
 Scenario: Redo a transaction with a missing group
-  Given I drop repository "dnf-ci-thirdparty"
+  Given I successfully execute dnf with args "group remove dnf-ci-testgroup"
+    And I drop repository "dnf-ci-thirdparty"
    When I execute dnf with args "history redo 1"
    Then the exit code is 1
     And stderr is
     """
-    Error: The following problems occurred while running a transaction:
-      Group id 'dnf-ci-testgroup' is not available.
+    Failed to resolve the transaction:
+    No match for argument: dnf-ci-testgroup
+    You can try to add to command line:
+      --skip-unavailable to skip unavailable packages
     """
 
 
 Scenario: Redo a transaction that removed a group and the group is was removed from the system already
-  Given I successfully execute dnf with args "group remove DNF-CI-Testgroup"
+  Given I successfully execute dnf with args "group remove dnf-ci-testgroup"
    When I execute dnf with args "history redo last"
    Then the exit code is 0
     And Transaction is empty
@@ -76,7 +80,7 @@ Scenario: Redo a transaction that installed a group and the group is still on th
         | Action        | Package                           |
         | group-install | DNF-CI-Testgroup                  |
     And History is following
-        | Id     | Command                               | Action        | Altered   |
-        | 2      | history redo last                     | Install       | 1         |
-        | 1      | group install DNF-CI-Testgroup        | Install       | 5         |
+        | Id     | Command                               | Action | Altered   |
+        | 2      | history redo last                     |        | 1         |
+        | 1      | group install dnf-ci-testgroup        |        | 5         |
     And Transaction is empty

--- a/dnf-behave-tests/dnf/history-redo.feature
+++ b/dnf-behave-tests/dnf/history-redo.feature
@@ -1,3 +1,4 @@
+@dnf5
 Feature: Transaction history redo
 
 
@@ -25,10 +26,10 @@ Scenario: Redo last transaction
         | install       | filesystem-0:3.9-2.fc29.x86_64             |
         | install-dep   | setup-0:2.12.1-1.fc29.noarch               |
     And History is following
-        | Id     | Command               | Action        | Altered   |
-        | 3      |                       | Install       | 2         |  
-        | 2      |                       | Removed       | 2         |  
-        | 1      | install filesystem    | Install       | 2         |  
+        | Id     | Command               | Action | Altered   |
+        | 3      |                       |        | 2         |
+        | 2      |                       |        | 2         |
+        | 1      | install filesystem    |        | 2         |
    When I execute dnf with args "history redo last-1"
    Then the exit code is 0
     And Transaction is following
@@ -36,11 +37,11 @@ Scenario: Redo last transaction
         | remove        | filesystem-0:3.9-2.fc29.x86_64             |
         | remove-unused | setup-0:2.12.1-1.fc29.noarch               |
     And History is following
-        | Id     | Command               | Action        | Altered   |
-        | 4      |                       | Removed       | 2         |  
-        | 3      |                       | Install       | 2         |  
-        | 2      |                       | Removed       | 2         |  
-        | 1      |                       | Install       | 2         |  
+        | Id     | Command               | Action | Altered   |
+        | 4      |                       |        | 2         |
+        | 3      |                       |        | 2         |
+        | 2      |                       |        | 2         |
+        | 1      |                       |        | 2         |
 
 
 Scenario: Redo a transaction with a package that is no longer available
@@ -48,8 +49,8 @@ Scenario: Redo a transaction with a package that is no longer available
    Then the exit code is 1
     And stderr is
         """
-        Error: The following problems occurred while running a transaction:
-          Cannot find rpm nevra "filesystem-3.9-2.fc29.x86_64".
+        Failed to resolve the transaction:
+        Cannot perform Install action because 'filesystem-3.9-2.fc29.x86_64' matches only excluded packages.
         """
 
 
@@ -61,8 +62,9 @@ Scenario: Redo a transaction with a package that is no longer available and --sk
         | install-dep   | setup-0:2.12.1-1.fc29.noarch               |
     And stderr is
         """
-        Warning, the following problems occurred while running a transaction:
-          Cannot find rpm nevra "filesystem-3.9-2.fc29.x86_64".
+        Cannot perform Install action because 'filesystem-3.9-2.fc29.x86_64' matches only excluded packages.
+
+        Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora
         """
 
 

--- a/dnf-behave-tests/dnf/history-rollback-env-upgrade.feature
+++ b/dnf-behave-tests/dnf/history-rollback-env-upgrade.feature
@@ -114,8 +114,6 @@ Scenario: Rollback a rollbacked environment upgrade transaction
     """
 
 
-# missing redo command
-@xfail
 @bz2016070
 Scenario: Redo an undo-ed environment upgrade transaction
   Given I execute dnf with args "history undo last"
@@ -128,8 +126,8 @@ Scenario: Redo an undo-ed environment upgrade transaction
         | downgrade              | TestGroup2PackageB-0:1.0-1.x86_64    |
     And History is following
         | Id     | Command                                              | Action | Altered   |
-        | 3      | history undo last                                    |        | 7         |
-        | 2      | group upgrade DNF-CI-RollbackTestEnv                 |        | 7         |
-        | 1      | group install DNF-CI-RollbackTestEnv                 |        | 7         |
+        | 3      | history undo last                                    |        | 8         |
+        | 2      | group upgrade dnf-ci-group-rollback-testenv          |        | 11        |
+        | 1      | group install dnf-ci-group-rollback-testenv          |        | 7         |
    When I execute dnf with args "history redo last"
    Then the exit code is 0

--- a/dnf-behave-tests/dnf/history-rollback-group-upgrade.feature
+++ b/dnf-behave-tests/dnf/history-rollback-group-upgrade.feature
@@ -98,8 +98,6 @@ Scenario: Rollback a rollbacked group upgrade transaction
     """
 
 
-# missing redo command
-@xfail
 @bz2016070
 Scenario: Redo an undo-ed group upgrade transaction
   Given I execute dnf with args "history undo last"
@@ -109,10 +107,10 @@ Scenario: Redo an undo-ed group upgrade transaction
         | downgrade              | TestGroup1PackageA-0:1.0-1.x86_64    |
         | downgrade              | TestGroup1PackageB-0:1.0-1.x86_64    |
     And History is following
-        | Id     | Command                                              | Action        | Altered   |
-        | 3      | history undo last                                    | Downgrade     | 3         |
-        | 2      | group upgrade DNF-CI-RollbackTestGroup1              | Upgrade       | 3         |
-        | 1      | group install DNF-CI-RollbackTestGroup1              | Install       | 3         |
+        | Id     | Command                                              | Action | Altered   |
+        | 3      | history undo last                                    |        | 4         |
+        | 2      | group upgrade dnf-ci-group-rollback-testgroup1       |        | 5         |
+        | 1      | group install dnf-ci-group-rollback-testgroup1       |        | 3         |
    When I execute dnf with args "history redo last"
    Then the exit code is 0
 

--- a/dnf-behave-tests/dnf/transaction-sr/replay.feature
+++ b/dnf-behave-tests/dnf/transaction-sr/replay.feature
@@ -1229,8 +1229,8 @@ Given I successfully execute dnf with args "install bottom-a1-1.0"
       | upgrade     | top-a-1:2.0-1.x86_64     |
   And dnf5 transaction items for transaction "last" are
       | action        | package                  | reason     | repository     |
-      | Upgrade       | top-a-1:2.0-1.x86_64     | User       | transaction-sr |
       | Upgrade       | bottom-a1-0:2.0-1.noarch | User       | transaction-sr |
+      | Upgrade       | top-a-1:2.0-1.x86_64     | User       | transaction-sr |
       | Replaced      | bottom-a1-0:1.0-1.noarch | User       | @System        |
       | Replaced      | top-a-1:1.0-1.x86_64     | User       | @System        |
   And package reasons are


### PR DESCRIPTION
- dnf5 history list doesn't fill in actions: https://github.com/rpm-software-management/dnf5/issues/1448
- There is a change in `Altered` count because dnf4 doesn't count/list `Upgraded` and `Downgraded` actions. dnf5 on the other hand shows (and counts) the `Replaced` action which is their equivalent.

Requires: https://github.com/rpm-software-management/dnf5/pull/1595