### PR TITLE
Add `--json` tests for `repo` and `advisory list` commands  

### DIFF
--- a/dnf-behave-tests/dnf/repo-json.feature
+++ b/dnf-behave-tests/dnf/repo-json.feature
@@ -1,0 +1,199 @@
+@dnf5
+Feature: Repo command with --json option
+
+
+Background: Using repositories dnf-ci-fedora and dnf-ci-thirdparty-updates
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-thirdparty-updates"
+    And I use repository "dnf-ci-fedora-updates" with configuration
+        | key     | value |
+        | enabled | 0     |
+    And I use repository "dnf-ci-thirdparty" with configuration
+        | key     | value |
+        | enabled | 0     |
+
+
+Scenario: Repo info without arguments --json
+   When I execute dnf with args "repo info --json"
+   Then the exit code is 0
+    And stdout json matches
+    """
+    [
+      {
+        "id":"dnf-ci-fedora",
+        "name":"dnf-ci-fedora test repository",
+        "is_enabled":true,
+        "priority":99,
+        "cost":1000,
+        "type":"available",
+        "exclude_pkgs":[],
+        "include_pkgs":[],
+        "timestamp":"*",
+        "metadata_expire":172800,
+        "skip_if_unavailable":false,
+        "repo_file_path":"\/tmp\/dnf_ci_installroot_*\/etc\/yum.repos.d\/dnf-ci-fedora.repo",
+        "base_url":[
+          "file:\/\/\/*\/dnf-behave-tests\/fixtures\/repos\/dnf-ci-fedora"
+        ],
+        "metalink":"",
+        "mirrorlist":"",
+        "gpg_key":[],
+        "repo_gpgcheck":false,
+        "gpgcheck":false,
+        "available_pkgs":289,
+        "pkgs":289,
+        "size":"*",
+        "content_tags":[],
+        "distro_tags":[],
+        "revision":"1550000000",
+        "max_timestamp":"*"
+      },
+      {
+        "id":"dnf-ci-thirdparty-updates",
+        "name":"dnf-ci-thirdparty-updates test repository",
+        "is_enabled":true,
+        "priority":99,
+        "cost":1000,
+        "type":"available",
+        "exclude_pkgs":[],
+        "include_pkgs":[],
+        "timestamp":"*",
+        "metadata_expire":172800,
+        "skip_if_unavailable":false,
+        "repo_file_path":"\/tmp\/dnf_ci_installroot_*\/etc\/yum.repos.d\/dnf-ci-thirdparty-updates.repo",
+        "base_url":[
+          "file:\/\/\/*\/dnf-behave-tests\/fixtures\/repos\/dnf-ci-thirdparty-updates"
+        ],
+        "metalink":"",
+        "mirrorlist":"",
+        "gpg_key":[],
+        "repo_gpgcheck":false,
+        "gpgcheck":false,
+        "available_pkgs":6,
+        "pkgs":6,
+        "size":"*",
+        "content_tags":[],
+        "distro_tags":[],
+        "revision":"1550000000",
+        "max_timestamp":"*"
+        }
+    ]
+    """
+
+
+Scenario: Repo list without arguments --json
+   When I execute dnf with args "repo list --json"
+   Then the exit code is 0
+    And stdout json matches
+    """
+    [
+      {
+        "id":"dnf-ci-fedora",
+        "name":"dnf-ci-fedora test repository",
+        "is_enabled":true
+      },
+      {
+        "id":"dnf-ci-thirdparty-updates",
+        "name":"dnf-ci-thirdparty-updates test repository",
+        "is_enabled":true
+      }
+    ]
+    """
+
+
+Scenario: Repo list without arguments --json --all
+   When I execute dnf with args "repo list --json --all"
+   Then the exit code is 0
+    And stdout json matches
+    """
+    [
+      {
+        "id":"dnf-ci-fedora-updates",
+        "name":"dnf-ci-fedora-updates test repository",
+        "is_enabled":false
+      },
+      {
+        "id":"dnf-ci-fedora",
+        "name":"dnf-ci-fedora test repository",
+        "is_enabled":true
+      },
+      {
+        "id":"dnf-ci-thirdparty-updates",
+        "name":"dnf-ci-thirdparty-updates test repository",
+        "is_enabled":true
+      },
+      {
+        "id":"dnf-ci-thirdparty",
+        "name":"dnf-ci-thirdparty test repository",
+        "is_enabled":false
+      }
+    ]
+    """
+
+
+Scenario: Repo info --json doesn't print REPOSYNC to stdout
+   When I execute dnf with args "repo info --json --refresh"
+   Then the exit code is 0
+    And stdout json matches
+    """
+    [
+      {
+        "id":"dnf-ci-fedora",
+        "name":"dnf-ci-fedora test repository",
+        "is_enabled":true,
+        "priority":99,
+        "cost":1000,
+        "type":"available",
+        "exclude_pkgs":[],
+        "include_pkgs":[],
+        "timestamp":"*",
+        "metadata_expire":172800,
+        "skip_if_unavailable":false,
+        "repo_file_path":"\/tmp\/dnf_ci_installroot_*\/etc\/yum.repos.d\/dnf-ci-fedora.repo",
+        "base_url":[
+          "file:\/\/\/*\/dnf-behave-tests\/fixtures\/repos\/dnf-ci-fedora"
+        ],
+        "metalink":"",
+        "mirrorlist":"",
+        "gpg_key":[],
+        "repo_gpgcheck":false,
+        "gpgcheck":false,
+        "available_pkgs":289,
+        "pkgs":289,
+        "size":"*",
+        "content_tags":[],
+        "distro_tags":[],
+        "revision":"1550000000",
+        "max_timestamp":"*"
+      },
+      {
+        "id":"dnf-ci-thirdparty-updates",
+        "name":"dnf-ci-thirdparty-updates test repository",
+        "is_enabled":true,
+        "priority":99,
+        "cost":1000,
+        "type":"available",
+        "exclude_pkgs":[],
+        "include_pkgs":[],
+        "timestamp":"*",
+        "metadata_expire":172800,
+        "skip_if_unavailable":false,
+        "repo_file_path":"\/tmp\/dnf_ci_installroot_*\/etc\/yum.repos.d\/dnf-ci-thirdparty-updates.repo",
+        "base_url":[
+          "file:\/\/\/*\/dnf-behave-tests\/fixtures\/repos\/dnf-ci-thirdparty-updates"
+        ],
+        "metalink":"",
+        "mirrorlist":"",
+        "gpg_key":[],
+        "repo_gpgcheck":false,
+        "gpgcheck":false,
+        "available_pkgs":6,
+        "pkgs":6,
+        "size":"*",
+        "content_tags":[],
+        "distro_tags":[],
+        "revision":"1550000000",
+        "max_timestamp":"*"
+        }
+    ]
+    """

--- a/dnf-behave-tests/dnf/steps/lib/json.py
+++ b/dnf-behave-tests/dnf/steps/lib/json.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from behave.formatter.ansi_escapes import escapes
+import fnmatch
+
+def diff_recursive(parent, obj1, obj2):
+    problems = []
+    if isinstance(obj1, list) and isinstance(obj2, list):
+        # The list was originally a dictionary
+        if (len(obj1) != 0 and isinstance(obj1[0], tuple)) or len(obj2) != 0 and isinstance(obj2[0], tuple):
+            keys1 = next(zip(*obj1)) if len(obj1) != 0 else []
+            keys2 = next(zip(*obj2)) if len(obj2) != 0 else []
+            if keys1 != keys2:
+                return ["Different keys in %s object: expected: %s%s%s vs actual: %s%s%s"
+                        % (parent, escapes['passed_arg'], keys1, escapes['reset'], escapes['failed_arg'], keys2,
+                           escapes['reset'])]
+            for i in range(0, len(keys1)):
+                problems += diff_recursive(parent + "[" + keys1[i] + "]", obj1[i][1], obj2[i][1])
+            return problems
+
+        if len(obj1) != len(obj2):
+            return ["Different count of elements in %s array: Expected: %s%s%s vs Actual: %s%s%s"
+                    % (parent, escapes['passed_arg'], len(obj1), escapes['reset'], escapes['failed_arg'], len(obj2),
+                       escapes['reset'])]
+        for i in range(0, len(obj1)):
+            problems += diff_recursive(parent + "[" + str(i) + "]", obj1[i], obj2[i])
+        return problems
+
+    else:
+        # The pattern is the second argument of fnmatch
+        if not fnmatch.fnmatch(str(obj2), str(obj1)):
+            return ["Different values for %s: Expected: '%s%s%s' vs Actual: '%s%s%s'"
+                    % (parent, escapes['passed_arg'], obj1, escapes['reset'], escapes['failed_arg'],
+                       obj2, escapes['reset'])]
+        return problems
+
+
+def diff_json_pattern_values(parent, obj1, obj2):
+    """
+    Recursively compare json objects obj1 and obj2
+    String values of obj1 can contain fnmatch patterns
+
+    Returns a list with problems
+    """
+
+    # Recursively sort lists
+    # (and convert dictionaries to lists of (key, value) pairs so that they're orderable)
+    def ordered(obj):
+        if isinstance(obj, list):
+            return sorted(ordered(x) for x in obj)
+        if isinstance(obj, dict):
+            return sorted((k, ordered(v)) for k, v in obj.items())
+        else:
+            return obj
+
+    try:
+        obj1 = ordered(obj1)
+    except TypeError:
+        raise AssertionError("Cannot sort expected json, this could be caused by different types in an array.")
+
+    try:
+        obj2 = ordered(obj2)
+    except TypeError:
+        raise AssertionError("Cannot sort input json, this could be caused by different types in an array.")
+
+    return diff_recursive(parent, obj1, obj2)

--- a/dnf-behave-tests/dnf/updateinfo-json.feature
+++ b/dnf-behave-tests/dnf/updateinfo-json.feature
@@ -1,0 +1,113 @@
+@dnf5
+Feature: dnf advisory command with --json
+
+
+Background:
+  Given I use repository "dnf-ci-fedora"
+    And I successfully execute dnf with args "install glibc flac"
+
+
+Scenario: Listing available updates in json format
+   When I use repository "dnf-ci-fedora-updates"
+    And I execute dnf with args "advisory list --json"
+   Then the exit code is 0
+    And stdout json matches
+    """
+    [
+      {
+        "name":"FEDORA-2999:002-02",
+        "type":"enhancement",
+        "severity":"Moderate",
+        "nevra":"flac-1.3.3-8.fc29.x86_64",
+        "buildtime":"2019-01-17 00:00:00"
+      },
+      {
+        "name":"FEDORA-2018-318f184000",
+        "type":"bugfix",
+        "severity":"none",
+        "nevra":"glibc-2.28-26.fc29.x86_64",
+        "buildtime":"2019-01-17 00:00:00"
+      }
+    ]
+    """
+
+
+Scenario: Listing available updates referencing bugizilla in json format
+   When I use repository "dnf-ci-fedora-updates"
+    And I execute dnf with args "advisory list --with-bz --json"
+   Then the exit code is 0
+    And stdout json matches
+    """
+    [
+      {
+        "advisory_name":"FEDORA-2018-318f184000",
+        "advisory_type":"bugfix",
+        "advisory_severity":"bugfix",
+        "advisory_buildtime":"2019-01-17 00:00:00",
+        "nevra":"glibc-2.28-26.fc29.x86_64",
+        "references":[
+          {
+            "reference_id":"222",
+            "reference_type":"bugzilla"
+          }
+        ]
+      }
+    ]
+    """
+
+
+Scenario: Listing updates in json format (when there's nothing to report)
+   When I execute dnf with args "advisory list --json"
+   Then the exit code is 0
+    And stdout is
+    """
+    []
+    """
+
+
+Scenario: Listing updates in json format with custom type and severity
+  Given I use repository "advisories-base"
+    And I execute dnf with args "install labirinto"
+    And I use repository "advisories-updates"
+   When I execute dnf with args "updateinfo list --json"
+   Then the exit code is 0
+    And stdout json matches
+    """
+    [
+      {
+        "name":"FEDORA-2019-57b5902ed1",
+        "type":"security",
+        "severity":"Critical",
+        "nevra":"labirinto-1.56.2-6.fc30.x86_64",
+        "buildtime":"2019-09-15 01:34:29"
+      },
+      {
+        "name":"FEDORA-2022-2222222222",
+        "type":"custom_type",
+        "severity":"custom_severity",
+        "nevra":"labirinto-1.56.2-6.fc30.x86_64",
+        "buildtime":"2019-09-15 01:34:29"
+      },
+      {
+        "name":"FEDORA-2022-2222222223",
+        "type":"security",
+        "severity":"custom_severity",
+        "nevra":"labirinto-1.56.2-6.fc30.x86_64",
+        "buildtime":"2019-09-15 01:34:29"
+      },
+      {
+        "name":"FEDORA-2022-2222222224",
+        "type":"custom_type",
+        "severity":"Critical",
+        "nevra":"labirinto-1.56.2-6.fc30.x86_64",
+        "buildtime":"2019-09-15 01:34:29"
+      },
+      {
+        "name":"FEDORA-2019-f4eb34cf4c",
+        "type":"security",
+        "severity":"Moderate",
+        "nevra":"labirinto-1.56.2-1.fc30.x86_64",
+        "buildtime":"2019-05-12 01:21:43"
+      }
+    ]
+    """

--- a/dnf-behave-tests/dnf/updateinfo.feature
+++ b/dnf-behave-tests/dnf/updateinfo.feature
@@ -52,18 +52,6 @@ Scenario: advisory summary (when there's nothing to report)
     """
 
 
-@not.with_dnf=5
-Scenario: advisory --summary when there's nothing to report (dnf4 compat)
-   When I execute dnf with args "install glibc flac"
-   Then the exit code is 0
-   When I execute dnf with args "advisory --summary"
-   Then the exit code is 0
-    And dnf4 stdout is
-    """
-    <REPOSYNC>
-    """
-
-
 Scenario: advisory summary --available (when there is an available update)
    When I execute dnf with args "install glibc flac"
    Then the exit code is 0
@@ -83,22 +71,6 @@ Scenario: advisory summary --available (when there is an available update)
     Bugfix      : 1
     Enhancement : 1
     Other       : 0
-    """
-
-
-@not.with_dnf=5
-Scenario: updateinfo --summary available when there is an available update (dnf4 compat)
-   When I execute dnf with args "install glibc flac"
-   Then the exit code is 0
-  Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo --summary available"
-   Then the exit code is 0
-    And dnf4 stdout is
-    """
-    <REPOSYNC>
-    Updates Information Summary: available
-        1 Bugfix notice(s)
-        1 Enhancement notice(s)
     """
 
 
@@ -160,52 +132,6 @@ Scenario: advisory info
     """
 
 
-@not.with_dnf=5
-Scenario: updateinfo --info (dnf4 compat)
-   When I execute dnf with args "install glibc flac"
-   Then the exit code is 0
-  Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo --info --available"
-   Then the exit code is 0
-    And dnf4 stdout matches line by line
-    """
-    <REPOSYNC>
-    ===============================================================================
-      flac enhacements
-    ===============================================================================
-      Update ID: FEDORA-2999:002-02
-           Type: enhancement
-        Updated: 2019-01-1\d \d\d:00:00
-    Description: Enhance some stuff
-       Severity: Moderate
-
-    ===============================================================================
-      glibc bug fix
-    ===============================================================================
-      Update ID: FEDORA-2018-318f184000
-           Type: bugfix
-        Updated: 2019-01-1\d \d\d:00:00
-           Bugs: 222 - 222
-           CVEs: 2999
-               : CVE-2999
-    Description: Fix some stuff
-       Severity: none
-    """
-
-
-@not.with_dnf=5
-Scenario: updateinfo info security (when there's nothing to report) (dnf4 compat)
-   When I execute dnf with args "install glibc flac"
-   Then the exit code is 0
-  Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo info security"
-   Then the exit code is 0
-   And stdout is
-   """
-   <REPOSYNC>
-   """
-
-
 # @dnf5daemon
 Scenario: advisory info security (when there's nothing to report)
    When I execute dnf with args "install glibc flac"
@@ -226,33 +152,12 @@ Scenario: advisory list
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory list"
    Then the exit code is 0
-    And dnf4 stdout is
-    """
-    <REPOSYNC>
-    FEDORA-2999:002-02     enhancement flac-1.3.3-8.fc29.x86_64
-    FEDORA-2018-318f184000 bugfix      glibc-2.28-26.fc29.x86_64
-    """
     And dnf5 stdout is
     """
     <REPOSYNC>
     Name                   Type        Severity                   Package              Issued
     FEDORA-2018-318f184000 bugfix      none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
     FEDORA-2999:002-02     enhancement Moderate  flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
-    """
-
-
-@not.with_dnf=5
-Scenario: updateinfo --list (dnf4 compat)
-   When I execute dnf with args "install glibc flac"
-   Then the exit code is 0
-  Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo --list"
-   Then the exit code is 0
-    And dnf4 stdout is
-    """
-    <REPOSYNC>
-    FEDORA-2999:002-02     enhancement flac-1.3.3-8.fc29.x86_64
-    FEDORA-2018-318f184000 bugfix      glibc-2.28-26.fc29.x86_64
     """
 
 
@@ -363,20 +268,6 @@ Examples:
         |        | FEDORA-2018-318f184000 |
 
 
-@not.with_dnf=5
-Scenario: updateinfo list updates plus --advisory (dnf4 compat)
-   When I execute dnf with args "install glibc flac"
-   Then the exit code is 0
-  Given I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "--advisory FEDORA-2018-318f184000 updateinfo list updates"
-   Then the exit code is 0
-    And stdout is
-    """
-    <REPOSYNC>
-    FEDORA-2018-318f184000 bugfix glibc-2.28-26.fc29.x86_64
-    """
-
-
 # @dnf5daemon
 Scenario: advisory info <advisory>
    When I execute dnf with args "install glibc flac"
@@ -462,29 +353,6 @@ Scenario: advisory lists advisories referencing CVE
     """
 
 
-@not.with_dnf=5
-@bz1750528
-Scenario Outline: updateinfo lists advisories referencing CVE (dnf4 compat)
-  Given I successfully execute dnf with args "install glibc flac"
-    And I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo <options>"
-   Then the exit code is 0
-    And stdout is
-    """
-    <REPOSYNC>
-    2999     bugfix glibc-2.28-26.fc29.x86_64
-    CVE-2999 bugfix glibc-2.28-26.fc29.x86_64
-    """
-
-Examples:
-    | options             |
-    | --list --with-cve   |
-    # yum compatibility
-    | list cves           |
-    | list --with-cve     |
-    | --list cves         |
-
-
 Scenario: advisory lists advisories referencing bugzilla
   Given I successfully execute dnf with args "install glibc flac"
     And I use repository "dnf-ci-fedora-updates"
@@ -496,26 +364,6 @@ Scenario: advisory lists advisories referencing bugzilla
     Bugzilla Type   Severity                   Package              Issued
     222      bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
     """
-
-
-@not.with_dnf=5
-Scenario Outline: updateinfo lists advisories referencing bugzilla (dnf4 compat)
-  Given I successfully execute dnf with args "install glibc flac"
-    And I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo <options>"
-   Then the exit code is 0
-    And stdout is
-    """
-    <REPOSYNC>
-    222 bugfix glibc-2.28-26.fc29.x86_64
-    """
-
-Examples:
-    | options             |
-    | --list --with-bz    |
-    # yum compatibility
-    | list bugzillas      |
-    | list bzs            |
 
 
 @bz1728004
@@ -560,127 +408,6 @@ Scenario: advisory show <advisory> of the running kernel after a kernel update
     And stdout is
     """
     <REPOSYNC>
-    """
-
-
-@not.with_dnf=5
-Scenario Outline: updateinfo lists advisories using direct commands (yum compat)
-  Given I successfully execute dnf with args "install glibc flac"
-    And I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "<command>"
-   Then the exit code is 0
-    And stdout is
-    """
-    <REPOSYNC>
-    FEDORA-2999:002-02     enhancement flac-1.3.3-8.fc29.x86_64
-    FEDORA-2018-318f184000 bugfix      glibc-2.28-26.fc29.x86_64
-    """
-
-Examples:
-    | command         |
-    | list-sec        |
-    | list-security   |
-    | list-updateinfo |
-
-
-@not.with_dnf=5
-Scenario Outline: updateinfo shows info for advisories using direct commands (yum compat)
-  Given I successfully execute dnf with args "install glibc flac"
-    And I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "<command>"
-   Then the exit code is 0
-    And stdout matches line by line
-    """
-    <REPOSYNC>
-    ===============================================================================
-      flac enhacements
-    ===============================================================================
-      Update ID: FEDORA-2999:002-02
-           Type: enhancement
-        Updated: 2019-01-1\d \d\d:00:00
-    Description: Enhance some stuff
-       Severity: Moderate
-
-    ===============================================================================
-      glibc bug fix
-    ===============================================================================
-      Update ID: FEDORA-2018-318f184000
-           Type: bugfix
-        Updated: 2019-01-1\d \d\d:00:00
-           Bugs: 222 - 222
-           CVEs: 2999
-               : CVE-2999
-    Description: Fix some stuff
-       Severity: none
-    """
-
-Examples:
-    | command         |
-    | info-sec        |
-    | info-security   |
-    | info-updateinfo |
-
-
-@not.with_dnf=5
-Scenario: updateinfo shows summary for advisories using direct commands (yum compat)
-  Given I successfully execute dnf with args "install glibc flac"
-    And I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "summary-updateinfo"
-   Then the exit code is 0
-    And stdout is
-    """
-    <REPOSYNC>
-    Updates Information Summary: available
-        1 Bugfix notice(s)
-        1 Enhancement notice(s)
-    """
-
-
-@not.with_dnf=5
-@bz1801092
-Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode (DNF version)
-  Given I set dnf command to "dnf"
-    And I successfully execute dnf with args "install glibc flac"
-    And I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo -v --list --with-cve"
-   Then the exit code is 0
-    And stdout matches line by line
-    """
-    DNF version: .*
-    cachedir: .*
-    User-Agent: constructed: .*
-    repo: using cache for: dnf-ci-fedora
-    dnf-ci-fedora: using metadata from .*
-    repo: downloading from remote: dnf-ci-fedora-updates
-    dnf-ci-fedora-updates test repository .* MB/s | .*
-    dnf-ci-fedora-updates: using metadata from .*
-    <REPOSYNC>
-    2999     bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
-    CVE-2999 bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
-    """
-
-
-@not.with_dnf=5
-@bz1801092
-Scenario: updateinfo lists advisories referencing CVE with dates in verbose mode (YUM version)
-  Given I set dnf command to "yum"
-    And I successfully execute dnf with args "install glibc flac"
-    And I use repository "dnf-ci-fedora-updates"
-   When I execute dnf with args "updateinfo -v --list --with-cve"
-   Then the exit code is 0
-    And stdout matches line by line
-    """
-    YUM version: .*
-    cachedir: .*
-    User-Agent: constructed: .*
-    repo: using cache for: dnf-ci-fedora
-    dnf-ci-fedora: using metadata from .*
-    repo: downloading from remote: dnf-ci-fedora-updates
-    dnf-ci-fedora-updates test repository .* MB/s | .*
-    dnf-ci-fedora-updates: using metadata from .*
-    <REPOSYNC>
-    2999     bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
-    CVE-2999 bugfix glibc-2.28-26.fc29.x86_64 2019-01-1\d \d\d:00:00
     """
 
 
@@ -852,11 +579,6 @@ Given I use repository "security-upgrade"
   And I execute dnf with args "install C-1-1"
  When I execute dnf with args "updateinfo list --updates"
  Then the exit code is 0
-  And dnf4 stdout is
-  """
-  <REPOSYNC>
-  DNF-D-2022-9 security      D-1-1.fc29.x86_64
-  """
   And dnf5 stdout is
   """
   <REPOSYNC>
@@ -892,11 +614,6 @@ Given I use repository "security-upgrade"
   And I execute dnf with args "install change-arch-noarch-1-1.noarch"
  When I execute dnf with args "updateinfo list --updates"
  Then the exit code is 0
-  And dnf4 stdout is
-  """
-  <REPOSYNC>
-  DNF-2019-4 security      change-arch-noarch-2-2.fc29.x86_64
-  """
   And dnf5 stdout is
   """
   <REPOSYNC>


### PR DESCRIPTION
- Add a step to compare json outputs
- Add `--json` tests for `repo` and `advisory list` commands 
- Removes unused dnf4 parts from updateinfo.feature