### PR TITLE
Remove tests from repoquery/files.feature and update config.feature error message

### DIFF
--- a/dnf-behave-tests/dnf/config.feature
+++ b/dnf-behave-tests/dnf/config.feature
@@ -195,7 +195,7 @@ Scenario: Dnf prints reasonable error when remote config file is not downloadabl
    And stderr matches line by line
    """
    Config error: Configuration file URL "xxxx://localhost:[\d]+/does-not-exist\.conf" could not be downloaded:
-     Curl error \(1\): Unsupported protocol for xxxx://localhost:[\d]+/does-not-exist\.conf \[Protocol "xxxx" not supported or disabled in libcurl\]
+     Curl error \(1\): Unsupported protocol for xxxx://localhost:[\d]+/does-not-exist\.conf \[Protocol "xxxx" not supported.*\]
    """
    # host unknown
    When I execute dnf with args "-c http://the_host:{context.dnf.ports[/remotedir]}/does-not-exist.conf repolist repo-from-remote-config"

--- a/dnf-behave-tests/dnf/repoquery/files.feature
+++ b/dnf-behave-tests/dnf/repoquery/files.feature
@@ -1,30 +1,6 @@
 @dnf5
 Feature: Repoquery tests working with files
 
-
-Scenario: list files in an rpm including files in filelists.xml
-Given I use repository "repoquery-files"
- When I execute dnf with args "repoquery a.x86_64 -l"
- Then the exit code is 0
-  And stdout is
-      """
-      <REPOSYNC>
-      /root-file
-      /usr/bin/a-binary
-      """
-
-
-Scenario: filter by file in primary.xml
-Given I use repository "repoquery-files"
- When I execute dnf with args "repoquery --file /usr/bin/a-binary"
- Then the exit code is 0
-  And stdout is
-      """
-      <REPOSYNC>
-      a-0:1.0-1.fc29.x86_64
-      """
-
-
 @RHEL-5747
 Scenario: filter by file in primary.xml but force command only search in rpm names -> empty output
 Given I use repository "repoquery-files"
@@ -35,14 +11,3 @@ Given I use repository "repoquery-files"
       <REPOSYNC>
       """
 
-
-@bz2276012
-Scenario: filter by file in filelists.xml
-Given I use repository "repoquery-files"
- When I execute dnf with args "repoquery --file /root-file"
- Then the exit code is 0
-  And stdout is
-      """
-      <REPOSYNC>
-      a-0:1.0-1.fc29.x86_64
-      """


### PR DESCRIPTION
The same tests doesn't exist in 9.5 branch, see:
https://github.com/rpm-software-management/ci-dnf-stack/pull/1510

And update the error message check from curl