### PR TITLE
Adjust history view merging test to match the new behavior

### DIFF
--- a/dnf-behave-tests/dnf/history-view.feature
+++ b/dnf-behave-tests/dnf/history-view.feature
@@ -77,9 +77,6 @@ Scenario: History info in range - transaction merging
     And History info "last-2..last-1" should match
         | Key           | Value                     |
         | Return-Code   | Success                   |
-        | Reinstall     | abcde-2.9.2-1.fc29.noarch |
-        | Reinstall     | flac-1.3.2-8.fc29.x86_64  |
-        | Reinstall     | wget-1.19.5-5.fc29.x86_64 |
 
 
 Scenario: History info of package


### PR DESCRIPTION
Upstream commit: 8234f4221efee5269258b384cffb3ac31107aa15

Based on the changes of transaction merging behavior for packages with the same version, as introduced in: https://github.com/rpm-software-management/dnf/issues/2031.

For: https://issues.redhat.com/browse/RHEL-17494