### PR TITLE
Check for diagnostic messages on stderr, not stdout

### DIFF
--- a/dnf-behave-tests/common/output.py
+++ b/dnf-behave-tests/common/output.py
@@ -181,9 +181,17 @@ def then_stderr_is(context):
 
 @behave.then("stderr matches line by line")
 def then_stderr_matches_line_by_line(context):
-    out_lines = context.cmd_stderr.split('\n')
-    regexp_lines = context.text.split('\n')
-    lines_match_to_regexps_line_by_line(out_lines, regexp_lines)
+    """
+    Checks that each line of stderr matches respective line in regular expressions.
+    Supports the <REPOSYNC> in the same way as the step "stderr is"
+    """
+    found = context.cmd_stderr.split('\n')
+    expected = context.text.split('\n')
+
+    dnf5_mode = hasattr(context, "dnf5_mode") and context.dnf5_mode
+    clean_expected, clean_found = handle_reposync(expected, found, dnf5_mode)
+
+    lines_match_to_regexps_line_by_line(clean_found, clean_expected)
 
 
 @behave.then("{dnf_version:dnf_version} exit code is {exitcode}")

--- a/dnf-behave-tests/dnf/append_options.feature
+++ b/dnf-behave-tests/dnf/append_options.feature
@@ -14,191 +14,236 @@ Background: Enable repository and set excludes in configuration
 Scenario: Test that excludes from config file are applied
    When I execute dnf with args "repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    wget-0:1.19.6-5.fc29.src
-    wget-0:1.19.6-5.fc29.x86_64
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        wget-0:1.19.6-5.fc29.src
+        wget-0:1.19.6-5.fc29.x86_64
+        """
 
 
 Scenario: Test adding of excludes
    When I execute dnf with args "--exclude=lz4 --exclude=wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        """
 
 
 Scenario: Test adding of excludes using --setopt
    When I execute dnf with args "--setopt=excludepkgs=lz4 --setopt=excludepkgs=wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        """
 
 
 Scenario: Test adding of excludes short notation
    When I execute dnf with args "--exclude=lz4,wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        """
 
 
 Scenario: Test adding of excludes short notation using --setopt
    When I execute dnf with args "--setopt=excludepkgs=lz4,wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        """
 
 
 Scenario: Test removing of existing excludes
    When I execute dnf with args "--exclude= repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    lame-0:3.100-5.fc29.src
-    lame-0:3.100-5.fc29.x86_64
-    lz4-0:1.8.2-2.fc29.i686
-    lz4-0:1.8.2-2.fc29.src
-    lz4-0:1.8.2-2.fc29.x86_64
-    wget-0:1.19.6-5.fc29.src
-    wget-0:1.19.6-5.fc29.x86_64
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        lame-0:3.100-5.fc29.src
+        lame-0:3.100-5.fc29.x86_64
+        lz4-0:1.8.2-2.fc29.i686
+        lz4-0:1.8.2-2.fc29.src
+        lz4-0:1.8.2-2.fc29.x86_64
+        wget-0:1.19.6-5.fc29.src
+        wget-0:1.19.6-5.fc29.x86_64
+        """
 
 
 Scenario: Test removing of existing excludes using --setopt
    When I execute dnf with args "--setopt=excludepkgs= repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    lame-0:3.100-5.fc29.src
-    lame-0:3.100-5.fc29.x86_64
-    lz4-0:1.8.2-2.fc29.i686
-    lz4-0:1.8.2-2.fc29.src
-    lz4-0:1.8.2-2.fc29.x86_64
-    wget-0:1.19.6-5.fc29.src
-    wget-0:1.19.6-5.fc29.x86_64
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        lame-0:3.100-5.fc29.src
+        lame-0:3.100-5.fc29.x86_64
+        lz4-0:1.8.2-2.fc29.i686
+        lz4-0:1.8.2-2.fc29.src
+        lz4-0:1.8.2-2.fc29.x86_64
+        wget-0:1.19.6-5.fc29.src
+        wget-0:1.19.6-5.fc29.x86_64
+        """
 
 
 Scenario: Test replacing of existing excludes
    When I execute dnf with args "--exclude= --exclude=lz4 --exclude=wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    lame-0:3.100-5.fc29.src
-    lame-0:3.100-5.fc29.x86_64
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        lame-0:3.100-5.fc29.src
+        lame-0:3.100-5.fc29.x86_64
+        """
 
 
 Scenario: Test replacing of existing excludes using --setopt
    When I execute dnf with args "--setopt=excludepkgs= --setopt=excludepkgs=lz4 --setopt=excludepkgs=wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    lame-0:3.100-5.fc29.src
-    lame-0:3.100-5.fc29.x86_64
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        lame-0:3.100-5.fc29.src
+        lame-0:3.100-5.fc29.x86_64
+        """
 
 
 Scenario: Test replacing of existing excludes short notation
    When I execute dnf with args "--exclude=,lz4,wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    lame-0:3.100-5.fc29.src
-    lame-0:3.100-5.fc29.x86_64
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        lame-0:3.100-5.fc29.src
+        lame-0:3.100-5.fc29.x86_64
+        """
 
 
 Scenario: Test replacing of existing excludes short notation using --setopt
    When I execute dnf with args "--setopt=excludepkgs=,lz4,wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    lame-0:3.100-5.fc29.src
-    lame-0:3.100-5.fc29.x86_64
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        lame-0:3.100-5.fc29.src
+        lame-0:3.100-5.fc29.x86_64
+        """
 
 
 @bz1788154
 Scenario: Test adding excludes (empty values in the middle of short notation are ignored)
    When I execute dnf with args "--exclude=lz4,,wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        """
 
 
 @bz1788154
 Scenario: Test adding excludes (empty values in the middle of short notation are ignored) using --setopt
    When I execute dnf with args "--setopt=excludepkgs=lz4,,wget repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        """
 
 
 @bz1788154
 Scenario: Test adding excludes (empty value at the end of short notation is ignored)
    When I execute dnf with args "--exclude=lz4,wget, repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        """
 
 
 @bz1788154
 Scenario: Test adding excludes (empty value at the end of short notation is ignored) using --setopt
    When I execute dnf with args "--setopt=excludepkgs=lz4,wget, repoquery abcde lame lz4 wget"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    abcde-0:2.9.3-1.fc29.noarch
-    abcde-0:2.9.3-1.fc29.src
-    """
+        """
+        abcde-0:2.9.3-1.fc29.noarch
+        abcde-0:2.9.3-1.fc29.src
+        """

--- a/dnf-behave-tests/dnf/broken-dependencies-report.feature
+++ b/dnf-behave-tests/dnf/broken-dependencies-report.feature
@@ -16,6 +16,7 @@ Scenario: Broken dependencies are reported when strict and best options are off
    Then the exit code is 0
     And stderr is
     """
+    <REPOSYNC>
     Problem: package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires libpq.so.5()(64bit), but none of the providers can be installed
       - package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests
@@ -33,6 +34,7 @@ Scenario: Broken dependencies are reported when strict option is off and best op
    Then the exit code is 0
     And stderr is
     """
+    <REPOSYNC>
     Problem: package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires libpq.so.5()(64bit), but none of the providers can be installed
       - package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests
@@ -50,6 +52,7 @@ Scenario: Broken dependencies are reported when skip-broken and best options are
    Then the exit code is 0
     And stderr is
     """
+    <REPOSYNC>
     Problem: package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires libpq.so.5()(64bit), but none of the providers can be installed
       - package postgresql-9.6.5-1.fc29.x86_64 from dnf-ci-fedora requires postgresql-libs(x86-64) = 9.6.5-1.fc29, but none of the providers can be installed
       - conflicting requests

--- a/dnf-behave-tests/dnf/cacheonly.feature
+++ b/dnf-behave-tests/dnf/cacheonly.feature
@@ -9,7 +9,7 @@ Background:
 Scenario: Cannot work with empty cache when using -C
   Given I execute dnf with args "install wget -C"
    Then the exit code is 1
-    And stderr is
+    And stderr contains lines
     """
     Cache-only enabled but no cache for repository "dnf-ci-fedora"
     """
@@ -19,7 +19,7 @@ Scenario: Cannot install a remote package when using -C
   Given I successfully execute dnf with args "makecache"
    When I execute dnf with args "install wget -C"
    Then the exit code is 1
-    And stderr is
+    And stderr contains lines
     """
     Cannot download the "wget-1.19.5-5.fc29.x86_64" package, cacheonly option is activated.
     """
@@ -46,7 +46,7 @@ Scenario: Install locally cached package using -C
 Scenario: Cannot work with empty cache when using cacheonly=metadata
   Given I execute dnf with args "install wget --setopt=cacheonly=metadata"
    Then the exit code is 1
-    And stderr is
+    And stderr contains lines
     """
     Cache-only enabled but no cache for repository "dnf-ci-fedora"
     """
@@ -73,4 +73,4 @@ Scenario: Local key is imported during installation with -C option
    Then Transaction is following
         | Action        | Package                        |
         | install       | setup-0:2.12.1-1.fc29.noarch   |
-    And stdout contains "The key was successfully imported."
+    And stderr contains "The key was successfully imported."

--- a/dnf-behave-tests/dnf/check-update.feature
+++ b/dnf-behave-tests/dnf/check-update.feature
@@ -39,11 +39,14 @@ Given I use repository "check-update"
   And Transaction is empty
  When I execute dnf with args "check-upgrade --security"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout is
-  """
-  <REPOSYNC>
-  No security updates needed, but 1 update(s) available
-  """
+      """
+      No security updates needed, but 1 update(s) available
+      """
 
 
 @bz2151910
@@ -58,7 +61,8 @@ Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "check-upgrade abcde"
  # abcde-2.9.3-1.fc29.src is not reported as an upgrade
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+     """
+     <REPOSYNC>
+     """
+  And stdout is empty

--- a/dnf-behave-tests/dnf/clean.feature
+++ b/dnf-behave-tests/dnf/clean.feature
@@ -8,9 +8,12 @@ Scenario: Ensure that metadata are unavailable after "dnf clean all"
    Then the exit code is 0
    When I execute dnf with args "repoquery cream -C"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         cream-0:1.0-1.src
         cream-0:1.0-1.x86_64
         """
@@ -18,12 +21,10 @@ Scenario: Ensure that metadata are unavailable after "dnf clean all"
    Then the exit code is 0
    When I execute dnf with args "repoquery cream -C"
    Then the exit code is 1
-    And stdout is
-        """
-        <REPOSYNC>
-        """
+    And stdout is empty
     And stderr is 
         """
+        <REPOSYNC>
         Cache-only enabled but no cache for repository "dnf-ci-rich"
         """
 
@@ -35,35 +36,42 @@ Scenario: Expire dnf cache and run repoquery for a package that has been removed
     And I use repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "repoquery --available SuperRipper"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         SuperRipper-0:1.2-1.src
         SuperRipper-0:1.2-1.x86_64
         SuperRipper-0:1.3-1.src
         SuperRipper-0:1.3-1.x86_64
-
         """
   Given I delete file "/{context.dnf.repos[dnf-ci-thirdparty-updates].path}/x86_64/SuperRipper-1.2-1.x86_64.rpm"
     And I generate repodata for repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "repoquery --available SuperRipper"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         SuperRipper-0:1.2-1.src
         SuperRipper-0:1.2-1.x86_64
         SuperRipper-0:1.3-1.src
         SuperRipper-0:1.3-1.x86_64
-
         """
    When I execute dnf with args "clean expire-cache"
    Then the exit code is 0
    When I execute dnf with args "repoquery --available SuperRipper"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         SuperRipper-0:1.2-1.src
         SuperRipper-0:1.3-1.src
         SuperRipper-0:1.3-1.x86_64
@@ -77,9 +85,12 @@ Scenario: Expire dnf cache and run repoquery when a package has been removed mea
     And I use repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "repoquery"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         CQRlib-extension-0:1.6-2.src
         CQRlib-extension-0:1.6-2.x86_64
         SuperRipper-0:1.2-1.src
@@ -91,9 +102,12 @@ Scenario: Expire dnf cache and run repoquery when a package has been removed mea
     And I generate repodata for repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "repoquery"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         CQRlib-extension-0:1.6-2.src
         CQRlib-extension-0:1.6-2.x86_64
         SuperRipper-0:1.2-1.src
@@ -105,9 +119,12 @@ Scenario: Expire dnf cache and run repoquery when a package has been removed mea
    Then the exit code is 0
    When I execute dnf with args "repoquery"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         CQRlib-extension-0:1.6-2.src
         CQRlib-extension-0:1.6-2.x86_64
         SuperRipper-0:1.2-1.src

--- a/dnf-behave-tests/dnf/comps-group-list.feature
+++ b/dnf-behave-tests/dnf/comps-group-list.feature
@@ -17,89 +17,113 @@ Background: Enable repo and mark a group as installed
 Scenario: All user visible groups are listed by default (installed group is not duplicated)
   When I execute dnf with args "group list"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name        Installed
-    empty-group          Empty group        no
-    no-name-group                           no
-    test-group           Test Group        yes 
-    """
+       """
+       ID                   Name        Installed
+       empty-group          Empty group        no
+       no-name-group                           no
+       test-group           Test Group        yes 
+       """
 
 Scenario: I can list also hidden groups
   When I execute dnf with args "group list --hidden"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name         Installed
-    empty-group          Empty group         no
-    hidden-group         Hidden group        no
-    no-name-group                            no
-    test-group           Test Group         yes
-    """
+       """
+       ID                   Name         Installed
+       empty-group          Empty group         no
+       hidden-group         Hidden group        no
+       no-name-group                            no
+       test-group           Test Group         yes
+       """
 
 Scenario: I can filter listed groups by their ids (hidden groups are included)
   When I execute dnf with args "group list "hidden-*""
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name         Installed
-    hidden-group         Hidden group        no
-    """
+       """
+       ID                   Name         Installed
+       hidden-group         Hidden group        no
+       """
 
 Scenario: I can filter listed groups by their names (hidden groups are included)
   When I execute dnf with args "group list "* group""
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name         Installed
-    empty-group          Empty group         no
-    hidden-group         Hidden group        no
-    test-group           Test Group         yes
-    """
+       """
+       ID                   Name         Installed
+       empty-group          Empty group         no
+       hidden-group         Hidden group        no
+       test-group           Test Group         yes
+       """
 
 Scenario: I can list only installed groups
   When I execute dnf with args "group list --installed"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name       Installed
-    test-group           Test Group       yes 
-    """
+       """
+       ID                   Name       Installed
+       test-group           Test Group       yes 
+       """
 
 Scenario: I can list only available groups
   When I execute dnf with args "group list --available"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name        Installed
-    empty-group          Empty group        no
-    no-name-group                           no
-    test-group           Test Group         no
-    """
+       """
+       ID                   Name        Installed
+       empty-group          Empty group        no
+       no-name-group                           no
+       test-group           Test Group         no
+       """
 
 Scenario: I can list only groups containing a package
-        When I execute dnf with args "group list --contains-pkgs=test-package"
+  When I execute dnf with args "group list --contains-pkgs=test-package"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name       Installed
-    no-name-group                          no
-    test-group           Test Group       yes
-    """
+       """
+       ID                   Name       Installed
+       no-name-group                          no
+       test-group           Test Group       yes
+       """
 
 Scenario: I can get info about all groups (installed group is not duplicated)
   When I execute dnf with args "group info"
   Then the exit code is 0
-   And stdout is
+   And stderr is
       """
       <REPOSYNC>
+      """
+   And stdout is
+      """
       Id                   : empty-group
       Name                 : Empty group
       Description          : 

--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -125,14 +125,15 @@ Scenario: Install and remove group with excluded package dependency
    When I execute dnf with args "group install --exclude=setup dnf-ci-testgroup"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Problem: package filesystem-3.9-2.fc29.x86_64 from dnf-ci-fedora requires setup, but none of the providers can be installed
-      - conflicting requests
-      - package setup-2.12.1-1.fc29.noarch from dnf-ci-fedora is filtered out by exclude filtering
-    You can try to add to command line:
-      --skip-broken to skip uninstallable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Problem: package filesystem-3.9-2.fc29.x86_64 from dnf-ci-fedora requires setup, but none of the providers can be installed
+          - conflicting requests
+          - package setup-2.12.1-1.fc29.noarch from dnf-ci-fedora is filtered out by exclude filtering
+        You can try to add to command line:
+          --skip-broken to skip uninstallable packages
+        """
 
 
 @dnf5
@@ -305,14 +306,17 @@ Scenario: Group list
  Given I use repository "dnf-ci-thirdparty"
   When I execute dnf with args "group list"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name                 Installed
-    cqrlib-non-devel     CQRlib-non-devel            no
-    dnf-ci-testgroup     DNF-CI-Testgroup            no
-    superripper-and-deps SuperRipper-and-deps        no
-    """
+       """
+       ID                   Name                 Installed
+       cqrlib-non-devel     CQRlib-non-devel            no
+       dnf-ci-testgroup     DNF-CI-Testgroup            no
+       superripper-and-deps SuperRipper-and-deps        no
+       """
 
 @dnf5
 @dnf5daemon
@@ -321,12 +325,15 @@ Scenario: Group list with arg
  Given I use repository "dnf-ci-thirdparty"
   When I execute dnf with args "group list dnf-ci-testgroup"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name             Installed
-    dnf-ci-testgroup     DNF-CI-Testgroup        no
-    """
+       """
+       ID                   Name             Installed
+       dnf-ci-testgroup     DNF-CI-Testgroup        no
+       """
 
 @bz1826198
 @dnf5
@@ -344,9 +351,12 @@ Scenario: List an environment with empty name
           Test Group
           <name-unset>
        """
-   And dnf5 stdout is
+   And dnf5 stderr is
        """
        <REPOSYNC>
+       """
+   And dnf5 stdout is
+       """
        ID                   Name       Installed
        no-name-group                          no
        test-group           Test Group        no
@@ -384,25 +394,31 @@ Scenario: List and info a group with missing packagelist
   Given I use repository "comps-group-merging"
    When I execute dnf with args "group list"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-       """
-       <REPOSYNC>
-       ID                   Name       Installed
-       test-group           Test Group        no
-       """
+        """
+        ID                   Name       Installed
+        test-group           Test Group        no
+        """
    When I execute dnf with args "group info test-group"
-   Then stdout is
-       """
-       <REPOSYNC>
-       Id                   : test-group
-       Name                 : Test Group
-       Description          : Test Group description updated.
-       Installed            : no
-       Order                : 
-       Langonly             : 
-       Uservisible          : yes
-       Repositories         : comps-group-merging
-       """
+   Then stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Id                   : test-group
+        Name                 : Test Group
+        Description          : Test Group description updated.
+        Installed            : no
+        Order                : 
+        Langonly             : 
+        Uservisible          : yes
+        Repositories         : comps-group-merging
+        """
 
 
 @dnf5
@@ -428,14 +444,17 @@ Scenario: Merge groups when one has empty packagelist
         | group-install | Test Group                        |
         | install-group | test-package-1.0-1.fc29.noarch    |
    When I execute dnf with args "group info test-group"
-   Then stdout is
-       """
-       <REPOSYNC>
-       Group: Test Group
-        Description: Test Group description updated.
-        Mandatory Packages:
-          test-package
-       """
+   Then stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Group: Test Group
+         Description: Test Group description updated.
+         Mandatory Packages:
+           test-package
+        """
 
 
 @dnf5
@@ -445,17 +464,20 @@ Scenario: Merge environment with missing names containg a group with missing nam
   Given I use repository "comps-group"
     And I use repository "comps-group-merging"
    When I execute dnf with args "environment info no-name-env"
-   Then stdout is
-       """
-       <REPOSYNC>
-       Id                   : no-name-env
-       Name                 : 
-       Description          : 
-       Order                : 
-       Installed            : False
-       Repositories         : comps-group, comps-group-merging
-       Required groups      : no-name-group
-       """
+   Then stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Id                   : no-name-env
+        Name                 : 
+        Description          : 
+        Order                : 
+        Installed            : False
+        Repositories         : comps-group, comps-group-merging
+        Required groups      : no-name-group
+        """
 
 
 @dnf5
@@ -463,19 +485,22 @@ Scenario: Merge environment with missing names containg a group with missing nam
 Scenario: Group info with a group that has missing name
   Given I use repository "comps-group"
    When I execute dnf with args "group info no-name-group"
-   Then stdout is
-       """
-       <REPOSYNC>
-       Id                   : no-name-group
-       Name                 : 
-       Description          : 
-       Installed            : no
-       Order                : 
-       Langonly             : 
-       Uservisible          : yes
-       Repositories         : comps-group
-       Mandatory packages   : test-package
-       """
+   Then stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Id                   : no-name-group
+        Name                 : 
+        Description          : 
+        Installed            : no
+        Order                : 
+        Langonly             : 
+        Uservisible          : yes
+        Repositories         : comps-group
+        Mandatory packages   : test-package
+        """
 
 
 # @dnf5
@@ -502,7 +527,7 @@ Scenario: Install an environment with a nonexistent group
         | group-install | Test Group                        |
         | group-install | <name-unset>                      |
         | install-group | test-package-1.0-1.fc29.noarch    |
-    And stderr is
+    And stderr contains lines
        """
        No match for group from environment: nonexistent-group
 
@@ -521,7 +546,7 @@ Scenario: Install an environment using @^environment syntax
         | group-install | Test Group                        |
         | group-install | <name-unset>                      |
         | install-group | test-package-1.0-1.fc29.noarch    |
-    And stderr is
+    And stderr contains lines
        """
        No match for group from environment: nonexistent-group
 
@@ -568,14 +593,17 @@ Scenario: 'dnf group list -C' works for unprivileged user even when decompressed
   When I execute dnf with args "group list -C" as an unprivileged user
   Then the exit code is 0
   Then stderr does not contain "Permission denied: '{context.dnf.installroot}/var/cache/dnf/dnf-ci-thirdparty-[a-z0-9]{{16}}/repodata/gen'"
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name                 Installed
-    cqrlib-non-devel     CQRlib-non-devel            no
-    dnf-ci-testgroup     DNF-CI-Testgroup            no
-    superripper-and-deps SuperRipper-and-deps        no
-    """
+       """
+       ID                   Name                 Installed
+       cqrlib-non-devel     CQRlib-non-devel            no
+       dnf-ci-testgroup     DNF-CI-Testgroup            no
+       superripper-and-deps SuperRipper-and-deps        no
+       """
 
 
 @dnf5
@@ -586,22 +614,28 @@ Scenario: dnf5 group list: empty output when run for the second time
   When I execute dnf with args "clean metadata"
    And I execute dnf with args "group list"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name         Installed
-    test-group-1         Test Group 1        no
-    test-group-2         Test Group 2        no
-    """
+       """
+       ID                   Name         Installed
+       test-group-1         Test Group 1        no
+       test-group-2         Test Group 2        no
+       """
   When I execute dnf with args "group list"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-    """
-    <REPOSYNC>
-    ID                   Name         Installed
-    test-group-1         Test Group 1        no
-    test-group-2         Test Group 2        no
-    """
+       """
+       ID                   Name         Installed
+       test-group-1         Test Group 1        no
+       test-group-2         Test Group 2        no
+       """
 
 @dnf5
 # This typically covers situations where initial system state is created from
@@ -613,19 +647,22 @@ Scenario: dnf can list installed groups even without their xml definitions prese
     And I delete file "/usr/lib/sysimage/libdnf5/comps_groups/test-group.xml"
    When I execute dnf with args "group info --installed"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Id                   : test-group
-    Name                 : Test Group
-    Description          : Test Group description.
-    Installed            : yes
-    Order                : 
-    Langonly             : 
-    Uservisible          : yes
-    Repositories         : @System
-    Mandatory packages   : test-package
-    """
+        """
+        Id                   : test-group
+        Name                 : Test Group
+        Description          : Test Group description.
+        Installed            : yes
+        Order                : 
+        Langonly             : 
+        Uservisible          : yes
+        Repositories         : @System
+        Mandatory packages   : test-package
+        """
 
 @dnf5
 # In case the group is not available in repositories, minimal solvable is created
@@ -637,19 +674,22 @@ Scenario: dnf can list installed groups even without their xml definitions prese
     And I drop repository "comps-group"
    When I execute dnf with args "group info --installed"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Id                   : test-group
-    Name                 : 
-    Description          : 
-    Installed            : yes
-    Order                : 
-    Langonly             : 
-    Uservisible          : yes
-    Repositories         : @System
-    Default packages     : test-package
-    """
+        """
+        Id                   : test-group
+        Name                 : 
+        Description          : 
+        Installed            : yes
+        Order                : 
+        Langonly             : 
+        Uservisible          : yes
+        Repositories         : @System
+        Default packages     : test-package
+        """
 
 # https://github.com/rpm-software-management/dnf5/issues/917
 @dnf5
@@ -658,6 +698,7 @@ Scenario: Remove group that is not installed
   When I execute dnf with args "group remove dnf-ci-testgroup"
   Then the exit code is 0
    And stderr is
-   """
-   No groups to remove for argument: dnf-ci-testgroup
-   """
+       """
+       <REPOSYNC>
+       No groups to remove for argument: dnf-ci-testgroup
+       """

--- a/dnf-behave-tests/dnf/config-drop-in.feature
+++ b/dnf-behave-tests/dnf/config-drop-in.feature
@@ -28,6 +28,7 @@ Scenario: Config files from the drop-in directories are loaded
    Then the exit code is 1
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Argument 'filesystem' matches only excluded packages.
         Argument 'wget' matches only excluded packages.
@@ -57,6 +58,7 @@ Scenario: In case of the same file name, /etc/dnf/libdnf5.conf.d/... masks usr/s
    Then the exit code is 1
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Argument 'dwm' matches only excluded packages.
         Argument 'filesystem' matches only excluded packages.
@@ -91,6 +93,7 @@ Scenario: The configs are ordered by name
    Then the exit code is 1
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Argument 'flac' matches only excluded packages.
         Argument 'lame' matches only excluded packages.
@@ -118,6 +121,7 @@ Scenario: The /etc/dnf/dnf.conf is loaded last
    Then the exit code is 1
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Argument 'flac' matches only excluded packages.
         """
@@ -131,6 +135,7 @@ Scenario: Fail when explicitly requested config file doesn't exist
    Then the exit code is 1
     And stderr is
         """
+        <REPOSYNC>
         Configuration file "/etc/dnf/libdnf5.conf.d/test.conf" not found
          cannot open file: (2) - No such file or directory [/etc/dnf/libdnf5.conf.d/test.conf]
         """

--- a/dnf-behave-tests/dnf/config.feature
+++ b/dnf-behave-tests/dnf/config.feature
@@ -29,10 +29,11 @@ Scenario: Test with dnf.conf in installroot (dnf.conf is taken from installroot)
    When I execute dnf with args "install filesystem"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Argument 'filesystem' matches only excluded packages.
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Argument 'filesystem' matches only excluded packages.
+        """
 
 
 @dnf5    
@@ -51,10 +52,11 @@ Scenario: Test with dnf.conf in installroot and --config (dnf.conf is taken from
    When I execute dnf with args "--config {context.dnf.installroot}/test/dnf.conf install dwm"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Argument 'dwm' matches only excluded packages.
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Argument 'dwm' matches only excluded packages.
+        """
 
 
 Scenario: Reposdir option in dnf.conf file in installroot
@@ -220,14 +222,14 @@ Scenario: Create dnf.conf file and test if host is using /etc/dnf/dnf.conf
    When I execute dnf with args "install vagare"
    Then the exit code is 1
     And stdout is
-    """
-    <REPOSYNC>
-    All matches were filtered out by exclude filtering for argument: vagare
-    """
+        """
+        All matches were filtered out by exclude filtering for argument: vagare
+        """
     And stderr is
-    """
-    Error: Unable to find a match: vagare
-    """
+        """
+        <REPOSYNC>
+        Error: Unable to find a match: vagare
+        """
 
 
 @no_installroot
@@ -252,14 +254,14 @@ Scenario: Create dnf.conf file and test if host is taking option --config /test/
    When I execute dnf with args "--config /test/dnf.conf install dedalo-signed"
    Then the exit code is 1
     And stdout is
-    """
-    <REPOSYNC>
-    All matches were filtered out by exclude filtering for argument: dedalo-signed
-    """
+        """
+        All matches were filtered out by exclude filtering for argument: dedalo-signed
+        """
     And stderr is
-    """
-    Error: Unable to find a match: dedalo-signed
-    """
+        """
+        <REPOSYNC>
+        Error: Unable to find a match: dedalo-signed
+        """
 
 
 @destructive
@@ -276,14 +278,14 @@ Scenario: Test without dnf.conf in installroot (dnf.conf is taken from host)
    When I execute dnf with args "install vagare"
    Then the exit code is 1
     And stdout is
-    """
-    <REPOSYNC>
-    All matches were filtered out by exclude filtering for argument: vagare
-    """
+        """
+        All matches were filtered out by exclude filtering for argument: vagare
+        """
     And stderr is
-    """
-    Error: Unable to find a match: vagare
-    """
+        """
+        <REPOSYNC>
+        Error: Unable to find a match: vagare
+        """
 
 
 @no_installroot

--- a/dnf-behave-tests/dnf/distro-sync.feature
+++ b/dnf-behave-tests/dnf/distro-sync.feature
@@ -71,7 +71,7 @@ Given I use repository "dnf-ci-gpg"
  When I execute dnf with args "distro-sync wget"
  Then the exit code is 1
   And dnf4 stderr contains "Error: GPG check FAILED"
-  And dnf5 stderr matches line by line
+  And dnf5 stderr contains lines matching
     """
     Transaction failed: Signature verification failed.
     PGP check for package "wget-2\.0\.0-1\.fc29\.x86_64" \(.*/wget-2.0.0-1.fc29.x86_64.rpm\) from repo "dnf-ci-gpg-updates" has failed: Problem occurred when opening the package.
@@ -92,7 +92,7 @@ Given I use repository "dnf-ci-gpg"
  When I execute dnf with args "distro-sync wget"
  Then the exit code is 1
   And dnf4 stderr contains "Error: GPG check FAILED"
-  And dnf5 stderr matches line by line
+  And dnf5 stderr contains lines matching
     """
     Transaction failed: Signature verification failed.
     PGP check for package "wget-2\.0\.0-1\.fc29\.x86_64" \(.*/wget-2.0.0-1.fc29.x86_64.rpm\) from repo "dnf-ci-gpg-updates" has failed: Problem occurred when opening the package.
@@ -108,12 +108,13 @@ Scenario: distro-sync list of packages, one of them is not available
    When I execute dnf with args "distro-sync flac nosuchpkg"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: nosuchpkg
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: nosuchpkg
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
     And Transaction is empty
 
 
@@ -125,10 +126,9 @@ Scenario: distro-sync list of packages with --skip-unavailable, one of them is n
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "distro-sync --skip-unavailable flac nosuchpkg"
    Then the exit code is 0
-    And stderr is
+    And stderr contains lines
     """
     No match for argument: nosuchpkg
-
     Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
     """
     And Transaction is following
@@ -144,7 +144,7 @@ Scenario: distro-sync list of packages, one of them is not installed
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "distro-sync flac dwm"
    Then the exit code is 1
-    And stderr is
+    And stderr contains lines
     """
     Failed to resolve the transaction:
     Packages for argument 'dwm' available, but not installed.
@@ -160,10 +160,9 @@ Scenario: distro-sync list of packages with --skip-unavailable, one of them is n
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "distro-sync --skip-unavailable dwm flac"
    Then the exit code is 0
-    And stderr is
+    And stderr contains lines
     """
     Packages for argument 'dwm' available, but not installed.
-
     Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
     """
     And Transaction is following
@@ -180,15 +179,13 @@ Scenario: distro-sync all with a broken dependency and without best
    When I execute dnf with args "distro-sync --no-best"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Problem: installed package labirinto-2.0-1.noarch requires labirinto-libs = 2.0-1, but none of the providers can be installed
-      - labirinto-libs-2.0-1.noarch does not belong to a distupgrade repository
-      - problem with installed package
-    You can try to add to command line:
-      --skip-broken to skip uninstallable packages
-    """
-    And stdout is
-    """
-    <REPOSYNC>
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Problem: installed package labirinto-2.0-1.noarch requires labirinto-libs = 2.0-1, but none of the providers can be installed
+          - labirinto-libs-2.0-1.noarch does not belong to a distupgrade repository
+          - problem with installed package
+        You can try to add to command line:
+          --skip-broken to skip uninstallable packages
+        """
+    And stdout is empty

--- a/dnf-behave-tests/dnf/downgrade.feature
+++ b/dnf-behave-tests/dnf/downgrade.feature
@@ -25,9 +25,10 @@ Scenario: Downgrade one RPM
    When I execute dnf with args "downgrade flac"
    Then the exit code is 0
     And stderr is
-    """
-    The lowest available version of the "flac.x86_64" package is already installed, cannot downgrade it.
-    """
+        """
+        <REPOSYNC>
+        The lowest available version of the "flac.x86_64" package is already installed, cannot downgrade it.
+        """
 
 
 Scenario: Downgrade RPM that requires downgrade of dependency
@@ -94,10 +95,11 @@ Scenario: Downgrade list of packages, none of them has a downgrade available
    Then the exit code is 0
     And stdout contains "Nothing to do."
     And stderr is
-    """
-    The lowest available version of the "wget.x86_64" package is already installed, cannot downgrade it.
-    The lowest available version of the "abcde.noarch" package is already installed, cannot downgrade it.
-    """
+        """
+        <REPOSYNC>
+        The lowest available version of the "wget.x86_64" package is already installed, cannot downgrade it.
+        The lowest available version of the "abcde.noarch" package is already installed, cannot downgrade it.
+        """
     And Transaction is empty
 
 
@@ -107,12 +109,13 @@ Scenario: Downgrade list of packages, one of them is not available
    When I execute dnf with args "downgrade flac nosuchpkg"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: nosuchpkg
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: nosuchpkg
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
     And Transaction is empty
 
 
@@ -121,7 +124,7 @@ Scenario: Downgrade list of packages with --skip-unavailable, one of them is not
    Then the exit code is 0
    When I execute dnf with args "downgrade --skip-unavailable flac nosuchpkg"
    Then the exit code is 0
-    And stderr is
+    And stderr contains lines
     """
     No match for argument: nosuchpkg
 
@@ -137,7 +140,7 @@ Scenario: Downgrade list of packages, one of them is not installed
    Then the exit code is 0
    When I execute dnf with args "downgrade flac abcde"
    Then the exit code is 1
-    And stderr is
+    And stderr contains lines
     """
     Failed to resolve the transaction:
     Packages for argument 'abcde' available, but not installed.
@@ -150,7 +153,7 @@ Scenario: Downgrade list of packages with --skip-unavailable, one of them is not
    Then the exit code is 0
    When I execute dnf with args "downgrade --skip-unavailable flac abcde"
    Then the exit code is 0
-    And stderr is
+    And stderr contains lines
     """
     Packages for argument 'abcde' available, but not installed.
 
@@ -166,7 +169,7 @@ Scenario: Downgrade mixture of not available/not installed/not downgradable/down
    Then the exit code is 0
    When I execute dnf with args "downgrade nosuchpkg flac wget abcde"
    Then the exit code is 1
-    And stderr is
+    And stderr contains lines
     """
     Failed to resolve the transaction:
     No match for argument: nosuchpkg
@@ -183,7 +186,7 @@ Scenario: Downgrade mixture of not available/not installed/not downgradable/down
    Then the exit code is 0
    When I execute dnf with args "downgrade --skip-unavailable nosuchpkg flac wget abcde"
    Then the exit code is 0
-    And stderr is
+    And stderr contains lines
     """
     No match for argument: nosuchpkg
     The lowest available version of the "wget.x86_64" package is already installed, cannot downgrade it.
@@ -202,12 +205,13 @@ Scenario Outline: Check <command> exit code - package does not exist
    When I execute dnf with args "<command> non-existent-package"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: non-existent-package
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: non-existent-package
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
 
 Examples:
     | command   |
@@ -220,10 +224,11 @@ Scenario Outline: Check <command> exit code - package not installed
    When I execute dnf with args "<command> flac"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Packages for argument 'flac' available, but not installed.
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Packages for argument 'flac' available, but not installed.
+        """
 
 Examples:
     | command   |
@@ -237,11 +242,14 @@ Scenario: Check upgrade exit code - package already on the highest version
     And I successfully execute dnf with args "install flac-0:1.3.3-3.fc29.x86_64"
    When I execute dnf with args "upgrade flac"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+        """
+        Nothing to do.
+        """
 
 
 @bz1759847
@@ -251,11 +259,11 @@ Scenario: Check downgrade exit code - package already on the lowest version
    When I execute dnf with args "downgrade flac"
    Then the exit code is 0
     And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+        """
+        Nothing to do.
+        """
     And stderr is
-    """
-    The lowest available version of the "flac.x86_64" package is already installed, cannot downgrade it.
-    """
+        """
+        <REPOSYNC>
+        The lowest available version of the "flac.x86_64" package is already installed, cannot downgrade it.
+        """

--- a/dnf-behave-tests/dnf/download-binary-xml-base.feature
+++ b/dnf-behave-tests/dnf/download-binary-xml-base.feature
@@ -22,7 +22,10 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I generate repodata for repository "dnf-ci-fedora" with extra arguments "--baseurl http://localhost:{context.dnf.ports[dnf-ci-fedora]}"
   And I use repository "dnf-ci-fedora"
  When I execute dnf with args "download setup --destdir={context.dnf.tempdir}"
- Then stderr is empty
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
  Then the exit code is 0
   And file sha256 checksums are following
       | Path                                                 | sha256                                                                                     |
@@ -36,7 +39,10 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I use repository "dnf-ci-fedora" as http
  When I execute dnf with args "download setup --destdir={context.dnf.tempdir}"
  Then the exit code is 0
- Then stderr is empty
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
   And file sha256 checksums are following
       | Path                                                 | sha256                                                                                     |
       | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm |
@@ -53,7 +59,10 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
       | baseurl | file://{context.dnf.installroot}/merged_repo |
  When I execute dnf with args "download setup alternator --destdir={context.dnf.tempdir}"
  Then the exit code is 0
-  And stderr is empty
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And file sha256 checksums are following
       | Path                                                 | sha256                                                                                      |
       | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm  |

--- a/dnf-behave-tests/dnf/download-binary.feature
+++ b/dnf-behave-tests/dnf/download-binary.feature
@@ -18,7 +18,7 @@ Scenario: Download an RPM that doesn't exist
 Scenario: Download an existing RPM
    When I execute dnf with args "download setup"
    Then the exit code is 0
-    And stdout contains "setup-0:2.12.1-1.fc29.noarch"
+    And stderr contains "setup-0:2.12.1-1.fc29.noarch"
     And file sha256 checksums are following
         | Path                                                  | sha256                                                                                        |
         | {context.dnf.tempdir}/setup-2.12.1-1.fc29.noarch.rpm  | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/setup-2.12.1-1.fc29.noarch.rpm    |
@@ -27,8 +27,8 @@ Scenario: Download an existing RPM
 Scenario: Download an existing RPM with dependencies
    When I execute dnf with args "download filesystem --resolve"
    Then the exit code is 0
-    And stdout contains "filesystem-0:3.9-2.fc29.x86_64"
-    And stdout contains "setup-0:2.12.1-1.fc29.noarch"
+    And stderr contains "filesystem-0:3.9-2.fc29.x86_64"
+    And stderr contains "setup-0:2.12.1-1.fc29.noarch"
     And file sha256 checksums are following
         | Path                                                      | sha256                                                                                        |
         | {context.dnf.tempdir}/filesystem-3.9-2.fc29.x86_64.rpm    | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm  |
@@ -38,7 +38,7 @@ Scenario: Download an existing RPM with dependencies
 @bz1844925
 Scenario: Error when failed to resolve dependencies
    When I execute dnf with args "download filesystem --resolve --exclude setup"
-    Then stderr is
+    Then stderr contains lines
         """
         Failed to resolve the transaction:
         Problem: package filesystem-3.9-2.fc29.x86_64 from dnf-ci-fedora requires setup, but none of the providers can be installed
@@ -51,8 +51,8 @@ Scenario: Error when failed to resolve dependencies
 Scenario: Download an existing RPM with dependencies into a --destdir
    When I execute dnf with args "download filesystem --resolve --destdir={context.dnf.tempdir}/downloaddir"
    Then the exit code is 0
-    And stdout contains "filesystem-0:3.9-2.fc29.x86_64"
-    And stdout contains "setup-0:2.12.1-1.fc29.noarch"
+    And stderr contains "filesystem-0:3.9-2.fc29.x86_64"
+    And stderr contains "setup-0:2.12.1-1.fc29.noarch"
     And file sha256 checksums are following
         | Path                                                                  | sha256                                                                                        |
         | {context.dnf.tempdir}/downloaddir/filesystem-3.9-2.fc29.x86_64.rpm    | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/x86_64/filesystem-3.9-2.fc29.x86_64.rpm  |
@@ -67,9 +67,9 @@ Scenario: Download an existing RPM with dependencies into a --destdir where a de
         | install       | setup-0:2.12.1-1.fc29.noarch          |
    When I execute dnf with args "download basesystem --resolve --destdir={context.dnf.tempdir}/downloaddir"
    Then the exit code is 0
-    And stdout contains "basesystem-0:11-6.fc29.noarch"
-    And stdout contains "filesystem-0:3.9-2.fc29.x86_64"
-    And stdout does not contain "setup-2.12.1-1.fc29.noarch"
+    And stderr contains "basesystem-0:11-6.fc29.noarch"
+    And stderr contains "filesystem-0:3.9-2.fc29.x86_64"
+    And stderr does not contain "setup-2.12.1-1.fc29.noarch"
     And file sha256 checksums are following
         | Path                                                                  | sha256                                                                                        |
         | {context.dnf.tempdir}/downloaddir/basesystem-11-6.fc29.noarch.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/basesystem-11-6.fc29.noarch.rpm   |
@@ -87,9 +87,9 @@ Scenario: Download an existing RPM with dependencies into a --destdir where all 
         | install-dep   | setup-0:2.12.1-1.fc29.noarch          |
    When I execute dnf with args "download basesystem --resolve --destdir={context.dnf.tempdir}/downloaddir"
    Then the exit code is 0
-    And stdout contains "basesystem-0:11-6.fc29.noarch"
-    And stdout does not contain "filesystem-0:3.9-2.fc29.x86_64"
-    And stdout does not contain "setup-0:2.12.1-1.fc29.noarch"
+    And stderr contains "basesystem-0:11-6.fc29.noarch"
+    And stderr does not contain "filesystem-0:3.9-2.fc29.x86_64"
+    And stderr does not contain "setup-0:2.12.1-1.fc29.noarch"
     And file sha256 checksums are following
         | Path                                                                  | sha256                                                                                        |
         | {context.dnf.tempdir}/downloaddir/basesystem-11-6.fc29.noarch.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/noarch/basesystem-11-6.fc29.noarch.rpm   |
@@ -102,13 +102,13 @@ Scenario: Download an existing RPM when there are multiple packages of the same 
   Given I use repository "dnf-ci-gpg" as http
    When I execute dnf with args "download --destdir={context.dnf.installroot}/downloaddir setup filesystem wget"
    Then the exit code is 0
-    And stdout contains "setup-0:2.12.1-1.fc29.noarch"
-    And stdout contains "filesystem-0:3.9-2.fc29.x86_64"
-    And stdout contains "wget-0:1.19.5-5.fc29.x86_64"
+    And stderr contains "setup-0:2.12.1-1.fc29.noarch"
+    And stderr contains "filesystem-0:3.9-2.fc29.x86_64"
+    And stderr contains "wget-0:1.19.5-5.fc29.x86_64"
       # check that each file was being downloaded only once
-    And stdout does not contain "setup-0:2.12.1-1.fc29.noarch.*setup-0:2.12.1-1.fc29.noarch"
-    And stdout does not contain "filesystem-0:3.9-2.fc29.x86_64.*filesystem-0:3.9-2.fc29.x86_64"
-    And stdout does not contain "wget-0:1.19.5-5.fc29.x86_64.*wget-0:1.19.5-5.fc29.x86_64"
+    And stderr does not contain "setup-0:2.12.1-1.fc29.noarch.*setup-0:2.12.1-1.fc29.noarch"
+    And stderr does not contain "filesystem-0:3.9-2.fc29.x86_64.*filesystem-0:3.9-2.fc29.x86_64"
+    And stderr does not contain "wget-0:1.19.5-5.fc29.x86_64.*wget-0:1.19.5-5.fc29.x86_64"
       # check that the files have been downloaded
     And file "downloaddir/setup-2.12.1-1.fc29.noarch.rpm" exists
     And file "downloaddir/filesystem-3.9-2.fc29.x86_64.rpm" exists

--- a/dnf-behave-tests/dnf/download-source.feature
+++ b/dnf-behave-tests/dnf/download-source.feature
@@ -109,7 +109,7 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I delete directory "/{context.dnf.repos[dnf-ci-fedora].path}/noarch"
  When I execute dnf with args "--setopt=keepcache=true install setup"
  Then the exit code is 0
-  And stderr is
+  And stderr contains lines
   """
   Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora
   """
@@ -129,7 +129,7 @@ Given I make packages from repository "dnf-ci-fedora" accessible via http
   And I delete directory "/{context.dnf.repos[dnf-ci-fedora].path}/noarch"
  When I execute dnf with args "install setup"
  Then the exit code is 0
-  And stderr is
+  And stderr contains lines
   """
   Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora
   """

--- a/dnf-behave-tests/dnf/download.feature
+++ b/dnf-behave-tests/dnf/download.feature
@@ -155,8 +155,8 @@ Given I use repository "simple-base" as http
   And I execute dnf with args "download labirinto --destdir={context.dnf.tempdir}/downloaddir"
  When I execute dnf with args "download labirinto --destdir={context.dnf.tempdir}/downloaddir"
  Then the exit code is 0
-  And stdout contains "labirinto-0:1.0-1.fc29.src             100% \|   0.0   B/s \|   0.0   B \|  00m00s\n>>> Already downloaded"
-  And stdout contains "labirinto-0:1.0-1.fc29.x86_64          100% \|   0.0   B/s \|   0.0   B \|  00m00s\n>>> Already downloaded"
+  And stderr contains "labirinto-0:1.0-1.fc29.src             100% \|   0.0   B/s \|   0.0   B \|  00m00s\n>>> Already downloaded"
+  And stderr contains "labirinto-0:1.0-1.fc29.x86_64          100% \|   0.0   B/s \|   0.0   B \|  00m00s\n>>> Already downloaded"
 
 
 @bz2077864

--- a/dnf-behave-tests/dnf/downloadonly.feature
+++ b/dnf-behave-tests/dnf/downloadonly.feature
@@ -9,7 +9,7 @@ Scenario: Install/reinstall/upgrade work correctly with --downloadonly option
 
    When I execute dnf with args "install wget"
    Then the exit code is 0
-    And stdout contains "Need to download 0 B."
+    And stderr contains "Need to download 0 B."
     And RPMDB Transaction is following
         | Action        | Package                                   |
         | install       | wget-0:1.19.5-5.fc29.x86_64               |
@@ -18,7 +18,7 @@ Scenario: Install/reinstall/upgrade work correctly with --downloadonly option
    Then the exit code is 0
     And RPMDB Transaction is empty
    When I execute dnf with args "reinstall wget"
-   Then stdout contains "Need to download 0 B."
+   Then stderr contains "Need to download 0 B."
 
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade --downloadonly wget"
@@ -29,7 +29,7 @@ Scenario: Install/reinstall/upgrade work correctly with --downloadonly option
 
    When I execute dnf with args "upgrade wget"
    Then the exit code is 0
-    And stdout contains "Need to download 0 B."
+    And stderr contains "Need to download 0 B."
     And RPMDB Transaction is following
         | Action        | Package                                   |
         | upgrade       | wget-0:1.19.6-5.fc29.x86_64               |
@@ -46,7 +46,7 @@ Scenario: Downgrade works correctly with --downloadonly option
 
    When I execute dnf with args "downgrade wget"
    Then the exit code is 0
-    And stdout contains "Need to download 0 B."
+    And stderr contains "Need to download 0 B."
     And RPMDB Transaction is following
         | Action        | Package                                   |
         | downgrade     | wget-0:1.19.5-5.fc29.x86_64               |
@@ -59,5 +59,5 @@ Scenario: Group install works correctly with --downloadonly
     And RPMDB Transaction is empty
    When I execute dnf with args "group install dnf-ci-testgroup"
    Then the exit code is 0
-    And stdout contains "Need to download 0 B."
+    And stderr contains "Need to download 0 B."
 

--- a/dnf-behave-tests/dnf/fileprovides.feature
+++ b/dnf-behave-tests/dnf/fileprovides.feature
@@ -9,7 +9,8 @@ Scenario: Run repoclosure with already created cache without filelists
     # This command requires filelists.xml
    When I execute dnf with args "repoclosure"
    Then the exit code is 0
-   Then stdout is
-   """
-   <REPOSYNC>
-   """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is empty

--- a/dnf-behave-tests/dnf/gpg.feature
+++ b/dnf-behave-tests/dnf/gpg.feature
@@ -73,7 +73,7 @@ Scenario: Fail to install signed package with incorrectly signed dependency (wit
         | install-dep   | glibc-common-0:2.28-9.fc29.x86_64         |
         | install-dep   | glibc-all-langpacks-0:2.28-9.fc29.x86_64  |
     And RPMDB Transaction is empty
-    And stderr matches line by line
+    And stderr contains lines matching
     """
     Transaction failed: Signature verification failed
     PGP check for package "basesystem-11-6\.fc29\.noarch" \(.*/basesystem-11-6\.fc29\.noarch\.rpm\) from repo "dnf-ci-gpg" has failed: Public key is not installed\.
@@ -89,7 +89,7 @@ Scenario: Fail to install signed package with incorrect checksum
         | Action        | Package                               |
         | install       | broken-package-0:0.2.4-1.fc29.noarch  |
     And RPMDB Transaction is empty
-    And stderr matches line by line
+    And stderr contains lines matching
     """
     Transaction failed: Signature verification failed
     PGP check for package "broken-package-0\.2\.4-1\.fc29\.noarch" \(.*/broken-package-0\.2\.4-1\.fc29\.noarch\.rpm\) from repo "dnf-ci-gpg" has failed: Problem occurred when opening the package\.
@@ -119,7 +119,7 @@ Scenario: Install masterkey signed, unsigned and masterkey signed with unknown k
 Scenario: Attempt to install unsigned package from repo with gpgcheck=1
    When I execute dnf with args "install flac"
    Then the exit code is 1
-    And stderr matches line by line
+    And stderr contains lines matching
     """
     Transaction failed: Signature verification failed
     PGP check for package "flac-1\.3\.2-8\.fc29\.x86_64" \(.*/flac-1\.3\.2-8\.fc29\.x86_64\.rpm\) from repo "dnf-ci-gpg" has failed: The package is not signed\.

--- a/dnf-behave-tests/dnf/history-redo-comps.feature
+++ b/dnf-behave-tests/dnf/history-redo-comps.feature
@@ -57,12 +57,13 @@ Scenario: Redo a transaction with a missing group
    When I execute dnf with args "history redo 1"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: dnf-ci-testgroup
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: dnf-ci-testgroup
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
 
 
 Scenario: Redo a transaction that removed a group and the group is was removed from the system already

--- a/dnf-behave-tests/dnf/history-redo.feature
+++ b/dnf-behave-tests/dnf/history-redo.feature
@@ -49,6 +49,7 @@ Scenario: Redo a transaction with a package that is no longer available
    Then the exit code is 1
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Cannot perform Install action because 'filesystem-3.9-2.fc29.x86_64' matches only excluded packages.
         """
@@ -60,7 +61,7 @@ Scenario: Redo a transaction with a package that is no longer available and --sk
     And Transaction is following
         | Action        | Package                                    |
         | install-dep   | setup-0:2.12.1-1.fc29.noarch               |
-    And stderr is
+    And stderr contains lines
         """
         Cannot perform Install action because 'filesystem-3.9-2.fc29.x86_64' matches only excluded packages.
 

--- a/dnf-behave-tests/dnf/history-rollback-env-upgrade.feature
+++ b/dnf-behave-tests/dnf/history-rollback-env-upgrade.feature
@@ -19,12 +19,15 @@ Background:
         | 1      | group install dnf-ci-group-rollback-testenv          |        | 7         |
    When I execute dnf with args "environment list --installed dnf-ci-group-rollback-testenv"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ID                            Name                   Installed
-    dnf-ci-group-rollback-testenv DNF-CI-RollbackTestEnv       yes
-    """
+        """
+        ID                            Name                   Installed
+        dnf-ci-group-rollback-testenv DNF-CI-RollbackTestEnv       yes
+        """
   Given I use repository "dnf-ci-group-rollback-2"
     And I successfully execute dnf with args "group upgrade dnf-ci-group-rollback-testenv"
    Then Transaction is following
@@ -59,12 +62,15 @@ Scenario: Rollback an environment upgrade transaction
         | 1      | group install dnf-ci-group-rollback-testenv          |        | 7         |
    When I execute dnf with args "environment list --installed dnf-ci-group-rollback-testenv"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ID                            Name                   Installed
-    dnf-ci-group-rollback-testenv DNF-CI-RollbackTestEnv       yes
-    """
+        """
+        ID                            Name                   Installed
+        dnf-ci-group-rollback-testenv DNF-CI-RollbackTestEnv       yes
+        """
 
 
 @bz2016070
@@ -77,14 +83,14 @@ Scenario: Rollback a rollbacked environment upgrade transaction
         | downgrade              | TestGroup1PackageB-0:1.0-1.x86_64    |
         | downgrade              | TestGroup2PackageA-0:1.0-1.x86_64    |
         | downgrade              | TestGroup2PackageB-0:1.0-1.x86_64    |
-    And stderr is
-    """
-    Group upgrade cannot be reverted, however associated package actions will be. (Group id: 'dnf-ci-group-rollback-testgroup1') .
-    Group upgrade cannot be reverted, however associated package actions will be. (Group id: 'dnf-ci-group-rollback-testgroup2') .
-    Environment upgrade cannot be reverted, however associated package actions will be. (Environment id: 'dnf-ci-group-rollback-testenv') .
+    And stderr contains lines
+        """
+        Group upgrade cannot be reverted, however associated package actions will be. (Group id: 'dnf-ci-group-rollback-testgroup1') .
+        Group upgrade cannot be reverted, however associated package actions will be. (Group id: 'dnf-ci-group-rollback-testgroup2') .
+        Environment upgrade cannot be reverted, however associated package actions will be. (Environment id: 'dnf-ci-group-rollback-testenv') .
 
-    Warning: skipped PGP checks for 4 packages from repository: dnf-ci-group-rollback-1
-    """
+        Warning: skipped PGP checks for 4 packages from repository: dnf-ci-group-rollback-1
+        """
     And History is following
         | Id     | Command                                              | Action | Altered   |
         | 3      | history rollback 1                                   |        | 8         |
@@ -106,12 +112,15 @@ Scenario: Rollback a rollbacked environment upgrade transaction
         | 1      | group install dnf-ci-group-rollback-testenv          |        | 7         |
    When I execute dnf with args "environment list --installed DNF-CI-RollbackTestEnv"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ID                            Name                   Installed
-    dnf-ci-group-rollback-testenv DNF-CI-RollbackTestEnv       yes
-    """
+        """
+        ID                            Name                   Installed
+        dnf-ci-group-rollback-testenv DNF-CI-RollbackTestEnv       yes
+        """
 
 
 @bz2016070

--- a/dnf-behave-tests/dnf/history-rollback-group-upgrade.feature
+++ b/dnf-behave-tests/dnf/history-rollback-group-upgrade.feature
@@ -15,12 +15,15 @@ Background:
         | 1      | group install dnf-ci-group-rollback-testgroup1       |        | 3         |
    When I execute dnf with args "group list --installed dnf-ci-group-rollback-testgroup1"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ID                               Name                      Installed
-    dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
-    """
+        """
+        ID                               Name                      Installed
+        dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
+        """
   Given I use repository "dnf-ci-group-rollback-2"
     And I successfully execute dnf with args "group upgrade dnf-ci-group-rollback-testgroup1"
    Then Transaction is following
@@ -49,12 +52,15 @@ Scenario: Rollback a group upgrade transaction
         | 1      | group install dnf-ci-group-rollback-testgroup1       |        | 3         |
    When I execute dnf with args "group list --installed dnf-ci-group-rollback-testgroup1"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ID                               Name                      Installed
-    dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
-    """
+        """
+        ID                               Name                      Installed
+        dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
+        """
 
 
 @bz2016070
@@ -65,7 +71,7 @@ Scenario: Rollback a rollbacked group upgrade transaction
         | Action                 | Package                              |
         | downgrade              | TestGroup1PackageA-0:1.0-1.x86_64    |
         | downgrade              | TestGroup1PackageB-0:1.0-1.x86_64    |
-    And stderr is
+    And stderr contains lines
     """
     Group upgrade cannot be reverted, however associated package actions will be. (Group id: 'dnf-ci-group-rollback-testgroup1') .
 
@@ -90,12 +96,15 @@ Scenario: Rollback a rollbacked group upgrade transaction
         | 1      | group install dnf-ci-group-rollback-testgroup1       |        | 3         |
    When I execute dnf with args "group list --installed dnf-ci-group-rollback-testgroup1"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ID                               Name                      Installed
-    dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
-    """
+        """
+        ID                               Name                      Installed
+        dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
+        """
 
 
 @bz2016070
@@ -145,12 +154,15 @@ Scenario: Rollback multiple group upgrade transactions
         | 1      | group install dnf-ci-group-rollback-testgroup1       |        | 3         |
    When I execute dnf with args "group list --installed dnf-ci-group-rollback-testgroup1"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ID                               Name                      Installed
-    dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
-    """
+        """
+        ID                               Name                      Installed
+        dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
+        """
 
 
 @bz2016070
@@ -209,9 +221,12 @@ Scenario: Excluded package is remembered until next group install when rolling b
         | 1      | group install dnf-ci-group-rollback-testgroup1       |        | 3         |
    When I execute dnf with args "group list --installed dnf-ci-group-rollback-testgroup1"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ID                               Name                      Installed
-    dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
-    """
+        """
+        ID                               Name                      Installed
+        dnf-ci-group-rollback-testgroup1 DNF-CI-RollbackTestGroup1       yes
+        """

--- a/dnf-behave-tests/dnf/history-rollback.feature
+++ b/dnf-behave-tests/dnf/history-rollback.feature
@@ -42,10 +42,11 @@ Scenario: Rollback a transaction with a package that is no longer available
    When I execute dnf with args "history rollback 1 -x glibc-2.28-26.fc29.x86_64"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Cannot perform Remove action because 'glibc-2.28-26.fc29.x86_64' matches only excluded packages.
-    Problem: installed package glibc-2.28-26.fc29.x86_64 requires glibc-common = 2.28-26.fc29, but none of the providers can be installed
-      - conflicting requests
-      - problem with installed package
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Cannot perform Remove action because 'glibc-2.28-26.fc29.x86_64' matches only excluded packages.
+        Problem: installed package glibc-2.28-26.fc29.x86_64 requires glibc-common = 2.28-26.fc29, but none of the providers can be installed
+          - conflicting requests
+          - problem with installed package
+        """

--- a/dnf-behave-tests/dnf/history-undo-comps.feature
+++ b/dnf-behave-tests/dnf/history-undo-comps.feature
@@ -69,9 +69,10 @@ Scenario: Undo a transaction with a missing group
    When I execute dnf with args "history undo last"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: dnf-ci-testgroup
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: dnf-ci-testgroup
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """

--- a/dnf-behave-tests/dnf/history-undo-dependant.feature
+++ b/dnf-behave-tests/dnf/history-undo-dependant.feature
@@ -14,15 +14,13 @@ Scenario: Undo module install with dependent userinstalled package
    When I execute dnf with args "history undo last-1"
    # the transaction is not supposed to reinstall required packages, but to fail
    Then the exit code is 1
-    And stdout is
-    """
-    <REPOSYNC>
-    """
+    And stdout is empty
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Extra package 'postgresql-test-9.6.8-1.module_1710+b535a823.x86_64' (with action 'Remove') which is not present in the stored transaction was pulled into the transaction.
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Extra package 'postgresql-test-9.6.8-1.module_1710+b535a823.x86_64' (with action 'Remove') which is not present in the stored transaction was pulled into the transaction.
 
-    You can try to add to command line:
-      --ignore-extras to allow extra packages in the transaction
-    """
+        You can try to add to command line:
+          --ignore-extras to allow extra packages in the transaction
+        """

--- a/dnf-behave-tests/dnf/history-undo.feature
+++ b/dnf-behave-tests/dnf/history-undo.feature
@@ -70,13 +70,14 @@ Scenario: Handle missing packages required for undoing the transaction
      Then the exit code is 1
      And Transaction is empty
      And stderr is
-     """
-     Failed to resolve the transaction:
-     Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
-     Cannot perform Install action, no match for: flac-1.3.2-8.fc29.x86_64.
-     You can try to add to command line:
-       --skip-unavailable to skip unavailable packages
-     """
+         """
+         <REPOSYNC>
+         Failed to resolve the transaction:
+         Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
+         Cannot perform Install action, no match for: flac-1.3.2-8.fc29.x86_64.
+         You can try to add to command line:
+           --skip-unavailable to skip unavailable packages
+         """
 
 
 Scenario: Missing packages are skipped if --skip-unavailable is specified
@@ -98,10 +99,11 @@ Scenario: Missing packages are skipped if --skip-unavailable is specified
      Then the exit code is 0
      And Transaction is empty
      And stderr is
-     """
-     Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
-     Cannot perform Install action, no match for: flac-1.3.2-8.fc29.x86_64.
-     """
+         """
+         <REPOSYNC>
+         Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
+         Cannot perform Install action, no match for: flac-1.3.2-8.fc29.x86_64.
+         """
 
 
 Scenario: Undo a transaction with a package that is no longer available
@@ -109,13 +111,14 @@ Scenario: Undo a transaction with a package that is no longer available
    When I execute dnf with args "history undo 1 -x filesystem"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Cannot perform Remove action because 'filesystem-3.9-2.fc29.x86_64' matches only excluded packages.
-    Problem: installed package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed
-      - conflicting requests
-      - problem with installed package
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Cannot perform Remove action because 'filesystem-3.9-2.fc29.x86_64' matches only excluded packages.
+        Problem: installed package filesystem-3.9-2.fc29.x86_64 requires setup, but none of the providers can be installed
+          - conflicting requests
+          - problem with installed package
+        """
 
 
 @bz2010259
@@ -234,7 +237,7 @@ Scenario: Undo a downgrade transaction
     And Transaction is following
         | Action  | Package                     |
         | upgrade | wget-0:1.19.6-5.fc29.x86_64 |
-    And stderr is
+    And stderr contains lines
     """
     Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
     """
@@ -249,11 +252,11 @@ Scenario: Undo an upgrade transaction with --skip-unavailable where the orignal 
    Then the exit code is 0
     And Transaction is empty
     And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+        """
+        Nothing to do.
+        """
     And stderr is
-    """
-    Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
-    """
+        """
+        <REPOSYNC>
+        Cannot perform Install action, no match for: wget-1.19.5-5.fc29.x86_64.
+        """

--- a/dnf-behave-tests/dnf/info.feature
+++ b/dnf-behave-tests/dnf/info.feature
@@ -10,9 +10,10 @@ Scenario: dnf info nonexistentpkg
  When I execute dnf with args "info non-existent-pkg"
  Then the exit code is 1
   And stderr is
-  """
-  No matching packages to list
-  """
+      """
+      <REPOSYNC>
+      No matching packages to list
+      """
 
 
 @dnf5
@@ -33,25 +34,28 @@ Scenario: dnf info --extras (installed pkgs, not from known repos)
 Given I drop repository "dnf-ci-fedora"
   And I execute dnf with args "info --extras"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Extra packages
-  Name            : setup
-  Epoch           : 0
-  Version         : 2.12.1
-  Release         : 1.fc29
-  Architecture    : noarch
-  Installed size  : 0.0   B
-  Source          : setup-2.12.1-1.fc29.src.rpm
-  From repository : dnf-ci-fedora
-  Summary         : A set of system configuration and setup files
-  URL             : https://pagure.io/setup/
-  License         : Public Domain
-  Description     : The setup package contains a set of important system configuration and
-                  : setup files, such as passwd, group, and profile.
-  Vendor          : <NULL>
-  """
+      """
+      Extra packages
+      Name            : setup
+      Epoch           : 0
+      Version         : 2.12.1
+      Release         : 1.fc29
+      Architecture    : noarch
+      Installed size  : 0.0   B
+      Source          : setup-2.12.1-1.fc29.src.rpm
+      From repository : dnf-ci-fedora
+      Summary         : A set of system configuration and setup files
+      URL             : https://pagure.io/setup/
+      License         : Public Domain
+      Description     : The setup package contains a set of important system configuration and
+                      : setup files, such as passwd, group, and profile.
+      Vendor          : <NULL>
+      """
 
 
 @dnf5
@@ -60,25 +64,28 @@ Scenario: dnf info setup (when setup is installed)
  Then the exit code is 0
 Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "info setup"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  Name            : setup
-  Epoch           : 0
-  Version         : 2.12.1
-  Release         : 1.fc29
-  Architecture    : noarch
-  Installed size  : 0.0   B
-  Source          : setup-2.12.1-1.fc29.src.rpm
-  From repository : dnf-ci-fedora
-  Summary         : A set of system configuration and setup files
-  URL             : https://pagure.io/setup/
-  License         : Public Domain
-  Description     : The setup package contains a set of important system configuration and
-                  : setup files, such as passwd, group, and profile.
-  Vendor          : <NULL>
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      Name            : setup
+      Epoch           : 0
+      Version         : 2.12.1
+      Release         : 1.fc29
+      Architecture    : noarch
+      Installed size  : 0.0   B
+      Source          : setup-2.12.1-1.fc29.src.rpm
+      From repository : dnf-ci-fedora
+      Summary         : A set of system configuration and setup files
+      URL             : https://pagure.io/setup/
+      License         : Public Domain
+      Description     : The setup package contains a set of important system configuration and
+                      : setup files, such as passwd, group, and profile.
+      Vendor          : <NULL>
+      """
 
 @dnf5
 Scenario: dnf info is case insensitive
@@ -86,64 +93,70 @@ Scenario: dnf info is case insensitive
  Then the exit code is 0
 Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "info SETUP"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  Name            : setup
-  Epoch           : 0
-  Version         : 2.12.1
-  Release         : 1.fc29
-  Architecture    : noarch
-  Installed size  : 0.0   B
-  Source          : setup-2.12.1-1.fc29.src.rpm
-  From repository : dnf-ci-fedora
-  Summary         : A set of system configuration and setup files
-  URL             : https://pagure.io/setup/
-  License         : Public Domain
-  Description     : The setup package contains a set of important system configuration and
-                  : setup files, such as passwd, group, and profile.
-  Vendor          : <NULL>
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      Name            : setup
+      Epoch           : 0
+      Version         : 2.12.1
+      Release         : 1.fc29
+      Architecture    : noarch
+      Installed size  : 0.0   B
+      Source          : setup-2.12.1-1.fc29.src.rpm
+      From repository : dnf-ci-fedora
+      Summary         : A set of system configuration and setup files
+      URL             : https://pagure.io/setup/
+      License         : Public Domain
+      Description     : The setup package contains a set of important system configuration and
+                      : setup files, such as passwd, group, and profile.
+      Vendor          : <NULL>
+      """
 
 @dnf5
 Scenario: dnf info setup (when setup is not installed but it is available)
  When I execute dnf with args "info setup"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Available packages
-  Name           : setup
-  Epoch          : 0
-  Version        : 2.12.1
-  Release        : 1.fc29
-  Architecture   : noarch
-  Download size  : [0-9.]+ KiB
-  Installed size : 0.0   B
-  Source         : setup-2.12.1-1.fc29.src.rpm
-  Repository     : dnf-ci-fedora
-  Summary        : A set of system configuration and setup files
-  URL            : https://pagure.io/setup/
-  License        : Public Domain
-  Description    : The setup package contains a set of important system configuration and
-                 : setup files, such as passwd, group, and profile.
-  Vendor         :
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Available packages
+      Name           : setup
+      Epoch          : 0
+      Version        : 2.12.1
+      Release        : 1.fc29
+      Architecture   : noarch
+      Download size  : [0-9.]+ KiB
+      Installed size : 0.0   B
+      Source         : setup-2.12.1-1.fc29.src.rpm
+      Repository     : dnf-ci-fedora
+      Summary        : A set of system configuration and setup files
+      URL            : https://pagure.io/setup/
+      License        : Public Domain
+      Description    : The setup package contains a set of important system configuration and
+                     : setup files, such as passwd, group, and profile.
+      Vendor         :
 
-  Name           : setup
-  Epoch          : 0
-  Version        : 2.12.1
-  Release        : 1.fc29
-  Architecture   : src
-  Download size  : [0-9.]+ KiB
-  Installed size : 616.0   B
-  Repository     : dnf-ci-fedora
-  Summary        : A set of system configuration and setup files
-  URL            : https://pagure.io/setup/
-  License        : Public Domain
-  Description    : The setup package contains a set of important system configuration and
-                 : setup files, such as passwd, group, and profile.
-  Vendor         :
-  """
+      Name           : setup
+      Epoch          : 0
+      Version        : 2.12.1
+      Release        : 1.fc29
+      Architecture   : src
+      Download size  : [0-9.]+ KiB
+      Installed size : 616.0   B
+      Repository     : dnf-ci-fedora
+      Summary        : A set of system configuration and setup files
+      URL            : https://pagure.io/setup/
+      License        : Public Domain
+      Description    : The setup package contains a set of important system configuration and
+                     : setup files, such as passwd, group, and profile.
+      Vendor         :
+      """
 
 
 @dnf5
@@ -152,25 +165,28 @@ Scenario: dnf info --installed setup (when setup is installed)
  Then the exit code is 0
 Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "info --installed setup"
- Then stdout is
-  """
-  <REPOSYNC>
-  Installed packages
-  Name            : setup
-  Epoch           : 0
-  Version         : 2.12.1
-  Release         : 1.fc29
-  Architecture    : noarch
-  Installed size  : 0.0   B
-  Source          : setup-2.12.1-1.fc29.src.rpm
-  From repository : dnf-ci-fedora
-  Summary         : A set of system configuration and setup files
-  URL             : https://pagure.io/setup/
-  License         : Public Domain
-  Description     : The setup package contains a set of important system configuration and
-                  : setup files, such as passwd, group, and profile.
-  Vendor          : <NULL>
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      Installed packages
+      Name            : setup
+      Epoch           : 0
+      Version         : 2.12.1
+      Release         : 1.fc29
+      Architecture    : noarch
+      Installed size  : 0.0   B
+      Source          : setup-2.12.1-1.fc29.src.rpm
+      From repository : dnf-ci-fedora
+      Summary         : A set of system configuration and setup files
+      URL             : https://pagure.io/setup/
+      License         : Public Domain
+      Description     : The setup package contains a set of important system configuration and
+                      : setup files, such as passwd, group, and profile.
+      Vendor          : <NULL>
+      """
 
 
 @dnf5
@@ -191,41 +207,44 @@ Scenario: info --installed alias packages from all enabled repositories
 @dnf5
 Scenario: dnf info --available setup (when setup is available)
  When I execute dnf with args "info --available setup"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Available packages
-  Name           : setup
-  Epoch          : 0
-  Version        : 2.12.1
-  Release        : 1.fc29
-  Architecture   : noarch
-  Download size  : [0-9.]+ KiB
-  Installed size : 0.0   B
-  Source         : setup-2.12.1-1.fc29.src.rpm
-  Repository     : dnf-ci-fedora
-  Summary        : A set of system configuration and setup files
-  URL            : https://pagure.io/setup/
-  License        : Public Domain
-  Description    : The setup package contains a set of important system configuration and
-                 : setup files, such as passwd, group, and profile.
-  Vendor         : 
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Available packages
+      Name           : setup
+      Epoch          : 0
+      Version        : 2.12.1
+      Release        : 1.fc29
+      Architecture   : noarch
+      Download size  : [0-9.]+ KiB
+      Installed size : 0.0   B
+      Source         : setup-2.12.1-1.fc29.src.rpm
+      Repository     : dnf-ci-fedora
+      Summary        : A set of system configuration and setup files
+      URL            : https://pagure.io/setup/
+      License        : Public Domain
+      Description    : The setup package contains a set of important system configuration and
+                     : setup files, such as passwd, group, and profile.
+      Vendor         : 
 
-  Name           : setup
-  Epoch          : 0
-  Version        : 2.12.1
-  Release        : 1.fc29
-  Architecture   : src
-  Download size  : [0-9.]+ KiB
-  Installed size : 616.0   B
-  Repository     : dnf-ci-fedora
-  Summary        : A set of system configuration and setup files
-  URL            : https://pagure.io/setup/
-  License        : Public Domain
-  Description    : The setup package contains a set of important system configuration and
-                 : setup files, such as passwd, group, and profile.
-  Vendor         :
-  """
+      Name           : setup
+      Epoch          : 0
+      Version        : 2.12.1
+      Release        : 1.fc29
+      Architecture   : src
+      Download size  : [0-9.]+ KiB
+      Installed size : 616.0   B
+      Repository     : dnf-ci-fedora
+      Summary        : A set of system configuration and setup files
+      URL            : https://pagure.io/setup/
+      License        : Public Domain
+      Description    : The setup package contains a set of important system configuration and
+                     : setup files, such as passwd, group, and profile.
+      Vendor         :
+      """
 
 
 @dnf5
@@ -233,76 +252,79 @@ Scenario: dnf info setup basesystem (when basesystem is not installed)
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "info setup basesystem"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  Name            : setup
-  Epoch           : 0
-  Version         : 2.12.1
-  Release         : 1.fc29
-  Architecture    : noarch
-  Installed size  : 0.0   B
-  Source          : setup-2.12.1-1.fc29.src.rpm
-  From repository : dnf-ci-fedora
-  Summary         : A set of system configuration and setup files
-  URL             : https://pagure.io/setup/
-  License         : Public Domain
-  Description     : The setup package contains a set of important system configuration and
-                  : setup files, such as passwd, group, and profile.
-  Vendor          : <NULL>
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      Name            : setup
+      Epoch           : 0
+      Version         : 2.12.1
+      Release         : 1.fc29
+      Architecture    : noarch
+      Installed size  : 0.0   B
+      Source          : setup-2.12.1-1.fc29.src.rpm
+      From repository : dnf-ci-fedora
+      Summary         : A set of system configuration and setup files
+      URL             : https://pagure.io/setup/
+      License         : Public Domain
+      Description     : The setup package contains a set of important system configuration and
+                      : setup files, such as passwd, group, and profile.
+      Vendor          : <NULL>
 
-  Available packages
-  Name           : basesystem
-  Epoch          : 0
-  Version        : 11
-  Release        : 6.fc29
-  Architecture   : noarch
-  Download size  : [0-9.]+ KiB
-  Installed size : 0.0   B
-  Source         : basesystem-11-6.fc29.src.rpm
-  Repository     : dnf-ci-fedora
-  Summary        : The skeleton package which defines a simple Fedora system
-  URL            : None
-  License        : Public Domain
-  Description    : Basesystem defines the components of a basic Fedora system
-                 : \(for example, the package installation order to use during bootstrapping\).
-                 : Basesystem should be in every installation of a system, and it
-                 : should never be removed.
-  Vendor         : 
+      Available packages
+      Name           : basesystem
+      Epoch          : 0
+      Version        : 11
+      Release        : 6.fc29
+      Architecture   : noarch
+      Download size  : [0-9.]+ KiB
+      Installed size : 0.0   B
+      Source         : basesystem-11-6.fc29.src.rpm
+      Repository     : dnf-ci-fedora
+      Summary        : The skeleton package which defines a simple Fedora system
+      URL            : None
+      License        : Public Domain
+      Description    : Basesystem defines the components of a basic Fedora system
+                     : \(for example, the package installation order to use during bootstrapping\).
+                     : Basesystem should be in every installation of a system, and it
+                     : should never be removed.
+      Vendor         : 
 
-  Name           : basesystem
-  Epoch          : 0
-  Version        : 11
-  Release        : 6.fc29
-  Architecture   : src
-  Download size  : [0-9.]+ KiB
-  Installed size : 583.0   B
-  Repository     : dnf-ci-fedora
-  Summary        : The skeleton package which defines a simple Fedora system
-  URL            : None
-  License        : Public Domain
-  Description    : Basesystem defines the components of a basic Fedora system
-                 : \(for example, the package installation order to use during bootstrapping\).
-                 : Basesystem should be in every installation of a system, and it
-                 : should never be removed.
-  Vendor         : 
+      Name           : basesystem
+      Epoch          : 0
+      Version        : 11
+      Release        : 6.fc29
+      Architecture   : src
+      Download size  : [0-9.]+ KiB
+      Installed size : 583.0   B
+      Repository     : dnf-ci-fedora
+      Summary        : The skeleton package which defines a simple Fedora system
+      URL            : None
+      License        : Public Domain
+      Description    : Basesystem defines the components of a basic Fedora system
+                     : \(for example, the package installation order to use during bootstrapping\).
+                     : Basesystem should be in every installation of a system, and it
+                     : should never be removed.
+      Vendor         : 
 
-  Name           : setup
-  Epoch          : 0
-  Version        : 2.12.1
-  Release        : 1.fc29
-  Architecture   : src
-  Download size  : [0-9.]+ KiB
-  Installed size : 616.0   B
-  Repository     : dnf-ci-fedora
-  Summary        : A set of system configuration and setup files
-  URL            : https://pagure.io/setup/
-  License        : Public Domain
-  Description    : The setup package contains a set of important system configuration and
-                 : setup files, such as passwd, group, and profile.
-  Vendor         : 
-  """
+      Name           : setup
+      Epoch          : 0
+      Version        : 2.12.1
+      Release        : 1.fc29
+      Architecture   : src
+      Download size  : [0-9.]+ KiB
+      Installed size : 616.0   B
+      Repository     : dnf-ci-fedora
+      Summary        : A set of system configuration and setup files
+      URL            : https://pagure.io/setup/
+      License        : Public Domain
+      Description    : The setup package contains a set of important system configuration and
+                     : setup files, such as passwd, group, and profile.
+      Vendor         : 
+      """
 
 
 @dnf5
@@ -310,25 +332,28 @@ Scenario: dnf info installed setup basesystem (when basesystem is not installed)
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "info --installed setup basesystem"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  Name            : setup
-  Epoch           : 0
-  Version         : 2.12.1
-  Release         : 1.fc29
-  Architecture    : noarch
-  Installed size  : 0.0   B
-  Source          : setup-2.12.1-1.fc29.src.rpm
-  From repository : dnf-ci-fedora
-  Summary         : A set of system configuration and setup files
-  URL             : https://pagure.io/setup/
-  License         : Public Domain
-  Description     : The setup package contains a set of important system configuration and
-                  : setup files, such as passwd, group, and profile.
-  Vendor          : <NULL>
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      Name            : setup
+      Epoch           : 0
+      Version         : 2.12.1
+      Release         : 1.fc29
+      Architecture    : noarch
+      Installed size  : 0.0   B
+      Source          : setup-2.12.1-1.fc29.src.rpm
+      From repository : dnf-ci-fedora
+      Summary         : A set of system configuration and setup files
+      URL             : https://pagure.io/setup/
+      License         : Public Domain
+      Description     : The setup package contains a set of important system configuration and
+                      : setup files, such as passwd, group, and profile.
+      Vendor          : <NULL>
+      """
 
 
 # Change in behavior compared to dnf4 - Available section contains all available
@@ -349,75 +374,78 @@ Scenario: dnf info setup basesystem (when both are installed)
  Then the exit code is 0
  When I execute dnf with args "info setup basesystem"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  Name            : basesystem
-  Epoch           : 0
-  Version         : 11
-  Release         : 6.fc29
-  Architecture    : noarch
-  Installed size  : 0.0   B
-  Source          : basesystem-11-6.fc29.src.rpm
-  From repository : dnf-ci-fedora
-  Summary         : The skeleton package which defines a simple Fedora system
-  URL             : None
-  License         : Public Domain
-  Description     : Basesystem defines the components of a basic Fedora system
-                  : \(for example, the package installation order to use during bootstrapping\).
-                  : Basesystem should be in every installation of a system, and it
-                  : should never be removed.
-  Vendor          : <NULL>
+      """
+      Installed packages
+      Name            : basesystem
+      Epoch           : 0
+      Version         : 11
+      Release         : 6.fc29
+      Architecture    : noarch
+      Installed size  : 0.0   B
+      Source          : basesystem-11-6.fc29.src.rpm
+      From repository : dnf-ci-fedora
+      Summary         : The skeleton package which defines a simple Fedora system
+      URL             : None
+      License         : Public Domain
+      Description     : Basesystem defines the components of a basic Fedora system
+                      : \(for example, the package installation order to use during bootstrapping\).
+                      : Basesystem should be in every installation of a system, and it
+                      : should never be removed.
+      Vendor          : <NULL>
 
-  Name            : setup
-  Epoch           : 0
-  Version         : 2.12.1
-  Release         : 1.fc29
-  Architecture    : noarch
-  Installed size  : 0.0   B
-  Source          : setup-2.12.1-1.fc29.src.rpm
-  From repository : dnf-ci-fedora
-  Summary         : A set of system configuration and setup files
-  URL             : https://pagure.io/setup/
-  License         : Public Domain
-  Description     : The setup package contains a set of important system configuration and
-                  : setup files, such as passwd, group, and profile.
-  Vendor          : <NULL>
+      Name            : setup
+      Epoch           : 0
+      Version         : 2.12.1
+      Release         : 1.fc29
+      Architecture    : noarch
+      Installed size  : 0.0   B
+      Source          : setup-2.12.1-1.fc29.src.rpm
+      From repository : dnf-ci-fedora
+      Summary         : A set of system configuration and setup files
+      URL             : https://pagure.io/setup/
+      License         : Public Domain
+      Description     : The setup package contains a set of important system configuration and
+                      : setup files, such as passwd, group, and profile.
+      Vendor          : <NULL>
 
-  Available packages
-  Name           : basesystem
-  Epoch          : 0
-  Version        : 11
-  Release        : 6.fc29
-  Architecture   : src
-  Download size  : [0-9.]+ KiB
-  Installed size : 583.0   B
-  Repository     : dnf-ci-fedora
-  Summary        : The skeleton package which defines a simple Fedora system
-  URL            : None
-  License        : Public Domain
-  Description    : Basesystem defines the components of a basic Fedora system
-                 : \(for example, the package installation order to use during bootstrapping\).
-                 : Basesystem should be in every installation of a system, and it
-                 : should never be removed.
-  Vendor         : 
+      Available packages
+      Name           : basesystem
+      Epoch          : 0
+      Version        : 11
+      Release        : 6.fc29
+      Architecture   : src
+      Download size  : [0-9.]+ KiB
+      Installed size : 583.0   B
+      Repository     : dnf-ci-fedora
+      Summary        : The skeleton package which defines a simple Fedora system
+      URL            : None
+      License        : Public Domain
+      Description    : Basesystem defines the components of a basic Fedora system
+                     : \(for example, the package installation order to use during bootstrapping\).
+                     : Basesystem should be in every installation of a system, and it
+                     : should never be removed.
+      Vendor         : 
 
-  Name           : setup
-  Epoch          : 0
-  Version        : 2.12.1
-  Release        : 1.fc29
-  Architecture   : src
-  Download size  : [0-9.]+ KiB
-  Installed size : 616.0   B
-  Repository     : dnf-ci-fedora
-  Summary        : A set of system configuration and setup files
-  URL            : https://pagure.io/setup/
-  License        : Public Domain
-  Description    : The setup package contains a set of important system configuration and
-                 : setup files, such as passwd, group, and profile.
-  Vendor         : 
-  """
+      Name           : setup
+      Epoch          : 0
+      Version        : 2.12.1
+      Release        : 1.fc29
+      Architecture   : src
+      Download size  : [0-9.]+ KiB
+      Installed size : 616.0   B
+      Repository     : dnf-ci-fedora
+      Summary        : A set of system configuration and setup files
+      URL            : https://pagure.io/setup/
+      License        : Public Domain
+      Description    : The setup package contains a set of important system configuration and
+                     : setup files, such as passwd, group, and profile.
+      Vendor         : 
+      """
  When I execute dnf with args "info --installed setup basesystem"
  Then the exit code is 0
  Then stdout contains "Installed packages"
@@ -456,13 +484,11 @@ Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "info --upgrades glibc"
  Then the exit code is 1
   And stderr is
-  """
-  No matching packages to list
-  """
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+      """
+      <REPOSYNC>
+      No matching packages to list
+      """
+  And stdout is empty
 
 
 @dnf5
@@ -472,32 +498,35 @@ Scenario: dnf info --obsoletes
 Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "info --obsoletes"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Obsoleting packages
-  Name           : glibc
-  Epoch          : 0
-  Version        : 2.28
-  Release        : 26.fc29
-  Architecture   : x86_64
-  Obsoletes      : glibc-0:2.28-9.fc29.x86_64
-  Download size  : [0-9.]+ KiB
-  Installed size : 0.0   B
-  Source         : glibc-2.28-26.fc29.src.rpm
-  Repository     : dnf-ci-fedora-updates
-  Summary        : The GNU libc libraries
-  URL            : http://www.gnu.org/software/glibc/
-  License        : LGPLv2\+ and LGPLv2\+ with exceptions and GPLv2\+ and GPLv2\+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
-  Description    : The glibc package contains standard libraries which are used by
-                 : multiple programs on the system. In order to save disk space and
-                 : memory, as well as to make upgrading easier, common system code is
-                 : kept in one place and shared between programs. This particular package
-                 : contains the most important sets of shared libraries: the standard C
-                 : library and the standard math library. Without these two libraries, a
-                 : Linux system will not function.
-  Vendor         : 
-  """
+      """
+      Obsoleting packages
+      Name           : glibc
+      Epoch          : 0
+      Version        : 2.28
+      Release        : 26.fc29
+      Architecture   : x86_64
+      Obsoletes      : glibc-0:2.28-9.fc29.x86_64
+      Download size  : [0-9.]+ KiB
+      Installed size : 0.0   B
+      Source         : glibc-2.28-26.fc29.src.rpm
+      Repository     : dnf-ci-fedora-updates
+      Summary        : The GNU libc libraries
+      URL            : http://www.gnu.org/software/glibc/
+      License        : LGPLv2\+ and LGPLv2\+ with exceptions and GPLv2\+ and GPLv2\+ with exceptions and BSD and Inner-Net and ISC and Public Domain and GFDL
+      Description    : The glibc package contains standard libraries which are used by
+                     : multiple programs on the system. In order to save disk space and
+                     : memory, as well as to make upgrading easier, common system code is
+                     : kept in one place and shared between programs. This particular package
+                     : contains the most important sets of shared libraries: the standard C
+                     : library and the standard math library. Without these two libraries, a
+                     : Linux system will not function.
+      Vendor         : 
+      """
 
 
 @dnf5
@@ -507,9 +536,10 @@ Scenario: dnf info obsoletes setup (when setup is not obsoleted)
  When I execute dnf with args "info --obsoletes setup"
  Then the exit code is 1
   And stderr is
-  """
-  No matching packages to list
-  """
+      """
+      <REPOSYNC>
+      No matching packages to list
+      """
 
 
 @dnf5
@@ -521,32 +551,35 @@ Scenario: dnf info respects repo priorities
         | priority      | 100     |
    When I execute dnf with args "info flac.x86_64"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Available packages
-    Name           : flac
-    Epoch          : 0
-    Version        : 1.3.2
-    Release        : 8.fc29
-    Architecture   : x86_64
-    Download size  : [0-9.]+ KiB
-    Installed size : 0.0   B
-    Source         : flac-1.3.2-8.fc29.src.rpm
-    Repository     : dnf-ci-fedora
-    Summary        : An encoder/decoder for the Free Lossless Audio Codec
-    URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2\+ and GFDL
-    Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                   : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                   : the stream format, reference encoders and decoders in library form,
-                   : flac, a command-line program to encode and decode FLAC files, metaflac,
-                   : a command-line metadata editor for FLAC files and input plugins for
-                   : various music players.
-                   : 
-                   : This package contains the command-line tools and documentation.
-    Vendor         : 
-    """
+        """
+        Available packages
+        Name           : flac
+        Epoch          : 0
+        Version        : 1.3.2
+        Release        : 8.fc29
+        Architecture   : x86_64
+        Download size  : [0-9.]+ KiB
+        Installed size : 0.0   B
+        Source         : flac-1.3.2-8.fc29.src.rpm
+        Repository     : dnf-ci-fedora
+        Summary        : An encoder/decoder for the Free Lossless Audio Codec
+        URL            : http://www.xiph.org/flac/
+        License        : BSD and GPLv2\+ and GFDL
+        Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                       : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                       : the stream format, reference encoders and decoders in library form,
+                       : flac, a command-line program to encode and decode FLAC files, metaflac,
+                       : a command-line metadata editor for FLAC files and input plugins for
+                       : various music players.
+                       : 
+                       : This package contains the command-line tools and documentation.
+        Vendor         : 
+        """
 
 
 @dnf5
@@ -557,98 +590,101 @@ Scenario: dnf info --showduplicates info all (even from lower-priority repo)
         | priority      | 100     |
    When I execute dnf with args "info flac.x86_64 --showduplicates"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Available packages
-    Name           : flac
-    Epoch          : 0
-    Version        : 1.3.2
-    Release        : 8.fc29
-    Architecture   : x86_64
-    Download size  : [0-9.]+ KiB
-    Installed size : 0.0   B
-    Source         : flac-1.3.2-8.fc29.src.rpm
-    Repository     : dnf-ci-fedora
-    Summary        : An encoder/decoder for the Free Lossless Audio Codec
-    URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2\+ and GFDL
-    Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                   : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                   : the stream format, reference encoders and decoders in library form,
-                   : flac, a command-line program to encode and decode FLAC files, metaflac,
-                   : a command-line metadata editor for FLAC files and input plugins for
-                   : various music players.
-                   : 
-                   : This package contains the command-line tools and documentation.
-    Vendor         : 
+        """
+        Available packages
+        Name           : flac
+        Epoch          : 0
+        Version        : 1.3.2
+        Release        : 8.fc29
+        Architecture   : x86_64
+        Download size  : [0-9.]+ KiB
+        Installed size : 0.0   B
+        Source         : flac-1.3.2-8.fc29.src.rpm
+        Repository     : dnf-ci-fedora
+        Summary        : An encoder/decoder for the Free Lossless Audio Codec
+        URL            : http://www.xiph.org/flac/
+        License        : BSD and GPLv2\+ and GFDL
+        Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                       : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                       : the stream format, reference encoders and decoders in library form,
+                       : flac, a command-line program to encode and decode FLAC files, metaflac,
+                       : a command-line metadata editor for FLAC files and input plugins for
+                       : various music players.
+                       : 
+                       : This package contains the command-line tools and documentation.
+        Vendor         : 
 
-    Name           : flac
-    Epoch          : 0
-    Version        : 1.3.3
-    Release        : 1.fc29
-    Architecture   : x86_64
-    Download size  : [0-9.]+ KiB
-    Installed size : 0.0   B
-    Source         : flac-1.3.3-1.fc29.src.rpm
-    Repository     : dnf-ci-fedora-updates
-    Summary        : An encoder/decoder for the Free Lossless Audio Codec
-    URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2\+ and GFDL
-    Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                   : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                   : the stream format, reference encoders and decoders in library form,
-                   : flac, a command-line program to encode and decode FLAC files, metaflac,
-                   : a command-line metadata editor for FLAC files and input plugins for
-                   : various music players.
-                   : 
-                   : This package contains the command-line tools and documentation.
-    Vendor         : 
+        Name           : flac
+        Epoch          : 0
+        Version        : 1.3.3
+        Release        : 1.fc29
+        Architecture   : x86_64
+        Download size  : [0-9.]+ KiB
+        Installed size : 0.0   B
+        Source         : flac-1.3.3-1.fc29.src.rpm
+        Repository     : dnf-ci-fedora-updates
+        Summary        : An encoder/decoder for the Free Lossless Audio Codec
+        URL            : http://www.xiph.org/flac/
+        License        : BSD and GPLv2\+ and GFDL
+        Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                       : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                       : the stream format, reference encoders and decoders in library form,
+                       : flac, a command-line program to encode and decode FLAC files, metaflac,
+                       : a command-line metadata editor for FLAC files and input plugins for
+                       : various music players.
+                       : 
+                       : This package contains the command-line tools and documentation.
+        Vendor         : 
 
-    Name           : flac
-    Epoch          : 0
-    Version        : 1.3.3
-    Release        : 2.fc29
-    Architecture   : x86_64
-    Download size  : [0-9.]+ KiB
-    Installed size : 0.0   B
-    Source         : flac-1.3.3-2.fc29.src.rpm
-    Repository     : dnf-ci-fedora-updates
-    Summary        : An encoder/decoder for the Free Lossless Audio Codec
-    URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2\+ and GFDL
-    Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                   : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                   : the stream format, reference encoders and decoders in library form,
-                   : flac, a command-line program to encode and decode FLAC files, metaflac,
-                   : a command-line metadata editor for FLAC files and input plugins for
-                   : various music players.
-                   : 
-                   : This package contains the command-line tools and documentation.
-    Vendor         : 
+        Name           : flac
+        Epoch          : 0
+        Version        : 1.3.3
+        Release        : 2.fc29
+        Architecture   : x86_64
+        Download size  : [0-9.]+ KiB
+        Installed size : 0.0   B
+        Source         : flac-1.3.3-2.fc29.src.rpm
+        Repository     : dnf-ci-fedora-updates
+        Summary        : An encoder/decoder for the Free Lossless Audio Codec
+        URL            : http://www.xiph.org/flac/
+        License        : BSD and GPLv2\+ and GFDL
+        Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                       : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                       : the stream format, reference encoders and decoders in library form,
+                       : flac, a command-line program to encode and decode FLAC files, metaflac,
+                       : a command-line metadata editor for FLAC files and input plugins for
+                       : various music players.
+                       : 
+                       : This package contains the command-line tools and documentation.
+        Vendor         : 
 
-    Name           : flac
-    Epoch          : 0
-    Version        : 1.3.3
-    Release        : 3.fc29
-    Architecture   : x86_64
-    Download size  : [0-9.]+ KiB
-    Installed size : 0.0   B
-    Source         : flac-1.3.3-3.fc29.src.rpm
-    Repository     : dnf-ci-fedora-updates
-    Summary        : An encoder/decoder for the Free Lossless Audio Codec
-    URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2\+ and GFDL
-    Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                   : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                   : the stream format, reference encoders and decoders in library form,
-                   : flac, a command-line program to encode and decode FLAC files, metaflac,
-                   : a command-line metadata editor for FLAC files and input plugins for
-                   : various music players.
-                   : 
-                   : This package contains the command-line tools and documentation.
-    Vendor         : 
-    """
+        Name           : flac
+        Epoch          : 0
+        Version        : 1.3.3
+        Release        : 3.fc29
+        Architecture   : x86_64
+        Download size  : [0-9.]+ KiB
+        Installed size : 0.0   B
+        Source         : flac-1.3.3-3.fc29.src.rpm
+        Repository     : dnf-ci-fedora-updates
+        Summary        : An encoder/decoder for the Free Lossless Audio Codec
+        URL            : http://www.xiph.org/flac/
+        License        : BSD and GPLv2\+ and GFDL
+        Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                       : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                       : the stream format, reference encoders and decoders in library form,
+                       : flac, a command-line program to encode and decode FLAC files, metaflac,
+                       : a command-line metadata editor for FLAC files and input plugins for
+                       : various music players.
+                       : 
+                       : This package contains the command-line tools and documentation.
+        Vendor         : 
+        """
 
 
 @dnf5
@@ -661,31 +697,34 @@ Scenario: dnf info doesn't show any available packages when there are no upgrade
     And I successfully execute dnf with args "install flac-1.3.3-1.fc29"
    When I execute dnf with args "info flac.x86_64"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Installed packages
-    Name            : flac
-    Epoch           : 0
-    Version         : 1.3.3
-    Release         : 1.fc29
-    Architecture    : x86_64
-    Installed size  : 0.0   B
-    Source          : flac-1.3.3-1.fc29.src.rpm
-    From repository : dnf-ci-fedora-updates
-    Summary         : An encoder/decoder for the Free Lossless Audio Codec
-    URL             : http://www.xiph.org/flac/
-    License         : BSD and GPLv2\+ and GFDL
-    Description     : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                    : the stream format, reference encoders and decoders in library form,
-                    : flac, a command-line program to encode and decode FLAC files, metaflac,
-                    : a command-line metadata editor for FLAC files and input plugins for
-                    : various music players.
-                    : 
-                    : This package contains the command-line tools and documentation.
-    Vendor          : <NULL>
-    """
+        """
+        Installed packages
+        Name            : flac
+        Epoch           : 0
+        Version         : 1.3.3
+        Release         : 1.fc29
+        Architecture    : x86_64
+        Installed size  : 0.0   B
+        Source          : flac-1.3.3-1.fc29.src.rpm
+        From repository : dnf-ci-fedora-updates
+        Summary         : An encoder/decoder for the Free Lossless Audio Codec
+        URL             : http://www.xiph.org/flac/
+        License         : BSD and GPLv2\+ and GFDL
+        Description     : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                        : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                        : the stream format, reference encoders and decoders in library form,
+                        : flac, a command-line program to encode and decode FLAC files, metaflac,
+                        : a command-line metadata editor for FLAC files and input plugins for
+                        : various music players.
+                        : 
+                        : This package contains the command-line tools and documentation.
+        Vendor          : <NULL>
+        """
 
 
 @dnf5
@@ -697,54 +736,57 @@ Scenario: dnf info shows available packages when there are upgrades in the highe
     And I successfully execute dnf with args "install flac-1.3.3-1.fc29"
    When I execute dnf with args "info flac.x86_64"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Installed packages
-    Name            : flac
-    Epoch           : 0
-    Version         : 1.3.3
-    Release         : 1.fc29
-    Architecture    : x86_64
-    Installed size  : 0.0   B
-    Source          : flac-1.3.3-1.fc29.src.rpm
-    From repository : dnf-ci-fedora-updates
-    Summary         : An encoder/decoder for the Free Lossless Audio Codec
-    URL             : http://www.xiph.org/flac/
-    License         : BSD and GPLv2\+ and GFDL
-    Description     : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                    : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                    : the stream format, reference encoders and decoders in library form,
-                    : flac, a command-line program to encode and decode FLAC files, metaflac,
-                    : a command-line metadata editor for FLAC files and input plugins for
-                    : various music players.
-                    : 
-                    : This package contains the command-line tools and documentation.
-    Vendor          : <NULL>
-
-    Available packages
-    Name           : flac
-    Epoch          : 0
-    Version        : 1.3.3
-    Release        : 3.fc29
-    Architecture   : x86_64
-    Download size  : [0-9.]+ KiB
-    Installed size : 0.0   B
-    Source         : flac-1.3.3-3.fc29.src.rpm
-    Repository     : dnf-ci-fedora-updates
-    Summary        : An encoder/decoder for the Free Lossless Audio Codec
-    URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2\+ and GFDL
-    Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                   : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                   : the stream format, reference encoders and decoders in library form,
-                   : flac, a command-line program to encode and decode FLAC files, metaflac,
-                   : a command-line metadata editor for FLAC files and input plugins for
-                   : various music players.
-                   : 
-                   : This package contains the command-line tools and documentation.
-    Vendor         : 
-    """
+        """
+        Installed packages
+        Name            : flac
+        Epoch           : 0
+        Version         : 1.3.3
+        Release         : 1.fc29
+        Architecture    : x86_64
+        Installed size  : 0.0   B
+        Source          : flac-1.3.3-1.fc29.src.rpm
+        From repository : dnf-ci-fedora-updates
+        Summary         : An encoder/decoder for the Free Lossless Audio Codec
+        URL             : http://www.xiph.org/flac/
+        License         : BSD and GPLv2\+ and GFDL
+        Description     : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                        : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                        : the stream format, reference encoders and decoders in library form,
+                        : flac, a command-line program to encode and decode FLAC files, metaflac,
+                        : a command-line metadata editor for FLAC files and input plugins for
+                        : various music players.
+                        : 
+                        : This package contains the command-line tools and documentation.
+        Vendor          : <NULL>
+    
+        Available packages
+        Name           : flac
+        Epoch          : 0
+        Version        : 1.3.3
+        Release        : 3.fc29
+        Architecture   : x86_64
+        Download size  : [0-9.]+ KiB
+        Installed size : 0.0   B
+        Source         : flac-1.3.3-3.fc29.src.rpm
+        Repository     : dnf-ci-fedora-updates
+        Summary        : An encoder/decoder for the Free Lossless Audio Codec
+        URL            : http://www.xiph.org/flac/
+        License        : BSD and GPLv2\+ and GFDL
+        Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                       : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                       : the stream format, reference encoders and decoders in library form,
+                       : flac, a command-line program to encode and decode FLAC files, metaflac,
+                       : a command-line metadata editor for FLAC files and input plugins for
+                       : various music players.
+                       : 
+                       : This package contains the command-line tools and documentation.
+        Vendor         : 
+        """
 
 
 @dnf5
@@ -756,29 +798,32 @@ Scenario: dnf info doesn't show package with same nevra from lower-priority repo
         | priority      | 100                                      |
    When I execute dnf with args "info flac.x86_64"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Available packages
-    Name           : flac
-    Epoch          : 0
-    Version        : 1.3.2
-    Release        : 8.fc29
-    Architecture   : x86_64
-    Download size  : [0-9.]+ KiB
-    Installed size : 0.0   B
-    Source         : flac-1.3.2-8.fc29.src.rpm
-    Repository     : dnf-ci-fedora
-    Summary        : An encoder/decoder for the Free Lossless Audio Codec
-    URL            : http://www.xiph.org/flac/
-    License        : BSD and GPLv2\+ and GFDL
-    Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
-                   : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
-                   : the stream format, reference encoders and decoders in library form,
-                   : flac, a command-line program to encode and decode FLAC files, metaflac,
-                   : a command-line metadata editor for FLAC files and input plugins for
-                   : various music players.
-                   : 
-                   : This package contains the command-line tools and documentation.
-    Vendor         : 
-    """
+        """
+        Available packages
+        Name           : flac
+        Epoch          : 0
+        Version        : 1.3.2
+        Release        : 8.fc29
+        Architecture   : x86_64
+        Download size  : [0-9.]+ KiB
+        Installed size : 0.0   B
+        Source         : flac-1.3.2-8.fc29.src.rpm
+        Repository     : dnf-ci-fedora
+        Summary        : An encoder/decoder for the Free Lossless Audio Codec
+        URL            : http://www.xiph.org/flac/
+        License        : BSD and GPLv2\+ and GFDL
+        Description    : FLAC stands for Free Lossless Audio Codec. Grossly oversimplified, FLAC
+                       : is similar to Ogg Vorbis, but lossless. The FLAC project consists of
+                       : the stream format, reference encoders and decoders in library form,
+                       : flac, a command-line program to encode and decode FLAC files, metaflac,
+                       : a command-line metadata editor for FLAC files and input plugins for
+                       : various music players.
+                       : 
+                       : This package contains the command-line tools and documentation.
+        Vendor         : 
+        """

--- a/dnf-behave-tests/dnf/install-dependencies.feature
+++ b/dnf-behave-tests/dnf/install-dependencies.feature
@@ -14,7 +14,7 @@ Scenario: Best candidates have conflicting dependencies
         | install-dep   | lib-0:1.0-1.fc29.x86_64           |
         | conflict      | lib-0:2.0-1.fc29.x86_64           |
         | broken        | foo-0:2.0-1.fc29.x86_64           |
-    And stderr is
+    And stderr contains lines
     """
     Problem: cannot install both lib-2.0-1.fc29.x86_64 from install-dependencies and lib-1.0-1.fc29.x86_64 from install-dependencies
       - package foo-2.0-1.fc29.x86_64 from install-dependencies requires lib-2.0, but none of the providers can be installed

--- a/dnf-behave-tests/dnf/install-exclude.feature
+++ b/dnf-behave-tests/dnf/install-exclude.feature
@@ -16,14 +16,15 @@ Scenario: Install an RPM that requires excluded RPM
    Then the exit code is 1
     And Transaction is empty
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Problem: package filesystem-3.9-2.fc29.x86_64 from dnf-ci-fedora requires setup, but none of the providers can be installed
-      - conflicting requests
-      - package setup-2.12.1-1.fc29.noarch from dnf-ci-fedora is filtered out by exclude filtering
-    You can try to add to command line:
-      --skip-broken to skip uninstallable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Problem: package filesystem-3.9-2.fc29.x86_64 from dnf-ci-fedora requires setup, but none of the providers can be installed
+          - conflicting requests
+          - package setup-2.12.1-1.fc29.noarch from dnf-ci-fedora is filtered out by exclude filtering
+        You can try to add to command line:
+          --skip-broken to skip uninstallable packages
+        """
 
 
 Scenario: Install RPMs while excluding part of them

--- a/dnf-behave-tests/dnf/install-fails.feature
+++ b/dnf-behave-tests/dnf/install-fails.feature
@@ -15,9 +15,10 @@ Scenario: Report error when installing empty file
     When I execute dnf with args "install empty.rpm"
     Then the exit code is 1
      And stderr is
-     """
-     Failed to load RPM "empty.rpm": empty.rpm: not a rpm
-     """
+         """
+         <REPOSYNC>
+         Failed to load RPM "empty.rpm": empty.rpm: not a rpm
+         """
 
 @bz1616321
 Scenario: Report error when installing text file
@@ -29,25 +30,28 @@ Scenario: Report error when installing text file
     When I execute dnf with args "install invalid.rpm"
     Then the exit code is 1
      And stderr is
-     """
-     Failed to load RPM "invalid.rpm": invalid.rpm: not a rpm
-     """
+         """
+         <REPOSYNC>
+         Failed to load RPM "invalid.rpm": invalid.rpm: not a rpm
+         """
 
 @bz1599774
 Scenario: Report error when installing non-existing RPM file
     When I execute dnf with args "install no_such_file.rpm"
     Then the exit code is 1
      And stderr is
-     """
-     Failed to access RPM "no_such_file.rpm": No such file or directory
-     """
+         """
+         <REPOSYNC>
+         Failed to access RPM "no_such_file.rpm": No such file or directory
+         """
 
 Scenario: Cannot install source rpm
    Given I use repository "simple-base"
     When I execute dnf with args "install vagare.src"
     Then the exit code is 1
      And stderr is
-     """
-     Failed to resolve the transaction:
-     Argument 'vagare.src' matches only source packages.
-     """
+         """
+         <REPOSYNC>
+         Failed to resolve the transaction:
+         Argument 'vagare.src' matches only source packages.
+         """

--- a/dnf-behave-tests/dnf/install-file-conflicts.feature
+++ b/dnf-behave-tests/dnf/install-file-conflicts.feature
@@ -12,9 +12,9 @@ Scenario: An error is reported when a package with a file conflict is tried to b
         | install                   | package-one-0:1.0-1.x86_64   |
    When I execute dnf with args "install package-two-1.0-1.x86_64"
    Then the exit code is 1
-    And stderr is
-    """
-    Transaction failed: Rpm transaction failed.
-    Warning: skipped PGP checks for 1 package from repository: dnf-ci-install-conflicts
-      - file /usr/lib/package/conflicting-file from install of package-two-0:1.0-1.x86_64 conflicts with file from package package-one-0:1.0-1.x86_64
-    """
+    And stderr contains lines
+        """
+        Transaction failed: Rpm transaction failed.
+        Warning: skipped PGP checks for 1 package from repository: dnf-ci-install-conflicts
+          - file /usr/lib/package/conflicting-file from install of package-two-0:1.0-1.x86_64 conflicts with file from package package-one-0:1.0-1.x86_64
+        """

--- a/dnf-behave-tests/dnf/install-latest-deps.feature
+++ b/dnf-behave-tests/dnf/install-latest-deps.feature
@@ -12,7 +12,7 @@ Scenario: prefer installing latests dependencies rather than smaller transaction
         | install       | ipa-client-0:1.0-1.fc29.x86_64  |
         | install-dep   | krb5-pkinit-0:2.0-1.fc29.x86_64 |
         | upgrade       | krb5-libs-0:2.0-1.fc29.x86_64   |
-    And stderr is
+    And stderr contains lines
     """
     Warning: skipped PGP checks for 3 packages from repository: install-latest-deps
     """
@@ -27,7 +27,7 @@ Scenario: if latests dependencies are not possible to install fall back to lower
         | Action        | Package                         |
         | install       | ipa-client-0:1.0-1.fc29.x86_64  |
         | install-dep   | krb5-pkinit-0:1.0-1.fc29.x86_64 |
-    And stderr is
+    And stderr contains lines
     """
     Warning: skipped PGP checks for 2 packages from repository: install-latest-deps
     """

--- a/dnf-behave-tests/dnf/install-non-existent.feature
+++ b/dnf-behave-tests/dnf/install-non-existent.feature
@@ -8,9 +8,10 @@ Scenario: Try to install a non-existent rpm
    When I execute dnf with args "install non-existent.rpm"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to access RPM "non-existent.rpm": No such file or directory
-    """
+        """
+        <REPOSYNC>
+        Failed to access RPM "non-existent.rpm": No such file or directory
+        """
 
 
 Scenario: Try to install a non-existent package
@@ -18,12 +19,13 @@ Scenario: Try to install a non-existent package
    When I execute dnf with args "install non-existent-package"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: non-existent-package
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: non-existent-package
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
 
 
 @bz1717429
@@ -32,12 +34,13 @@ Scenario: Install an existent and an non-existent package
    When I execute dnf with args "install setup non-existent-package"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: non-existent-package
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: non-existent-package
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
 
 
 @bz1717429
@@ -45,7 +48,7 @@ Scenario: Install an existent and an non-existent package with --skip-unavailabl
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install setup non-existent-package --skip-unavailable"
    Then the exit code is 0
-    And stderr is
+    And stderr contains lines
     """
     No match for argument: non-existent-package
 

--- a/dnf-behave-tests/dnf/install-remove.feature
+++ b/dnf-behave-tests/dnf/install-remove.feature
@@ -201,12 +201,15 @@ Scenario: Install remove group
         | install-dep   | water-0:1.0-1.x86_64              |
    When I execute dnf with args "group list beverages"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    ID +Name +Installed
-    beverages +Beverages +yes
-    """
+        """
+        ID +Name +Installed
+        beverages +Beverages +yes
+        """
    When I execute dnf with args "install water_carbonated"
    Then the exit code is 0
     And Transaction is following

--- a/dnf-behave-tests/dnf/list-recent.feature
+++ b/dnf-behave-tests/dnf/list-recent.feature
@@ -17,12 +17,15 @@ Background: prepare repository with recent package labirinto
 Scenario: dnf list --recent
    When I execute dnf with args "list --recent"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Recently added packages
-    labirinto\.x86_64\s+1\.0-1\.fc29\s+simple-base
-    """
+        """
+        Recently added packages
+        labirinto\.x86_64\s+1\.0-1\.fc29\s+simple-base
+        """
 
 
 Scenario: dnf list package that is not recently added
@@ -32,11 +35,9 @@ Scenario: dnf list package that is not recently added
    # but was not recently added
    When I execute dnf with args "list --recent vagare"
    Then the exit code is 1
-    And stdout is
-    """
-    <REPOSYNC>
-    """
+    And stdout is empty
     And stderr is
-    """
-    No matching packages to list
-    """
+        """
+        <REPOSYNC>
+        No matching packages to list
+        """

--- a/dnf-behave-tests/dnf/list-showduplicates.feature
+++ b/dnf-behave-tests/dnf/list-showduplicates.feature
@@ -18,24 +18,27 @@ Scenario: Test for list with --showduplicates when the package is installed
       | install       | flac-0:1.3.2-8.fc29.x86_64 |
  When I execute dnf with args "list --showduplicates flac"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
  Then stdout matches line by line
- """
- <REPOSYNC>
- Installed packages
- flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
+      """
+      Installed packages
+      flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
 
- Available packages
- flac.src\s+1.3.2-8.fc29\s+dnf-ci-fedora
- flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
- flac.src\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
- flac.src\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
- flac.src\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
- flac.src\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
- flac.x86_64\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
- """
+      Available packages
+      flac.src\s+1.3.2-8.fc29\s+dnf-ci-fedora
+      flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
+      flac.src\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+      flac.src\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
+      flac.src\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
+      flac.src\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
+      flac.x86_64\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
+      """
 
 
 Scenario: Test for list without --showduplicates when the package is installed
@@ -46,50 +49,59 @@ Scenario: Test for list without --showduplicates when the package is installed
       | install       | flac-0:1.3.2-8.fc29.x86_64 |
  When I execute dnf with args "list flac"
  Then the exit code is 0
- Then stdout matches line by line
- """
- <REPOSYNC>
- Installed packages
- flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
 
- Available packages
- flac.src\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
- flac.x86_64\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
- """
+      Available packages
+      flac.src\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
+      flac.x86_64\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
+      """
 
 
 Scenario: Test for list with --showduplicates when the package is not installed
  When I execute dnf with args "update"
   And I execute dnf with args "list --showduplicates flac"
  Then the exit code is 0
- Then stdout matches line by line
- """
- <REPOSYNC>
- Available packages
- flac.src\s+1.3.2-8.fc29\s+dnf-ci-fedora
- flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
- flac.src\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
- flac.src\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
- flac.src\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
- flac.src\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
- flac.x86_64\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
- """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Available packages
+      flac.src\s+1.3.2-8.fc29\s+dnf-ci-fedora
+      flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
+      flac.src\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+      flac.src\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
+      flac.src\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
+      flac.src\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
+      flac.x86_64\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
+      """
 
 
 Scenario: Test for list without --showduplicates when the package is not installed
  When I execute dnf with args "update"
   And I execute dnf with args "list flac"
  Then the exit code is 0
- Then stdout matches line by line
- """
- <REPOSYNC>
- Available packages
- flac.src\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
- flac.x86_64\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
- """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Available packages
+      flac.src\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
+      flac.x86_64\s+1.4.0-1.fc29\s+dnf-ci-fedora-updates-testing
+      """
 
 
 @bz1655605
@@ -102,21 +114,25 @@ Scenario: Test for list --available --showduplicates when package is installed a
       | Action        | Package                    |
       | install       | flac-0:1.3.3-1.fc29.x86_64 |
  When I execute dnf with args "list --available --showduplicates flac"
- Then stdout matches line by line
- """
- <REPOSYNC>
- Available packages
- flac.src\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
- flac.src\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
- flac.src\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
- flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
- """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Available packages
+      flac.src\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+      flac.src\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
+      flac.src\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
+      flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
+      """
  When I drop repository "dnf-ci-fedora-updates"
   And I execute dnf with args "list --available --showduplicates flac"
  Then the exit code is 1
- And stderr is
- """
- No matching packages to list
- """
+  And stderr is
+      """
+      <REPOSYNC>
+      No matching packages to list
+      """

--- a/dnf-behave-tests/dnf/list.feature
+++ b/dnf-behave-tests/dnf/list.feature
@@ -10,9 +10,10 @@ Scenario: dnf list nonexistentpkg
  When I execute dnf with args "list non-existent-pkg"
  Then the exit code is 1
   And stderr is
-  """
-  No matching packages to list
-  """
+      """
+      <REPOSYNC>
+      No matching packages to list
+      """
 
 
 @dnf5
@@ -33,12 +34,15 @@ Scenario: dnf list --extras (installed pkgs, not from known repos)
 Given I drop repository "dnf-ci-fedora"
   And I execute dnf with args "list --extras"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Extra packages
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+      """
+      Extra packages
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 @dnf5
@@ -47,12 +51,15 @@ Scenario: dnf list setup (when setup is installed)
  Then the exit code is 0
 Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "list setup"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 @dnf5
 Scenario: dnf list is case insensitive
@@ -60,23 +67,29 @@ Scenario: dnf list is case insensitive
  Then the exit code is 0
 Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "list SETUP"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 @dnf5
 Scenario: dnf list setup (when setup is not installed but it is available)
  When I execute dnf with args "list setup"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Available packages
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  setup.src +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Available packages
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      setup.src +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 @dnf5
@@ -85,12 +98,15 @@ Scenario: dnf list --installed setup (when setup is installed)
  Then the exit code is 0
 Given I drop repository "dnf-ci-fedora"
  When I execute dnf with args "list --installed setup"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 @dnf5
@@ -99,29 +115,35 @@ Scenario: List --installed alias packages from all enabled repositories
  Then the exit code is 0
  When I execute dnf with args "list --installed"
  Then the exit code is 0
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  basesystem.noarch +11-6.fc29 +dnf-ci-fedora
-  filesystem.x86_64 +3.9-2.fc29 +dnf-ci-fedora
-  glibc.x86_64 +2.28-9.fc29 +dnf-ci-fedora
-  glibc-all-langpacks.x86_64 +2.28-9.fc29 +dnf-ci-fedora
-  glibc-common.x86_64 +2.28-9.fc29 +dnf-ci-fedora
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      basesystem.noarch +11-6.fc29 +dnf-ci-fedora
+      filesystem.x86_64 +3.9-2.fc29 +dnf-ci-fedora
+      glibc.x86_64 +2.28-9.fc29 +dnf-ci-fedora
+      glibc-all-langpacks.x86_64 +2.28-9.fc29 +dnf-ci-fedora
+      glibc-common.x86_64 +2.28-9.fc29 +dnf-ci-fedora
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 @dnf5
 Scenario: dnf list --available setup (when setup is available)
  When I execute dnf with args "list --available setup"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Available packages
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  setup.src +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Available packages
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      setup.src +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 @dnf5
@@ -129,17 +151,20 @@ Scenario: dnf list setup basesystem (when basesystem is not installed)
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "list setup basesystem"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
 
-  Available packages
-  basesystem.noarch +11-6.fc29 +dnf-ci-fedora
-  basesystem.src +11-6.fc29 +dnf-ci-fedora
-  setup.src +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+      Available packages
+      basesystem.noarch +11-6.fc29 +dnf-ci-fedora
+      basesystem.src +11-6.fc29 +dnf-ci-fedora
+      setup.src +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 @dnf5
@@ -147,12 +172,15 @@ Scenario: dnf list installed setup basesystem (when basesystem is not installed)
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "list --installed setup basesystem"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Installed packages
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 # Change in behavior compared to dnf4 - Available section contains all available
@@ -162,15 +190,18 @@ Scenario: dnf list available setup basesystem (when basesystem is available)
  When I execute dnf with args "install setup"
  Then the exit code is 0
  When I execute dnf with args "list --available setup basesystem"
- Then stdout matches line by line
-  """
-  <REPOSYNC>
-  Available packages
-  basesystem.noarch +11-6.fc29 +dnf-ci-fedora
-  basesystem.src +11-6.fc29 +dnf-ci-fedora
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  setup.src +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
+      Available packages
+      basesystem.noarch +11-6.fc29 +dnf-ci-fedora
+      basesystem.src +11-6.fc29 +dnf-ci-fedora
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      setup.src +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 @dnf5
@@ -179,35 +210,44 @@ Scenario: dnf list setup basesystem (when both are installed)
  Then the exit code is 0
  When I execute dnf with args "list setup basesystem"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  basesystem.noarch +11-6.fc29 +dnf-ci-fedora
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
+      Installed packages
+      basesystem.noarch +11-6.fc29 +dnf-ci-fedora
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
 
-  Available packages
-  basesystem.src +11-6.fc29 +dnf-ci-fedora
-  setup.src +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+      Available packages
+      basesystem.src +11-6.fc29 +dnf-ci-fedora
+      setup.src +2.12.1-1.fc29 +dnf-ci-fedora
+      """
  When I execute dnf with args "list --installed setup basesystem"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Installed packages
-  basesystem.noarch +11-6.fc29 +dnf-ci-fedora
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+      """
+      Installed packages
+      basesystem.noarch +11-6.fc29 +dnf-ci-fedora
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
  When I execute dnf with args "list --available setup.noarch basesystem.noarch"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Available packages
-  basesystem.noarch +11-6.fc29 +dnf-ci-fedora
-  setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
-  """
+      """
+      Available packages
+      basesystem.noarch +11-6.fc29 +dnf-ci-fedora
+      setup.noarch +2.12.1-1.fc29 +dnf-ci-fedora
+      """
 
 
 @dnf5
@@ -230,14 +270,17 @@ Scenario Outline: dnf list <upgrades alias>
 Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "list <upgrades alias>"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Available upgrades
-  glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates
-  glibc-all-langpacks.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates
-  glibc-common.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates
-  """
+      """
+      Available upgrades
+      glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates
+      glibc-all-langpacks.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates
+      glibc-common.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates
+      """
 
 Examples:
         | upgrades alias     |
@@ -251,13 +294,11 @@ Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "list --upgrades glibc"
  Then the exit code is 1
   And stderr is
-  """
-  No matching packages to list
-  """
-  And stdout matches line by line
-  """
-  <REPOSYNC>
-  """
+      """
+      <REPOSYNC>
+      No matching packages to list
+      """
+  And stdout is empty
 
 
 @dnf5
@@ -267,13 +308,16 @@ Scenario: dnf list --obsoletes
 Given I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "list --obsoletes"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  Obsoleting packages
-  glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates
-  \s+glibc.x86_64\s+2.28-9.fc29\s+dnf-ci-fedora
-  """
+      """
+      Obsoleting packages
+      glibc.x86_64\s+2.28-26.fc29\s+dnf-ci-fedora-updates
+      \s+glibc.x86_64\s+2.28-9.fc29\s+dnf-ci-fedora
+      """
 
 
 @dnf5
@@ -283,9 +327,10 @@ Scenario: dnf list obsoletes setup (when setup is not obsoleted)
  When I execute dnf with args "list --obsoletes setup"
  Then the exit code is 1
   And stderr is
-  """
-  No matching packages to list
-  """
+      """
+      <REPOSYNC>
+      No matching packages to list
+      """
 
 
 # TODO(mblaha) - the test does not respect dnf_command and runs dnf4 in subprocess
@@ -307,12 +352,15 @@ Scenario: dnf list respects repo priorities
         | priority      | 100     |
    When I execute dnf with args "list flac.x86_64"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Available packages
-    flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
-    """
+        """
+        Available packages
+        flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
+        """
 
 
 @dnf5
@@ -323,15 +371,18 @@ Scenario: dnf list --showduplicates lists all (even from lower-priority repo)
         | priority      | 100     |
    When I execute dnf with args "list flac.x86_64 --showduplicates"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Available packages
-    flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
-    flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
-    flac.x86_64\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
-    flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
-    """
+        """
+        Available packages
+        flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
+        flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+        flac.x86_64\s+1.3.3-2.fc29\s+dnf-ci-fedora-updates
+        flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
+        """
 
 
 @dnf5
@@ -344,12 +395,15 @@ Scenario: dnf list doesn't show any available packages when there are no upgrade
     And I successfully execute dnf with args "install flac-1.3.3-1.fc29"
    When I execute dnf with args "list flac.x86_64"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Installed packages
-    flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
-    """
+        """
+        Installed packages
+        flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+        """
 
 
 @dnf5
@@ -361,15 +415,18 @@ Scenario: dnf list shows available packages when there are upgrades in the highe
     And I successfully execute dnf with args "install flac-1.3.3-1.fc29"
    When I execute dnf with args "list flac.x86_64"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Installed packages
-    flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
+        """
+        Installed packages
+        flac.x86_64\s+1.3.3-1.fc29\s+dnf-ci-fedora-updates
 
-    Available packages
-    flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
-    """
+        Available packages
+        flac.x86_64\s+1.3.3-3.fc29\s+dnf-ci-fedora-updates
+        """
 
 
 @dnf5
@@ -381,12 +438,15 @@ Scenario: dnf list doesn't show package with same nevra from lower-priority repo
         | priority      | 100                                      |
    When I execute dnf with args "list flac.x86_64"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    Available packages
-    flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
-    """
+        """
+        Available packages
+        flac.x86_64\s+1.3.2-8.fc29\s+dnf-ci-fedora
+        """
 
 
 # TODO(mblaha) --security not supported for list command
@@ -396,12 +456,15 @@ Given I use repository "security-upgrade"
   And I execute dnf with args "install change-arch-noarch-1-1.noarch"
  When I execute dnf with args "list upgrades --security"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout is
-  """
-  <REPOSYNC>
-  Available Upgrades
-  change-arch-noarch.x86_64                  2-2                  security-upgrade
-  """
+      """
+      Available Upgrades
+      change-arch-noarch.x86_64                  2-2                  security-upgrade
+      """
 
 
 # TODO(mblaha) --security not supported for list command
@@ -412,14 +475,18 @@ Given I use repository "security-upgrade"
   # Make sure change-arch-2-2.x86_64 is available since we are testing we don't list it.
   # It also has to have an available advisory. (We cannot verify that here because the updateinfo command is bugged when dealing with arch changes)
   And I successfully execute dnf with args "repoquery change-arch-2-2.x86_64"
-  Then stdout is
-  """
-  <REPOSYNC>
-  change-arch-0:2-2.x86_64
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      change-arch-0:2-2.x86_64
+      """
  When I execute dnf with args "list upgrades --security"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty

--- a/dnf-behave-tests/dnf/mark.feature
+++ b/dnf-behave-tests/dnf/mark.feature
@@ -74,10 +74,10 @@ Scenario: Marking as dependency a list of pkgs when one of them is not available
    When I execute dnf with args "install lame"
     And I execute dnf with args "mark --skip-unavailable dependency lame nosuchpkg"
    Then the exit code is 0
-    And stderr is
-    """
-    No match for argument: nosuchpkg
-    """
+    And stderr contains lines
+        """
+        No match for argument: nosuchpkg
+        """
     And package reasons are
         | Package                       | Reason     |
         | lame-3.100-4.fc29.x86_64      | Dependency |
@@ -136,14 +136,14 @@ Scenario: Mark package as the same reason it currently has
    When I execute dnf with args "mark user lame"
    Then the exit code is 0
     And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+        """
+        Nothing to do.
+        """
     And stderr is
-    """
-    Package "lame-3.100-4.fc29.x86_64" is already installed with reason "User".
-    """
+        """
+        <REPOSYNC>
+        Package "lame-3.100-4.fc29.x86_64" is already installed with reason "User".
+        """
 
 
 #@dnf5 currently fails, see:

--- a/dnf-behave-tests/dnf/metadata.feature
+++ b/dnf-behave-tests/dnf/metadata.feature
@@ -12,7 +12,7 @@ Given I create directory "/temp-repos/temp-repo"
  Then the exit code is 0
  When I execute dnf with args "list"
  Then the exit code is 0
-  And stdout contains "testrepo"
+  And stderr contains "testrepo"
 Given I copy directory "{context.scenario.repos_location}/dnf-ci-fedora" to "/temp-repos/temp-repo/dnf-ci-fedora"
  Then the exit code is 0
   And I execute "createrepo_c --update ." in "{context.dnf.installroot}/temp-repos/temp-repo"

--- a/dnf-behave-tests/dnf/module/demodularization.feature
+++ b/dnf-behave-tests/dnf/module/demodularization.feature
@@ -33,9 +33,12 @@ Scenario: Test module info contains Demodularized rpms when defined
    Given I use repository "dnf-ci-fedora-modular-demodularized"
    When I execute dnf with args "module info nodejs:5"
    Then the exit code is 0
-    And stdout is
+    And stderr is
       """
       <REPOSYNC>
+      """
+    And stdout is
+      """
       Name               : nodejs
       Stream             : 5
       Version            : 20150811143429

--- a/dnf-behave-tests/dnf/module/enable-errors.feature
+++ b/dnf-behave-tests/dnf/module/enable-errors.feature
@@ -22,6 +22,7 @@ Scenario: Fail to enable a different stream of an already enabled module
         | nodejs    | enabled   | 8         |           |
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         The operation would result in switching of module 'nodejs' stream '8' to stream '10'
         Error: It is not possible to switch enabled streams of a module unless explicitly enabled via configuration option module_stream_switch.
@@ -45,6 +46,7 @@ Scenario: Fail to install a different stream of an already enabled module
         | nodejs    | enabled   | 8         |           |
     And stderr is
         """
+        <REPOSYNC>
         The operation would result in switching of module 'nodejs' stream '8' to stream '10'
         Error: It is not possible to switch enabled streams of a module unless explicitly enabled via configuration option module_stream_switch.
         """
@@ -68,6 +70,7 @@ Scenario: Fail to install a different stream of an already enabled module using 
         | nodejs    | enabled   | 8         |           |
     And stderr is
         """
+        <REPOSYNC>
         The operation would result in switching of module 'nodejs' stream '8' to stream '10'
         Error: It is not possible to switch enabled streams of a module unless explicitly enabled via configuration option module_stream_switch.
         """
@@ -82,6 +85,7 @@ Scenario: Fail to enable a module stream when specifying only module
         | Module    | State     | Stream    | Profiles  |
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Unable to resolve argument 'nodejs':
           - Argument 'nodejs' matches 4 streams ('10', '11', '12', '8') of module 'nodejs', but none of the streams are enabled or default.
@@ -98,6 +102,7 @@ Scenario: Fail to enable a module stream when specifying wrong version
         | Module    | State     | Stream    | Profiles  |
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         No match for argument: nodejs:8:99
         You can try to add to command line:
@@ -115,6 +120,7 @@ Scenario: Fail to enable a non-existent module stream
         | Module    | State     | Stream    | Profiles  |
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         No match for argument: nodejs:1
         You can try to add to command line:
@@ -145,6 +151,7 @@ Scenario: Fail to enable a module stream when specifying more streams of the sam
         | Module    | State     | Stream    | Profiles  |
     And stderr is
         """
+        <REPOSYNC>
         Cannot enable multiple streams for module 'nodejs'
         """
 

--- a/dnf-behave-tests/dnf/module/enable-latest.feature
+++ b/dnf-behave-tests/dnf/module/enable-latest.feature
@@ -13,6 +13,7 @@ Scenario: Enable a module stream that is not latest fails with --best
         | Module    | State     | Stream    | Profiles  |
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Modular dependency problems with the latest modules:
         Problem: cannot install the best candidate for the job

--- a/dnf-behave-tests/dnf/module/filtering.feature
+++ b/dnf-behave-tests/dnf/module/filtering.feature
@@ -13,9 +13,12 @@ Scenario: Check that only module packages including src are available
         | berry-source | enabled   | wood       |           |
    When I execute dnf with args "repoquery berry"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         berry-0:1.0-1.wood.src
         berry-0:1.0-1.wood.x86_64
         """
@@ -29,9 +32,12 @@ Scenario: Check that only module packages including src are available
       | berry-source | enabled   | garden     |           |
  When I execute dnf with args "repoquery berry"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       berry-0:1.0-1.garden.src
       berry-0:1.0-1.garden.x86_64
       """
@@ -46,9 +52,12 @@ Scenario: Check that source packages do not filter binary rpms
       | yum-source   | enabled   | 1          |           |
  When I execute dnf with args "repoquery yum"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       yum-0:3.4.3-0.x86_64
       yum-0:3.8.3-0.f29.modular.src
       yum-0:3.8.3-0.f29.modular.x86_64

--- a/dnf-behave-tests/dnf/module/info-without-install.feature
+++ b/dnf-behave-tests/dnf/module/info-without-install.feature
@@ -21,9 +21,12 @@ Given I use repository "dnf-ci-fedora-modular-updates"
 Scenario: Get info for a module, only module name specified
  When I execute dnf with args "module info nodejs"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       Name             : nodejs
       Stream           : 10
       Version          : 20180920144631
@@ -192,9 +195,12 @@ Scenario: Get info for a module, only module name specified
 Scenario: Get info for an enabled stream, module name and stream specified
  When I execute dnf with args "module info nodejs:11"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       Name             : nodejs
       Stream           : 11
       Version          : 20180920144611
@@ -247,6 +253,7 @@ Scenario: Get info for an enabled stream, module name and stream specified
    Then the exit code is 0
     And stderr is
         """
+        <REPOSYNC>
         No matches found for "non-existing-module".
         """
 
@@ -254,9 +261,12 @@ Scenario: Get info for an enabled stream, module name and stream specified
   Scenario: Get info for two enabled modules from different repos
    When I execute dnf with args "module info nodejs:8 postgresql:10"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Name             : nodejs
         Stream           : 8 [d][e][a]
         Version          : 20180801080000
@@ -320,7 +330,6 @@ Scenario: Get info for an enabled stream, module name and stream specified
    Then the exit code is 0
     And stdout is
         """
-        <REPOSYNC>
         Name             : postgresql
         Stream           : 10
         Version          : 20181211125304
@@ -342,6 +351,7 @@ Scenario: Get info for an enabled stream, module name and stream specified
         """
     And stderr is
         """
+        <REPOSYNC>
         No matches found for "non-existing-module".
         """
 
@@ -351,9 +361,12 @@ Scenario: Get info for an enabled stream, module name and stream specified
   Scenario: I can get the module context of the active stream
    When I execute dnf with args "module info nodejs:8"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Name             : nodejs
         Stream           : 8 [d][e][a]
         Version          : 20180801080000

--- a/dnf-behave-tests/dnf/module/info.feature
+++ b/dnf-behave-tests/dnf/module/info.feature
@@ -33,9 +33,12 @@ Given I use repository "dnf-ci-fedora-modular-updates"
 Scenario: Get info for a module, only module name specified
  When I execute dnf with args "module info nodejs"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       Name             : nodejs
       Stream           : 10
       Version          : 20180920144631
@@ -204,9 +207,12 @@ Scenario: Get info for a module, only module name specified
 Scenario: Get info for an enabled stream, module name and stream specified
  When I execute dnf with args "module info nodejs:11"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       Name             : nodejs
       Stream           : 11
       Version          : 20180920144611
@@ -257,9 +263,12 @@ Scenario: Get info for an enabled stream, module name and stream specified
   Scenario: Get info for an installed profile, module name and profile specified
    When I execute dnf with args "module info nodejs/minimal"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Ignoring unnecessary profile: 'nodejs/minimal'
         Name             : nodejs
         Stream           : 10
@@ -430,9 +439,12 @@ Scenario: Get info for an enabled stream, module name and stream specified
   Scenario: Get info for an installed profile, module name, stream and profile specified
    When I execute dnf with args "module info nodejs:11/minimal"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Ignoring unnecessary profile: 'nodejs/minimal'
         Name             : nodejs
         Stream           : 11
@@ -484,9 +496,12 @@ Scenario: Get info for an enabled stream, module name and stream specified
   Scenario: Non-existent profile is ignored for dnf module info
    When I execute dnf with args "module info nodejs:11/non-existing-profile"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Ignoring unnecessary profile: 'nodejs/non-existing-profile'
         Name             : nodejs
         Stream           : 11
@@ -545,9 +560,12 @@ Scenario: Get info for an enabled stream, module name and stream specified
   Scenario: Get info for two enabled modules from different repos
    When I execute dnf with args "module info nodejs:8 postgresql:10"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Name             : nodejs
         Stream           : 8 [d][e][a]
         Version          : 20180801080000
@@ -609,9 +627,12 @@ Scenario: Get info for an enabled stream, module name and stream specified
   Scenario: Get info for two modules, one of them non-existent
    When I execute dnf with args "module info postgresql:10 non-existing-module"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Unable to resolve argument non-existing-module
         Name             : postgresql
         Stream           : 10
@@ -650,9 +671,12 @@ Scenario: Get info for an enabled stream, module name and stream specified
   Scenario Outline: I can get the info about content of existing module streams with <command>
    When I execute dnf with args "<command>"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Name    : postgresql:10:20181211125304:6c81f848:x86_64
         client  : postgresql
         default : postgresql-server
@@ -689,9 +713,12 @@ Examples:
   Scenario: Profile specification is ignored by dnf module info --profile
    When I execute dnf with args "module info --profile postgresql/client"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Ignoring unnecessary profile: 'postgresql/client'
         Name    : postgresql:10:20181211125304:6c81f848:x86_64
         client  : postgresql
@@ -723,9 +750,12 @@ Examples:
   Scenario: I can get the info about contents of more than one module profile streams
    When I execute dnf with args "module info --profile postgresql:10 nodejs:11"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Name        : nodejs:11:20180920144611:6c81f848:x86_64
         default     : nodejs
                     : npm
@@ -770,9 +800,12 @@ Examples:
   Scenario: I can get the module context of the active stream
    When I execute dnf with args "module info nodejs:8"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Name             : nodejs
         Stream           : 8 [d][e][a]
         Version          : 20180801080000

--- a/dnf-behave-tests/dnf/module/metadata-format.feature
+++ b/dnf-behave-tests/dnf/module/metadata-format.feature
@@ -8,9 +8,12 @@ Feature: libmodulemd document format tests
 Scenario: Metadata containing additional uknown field can be read (the field is ignored)
 Given I use repository "additional-field-modulemd"
  When I execute dnf with args "module info nodejs"
- Then stdout is
+ Then stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       Name             : nodejs
       Stream           : 5
       Version          : 20150811143428
@@ -40,9 +43,12 @@ Given I use repository "additional-field-modulemd"
   And I use repository "dnf-ci-fedora"
   And I execute dnf with args "module enable nodejs:5"
  When I execute dnf with args "repoquery nodejs"
- Then stdout is
+ Then stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-1:5.3.1-1.module_2011+41787af0.src
       nodejs-1:5.3.1-1.module_2011+41787af0.x86_64
       """

--- a/dnf-behave-tests/dnf/module/platform.feature
+++ b/dnf-behave-tests/dnf/module/platform.feature
@@ -42,14 +42,14 @@ Scenario: I can't list info for the pseudo-module
  When I execute dnf with args "module info pseudoplatform"
  Then the exit code is 1
   And stdout is
-   """
-   <REPOSYNC>
-   Unable to resolve argument pseudoplatform
-   """
+      """
+      Unable to resolve argument pseudoplatform
+      """
   And stderr is
-   """
-   Error: No matching Modules to list
-   """
+      """
+      <REPOSYNC>
+      Error: No matching Modules to list
+      """
 
 
 @dnf5
@@ -58,6 +58,7 @@ Scenario: I can't enable pseudo-module
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       No match for argument: pseudoplatform:6.0
       You can try to add to command line:
@@ -81,6 +82,7 @@ Scenario: I can't disable pseudo-module
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       No match for argument: pseudoplatform:6.0
       You can try to add to command line:
@@ -100,15 +102,18 @@ Scenario: I can't update pseudo-module
 Scenario: I can't remove pseudo-module
  When I execute dnf with args "module remove pseudoplatform:6.0"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout matches line by line
-  """
-  <REPOSYNC>
-  ^Dependencies resolved.
-  ^Nothing to do.
-  ^Complete!
-  """
+      """
+      ^Dependencies resolved.
+      ^Nothing to do.
+      ^Complete!
+      """
   And stderr contains lines
-  """
-  Problems in request:
-  missing groups or modules: pseudoplatform:6.0
-  """
+      """
+      Problems in request:
+      missing groups or modules: pseudoplatform:6.0
+      """

--- a/dnf-behave-tests/dnf/module/provides.feature
+++ b/dnf-behave-tests/dnf/module/provides.feature
@@ -10,9 +10,12 @@ Given I use repository "dnf-ci-fedora-modular"
 Scenario: I can get list of all modules providing specific package
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
       Module   : nodejs:10:20180920144631:6c81f848:x86_64
       Profiles : development
@@ -45,9 +48,12 @@ Scenario: I can get list of enabled modules providing specific package
 Given I successfully execute dnf with args "module enable nodejs:8"
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
       Module   : nodejs:10:20180920144631:6c81f848:x86_64
       Profiles : development
@@ -80,9 +86,12 @@ Scenario: I see packages only once when they are availiable and installed
 Given I successfully execute dnf with args "module enable nodejs:8"
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
       Module   : nodejs:10:20180920144631:6c81f848:x86_64
       Profiles : development
@@ -116,9 +125,12 @@ Given I successfully execute dnf with args "module enable nodejs:8"
       | module-profile-install    | nodejs/development                                  |
  When I execute dnf with args "module provides nodejs-devel"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-devel-1:10.11.0-1.module_2200+adbac02b.x86_64
       Module   : nodejs:10:20180920144631:6c81f848:x86_64
       Profiles : development

--- a/dnf-behave-tests/dnf/module/repoquery.feature
+++ b/dnf-behave-tests/dnf/module/repoquery.feature
@@ -6,17 +6,20 @@ Scenario Outline: <command> returns packages from both default and enabled strea
     And I successfully execute dnf with args "module enable dwm:6.0"
    When I execute dnf with args "module <command> dwm nodejs"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    dwm-6.0-1.module_1997+c375c79c.src
-    dwm-6.0-1.module_1997+c375c79c.x86_64
-    nodejs-1:8.11.4-1.module_2030+42747d40.src
-    nodejs-1:8.11.4-1.module_2030+42747d40.x86_64
-    nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
-    nodejs-docs-1:8.11.4-1.module_2030+42747d40.noarch
-    npm-1:8.11.4-1.module_2030+42747d40.x86_64
-    """
+        """
+        dwm-6.0-1.module_1997+c375c79c.src
+        dwm-6.0-1.module_1997+c375c79c.x86_64
+        nodejs-1:8.11.4-1.module_2030+42747d40.src
+        nodejs-1:8.11.4-1.module_2030+42747d40.x86_64
+        nodejs-devel-1:8.11.4-1.module_2030+42747d40.x86_64
+        nodejs-docs-1:8.11.4-1.module_2030+42747d40.noarch
+        npm-1:8.11.4-1.module_2030+42747d40.x86_64
+        """
 
 Examples:
     | command                   |
@@ -30,12 +33,15 @@ Scenario: module repoquery --installed lists only installed modular packages
     And I successfully execute dnf with args "module install nodejs:10/minimal"
    When I execute dnf with args "module repoquery --installed dwm nodejs"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    nodejs-1:10.11.0-1.module_2200+adbac02b.x86_64
-    npm-1:10.11.0-1.module_2200+adbac02b.x86_64
-    """
+        """
+        nodejs-1:10.11.0-1.module_2200+adbac02b.x86_64
+        npm-1:10.11.0-1.module_2200+adbac02b.x86_64
+        """
 
 
 Scenario: module repoquery --installed returns also packages not available any more
@@ -46,12 +52,15 @@ Scenario: module repoquery --installed returns also packages not available any m
     And I drop repository "dnf-ci-fedora-modular-updates"
    When I execute dnf with args "module repoquery --installed dwm nodejs"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    nodejs-1:12.1.0-1.module_2379+8d497405.x86_64
-    npm-1:12.1.0-1.module_2379+8d497405.x86_64
-    """
+        """
+        nodejs-1:12.1.0-1.module_2379+8d497405.x86_64
+        npm-1:12.1.0-1.module_2379+8d497405.x86_64
+        """
 
 
 Scenario: module repoquery can be used with both --installed and --available together
@@ -62,13 +71,16 @@ Scenario: module repoquery can be used with both --installed and --available tog
     And I drop repository "dnf-ci-fedora-modular-updates"
    When I execute dnf with args "module repoquery --installed --available dwm nodejs ninja"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    ninja-build-1.8.2-4.module_1991+4e5efe2f.src
-    ninja-build-1.8.2-4.module_1991+4e5efe2f.x86_64
-    ninja-build-debuginfo-1.8.2-4.module_1991+4e5efe2f.x86_64
-    ninja-build-debugsource-1.8.2-4.module_1991+4e5efe2f.x86_64
-    nodejs-1:12.1.0-1.module_2379+8d497405.x86_64
-    npm-1:12.1.0-1.module_2379+8d497405.x86_64
-    """
+        """
+        ninja-build-1.8.2-4.module_1991+4e5efe2f.src
+        ninja-build-1.8.2-4.module_1991+4e5efe2f.x86_64
+        ninja-build-debuginfo-1.8.2-4.module_1991+4e5efe2f.x86_64
+        ninja-build-debugsource-1.8.2-4.module_1991+4e5efe2f.x86_64
+        nodejs-1:12.1.0-1.module_2379+8d497405.x86_64
+        npm-1:12.1.0-1.module_2379+8d497405.x86_64
+        """

--- a/dnf-behave-tests/dnf/module/updateinfo.feature
+++ b/dnf-behave-tests/dnf/module/updateinfo.feature
@@ -21,9 +21,12 @@ Given I use repository "dnf-ci-fedora-modular"
 Given I use repository "dnf-ci-fedora-modular-updates"
  When I execute dnf with args "updateinfo --list"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       FEDORA-2019-0329090518 enhancement postgresql-9.6.11-1.x86_64
       """
 
@@ -43,10 +46,11 @@ Given I use repository "dnf-ci-fedora-modular"
 Given I use repository "dnf-ci-fedora-modular-updates"
  Then I execute dnf with args "updateinfo --list"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 
 @dnf5
@@ -57,10 +61,11 @@ Given I use repository "dnf-ci-fedora"
   And I use repository "dnf-ci-fedora-modular-updates"
   And I execute dnf with args "module enable postgresql:9.6"
  When I execute dnf with args "updateinfo --list"
- Then stdout is
+ Then stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 
 @bz1804234
@@ -72,9 +77,12 @@ Given I use repository "dnf-ci-fedora"
   And I execute dnf with args "module install postgresql/default"
   And I use repository "dnf-ci-fedora-modular-updates"
  When I execute dnf with args "updateinfo --list"
- Then stdout is
+ Then stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       FEDORA-2019-0329090518 enhancement nodejs-1:8.14.0-1.x86_64
       FEDORA-2019-0329090518 enhancement postgresql-9.6.11-1.x86_64
       """
@@ -89,9 +97,12 @@ Given I use repository "dnf-ci-fedora"
   And I use repository "dnf-ci-fedora-modular-updates"
   And I execute dnf with args "module enable nodejs:8"
  When I execute dnf with args "updateinfo --list"
- Then stdout is
+ Then stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       FEDORA-2019-0329090518 enhancement nodejs-1:8.14.0-1.x86_64
       FEDORA-2019-0329090518 enhancement postgresql-9.6.11-1.x86_64
       """
@@ -114,9 +125,12 @@ Given I use repository "dnf-ci-multicontext-modular-advisory"
       | module-stream-enable  | perl-DBI:master                                        |
   When I execute dnf with args "updateinfo --list"
   Then the exit code is 0
-   And stdout is
+   And stderr is
       """
       <REPOSYNC>
+      """
+   And stdout is
+      """
       FEDORA-2019-0329090518 enhancement test-perl-DBI-1-2.module_el8+6587+9879afr5.x86_64
       """
   When I execute dnf with args "check-update --enhancement"
@@ -129,8 +143,8 @@ Given I use repository "dnf-ci-multicontext-modular-advisory"
       | upgrade               | test-perl-DBI-0:1-2.module_el8+6587+9879afr5.x86_64   |
   When I execute dnf with args "updateinfo"
   Then the exit code is 0
-   And stdout is
-      """
-      <REPOSYNC>
-
-      """
+   And stderr is
+       """
+       <REPOSYNC>
+       """
+   And stdout is empty

--- a/dnf-behave-tests/dnf/obsoletes.feature
+++ b/dnf-behave-tests/dnf/obsoletes.feature
@@ -294,10 +294,10 @@ Scenario: Obsoleted package is not installed when group contains both obsoleter 
         | Action        | Package                               |
         | install-group | PackageD-0:2.0-1.x86_64               |
         | group-install | Obsoleter and obsoleted               |
-    And stderr is
-    """
-    Warning: skipped PGP checks for 1 package from repository: dnf-ci-obsoletes
-    """
+    And stderr contains lines
+        """
+        Warning: skipped PGP checks for 1 package from repository: dnf-ci-obsoletes
+        """
 
 
 @dnf5
@@ -306,12 +306,13 @@ Scenario: Both packages are installed when group contains both obsoleter and obs
    When I execute dnf with args "group install obsoleter-obsoleted --setopt=obsoletes=False"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Problem: package PackageD-2.0-1.x86_64 from dnf-ci-obsoletes obsoletes PackageC < 2.0 provided by PackageC-1.0-1.x86_64 from dnf-ci-obsoletes
-      - cannot install the best candidate for the job
-      - conflicting requests
-    You can try to add to command line:
-      --no-best to not limit the transaction to the best candidates
-      --skip-broken to skip uninstallable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Problem: package PackageD-2.0-1.x86_64 from dnf-ci-obsoletes obsoletes PackageC < 2.0 provided by PackageC-1.0-1.x86_64 from dnf-ci-obsoletes
+          - cannot install the best candidate for the job
+          - conflicting requests
+        You can try to add to command line:
+          --no-best to not limit the transaction to the best candidates
+          --skip-broken to skip uninstallable packages
+        """

--- a/dnf-behave-tests/dnf/offline.feature
+++ b/dnf-behave-tests/dnf/offline.feature
@@ -13,7 +13,7 @@ Scenario: Test offline when reboot wasn't performed
   And DNF Transaction is following
       | Action        | Package                    |
       | install       | flac-0:1.3.2-8.fc29.x86_64 |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -31,13 +31,13 @@ Scenario: Test offline when an offline transaction is already queued
   And DNF Transaction is following
       | Action        | Package                    |
       | install       | flac-0:1.3.2-8.fc29.x86_64 |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
  When I execute dnf with args "install --offline flac"
  Then the exit code is 0
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
 
@@ -76,7 +76,7 @@ Scenario: Test offline clean
   And DNF Transaction is following
       | Action        | Package                    |
       | install       | flac-0:1.3.2-8.fc29.x86_64 |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -100,7 +100,7 @@ Scenario: Test offline install and offline status
   And DNF Transaction is following
       | Action        | Package                    |
       | install       | flac-0:1.3.2-8.fc29.x86_64 |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -134,7 +134,7 @@ Given I use repository "dnf-ci-fedora-updates"
       | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
       | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
       | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -157,7 +157,7 @@ Given I use repository "dnf-ci-thirdparty"
       | install-group | lame-0:3.100-4.fc29.x86_64        |
       | install-dep   | lame-libs-0:3.100-4.fc29.x86_64   |
       | group-install | DNF-CI-Testgroup                  |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -180,7 +180,7 @@ Given I use repository "simple-base"
   And DNF Transaction is following
       | Action        | Package                               |
       | upgrade       | labirinto-2.0-1.fc29.x86_64           |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -208,7 +208,7 @@ Given I use repository "simple-base"
   And DNF Transaction is following
       | Action        | Package                               |
       | upgrade       | labirinto-2.0-1.fc29.x86_64           |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """

--- a/dnf-behave-tests/dnf/optional-metadata.feature
+++ b/dnf-behave-tests/dnf/optional-metadata.feature
@@ -21,13 +21,16 @@ Background:
 Scenario: Optional metadata are loaded when explicitly requested by the option
   Given I execute dnf with args "makecache --setopt=optional_metadata_types=,comps"
    Then the exit code is 0
-    And stdout matches line by line
-    """
-    Updating and loading repositories:
-     advisories-and-groups test repository .*
-    Repositories loaded.
-    Metadata cache created.
-    """
+    And stderr matches line by line
+        """
+        Updating and loading repositories:
+         advisories-and-groups test repository .*
+        Repositories loaded.
+        """
+    And stdout is
+        """
+        Metadata cache created.
+        """
    When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
     """
@@ -46,23 +49,25 @@ Scenario: Optional metadata are loaded when explicitly requested by the option
 Scenario: Invalid metadata type is ignored when processing the option
   Given I execute dnf with args "makecache --setopt=optional_metadata_types=,abcdef"
    Then the exit code is 0
-    And stdout matches line by line
-    """
-    Updating and loading repositories:
-    Repositories loaded.
-    Metadata cache created.
-    """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Metadata cache created.
+        """
 
 
 Scenario: Optional metadata are loaded when requested by command
   Given I execute dnf with args "advisory list --setopt=optional_metadata_types=,"
    Then the exit code is 0
-    And stdout matches line by line
-    """
-    Updating and loading repositories:
-     advisories-and-groups test repository .*
-    Repositories loaded.
-    """
+    And stderr matches line by line
+        """
+        Updating and loading repositories:
+         advisories-and-groups test repository .*
+        Repositories loaded.
+        """
    When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
     """
@@ -82,20 +87,21 @@ Scenario: Operation returns an error when metadata are not present in cacheonly 
   Given I execute dnf with args "advisory list --cacheonly --setopt=optional_metadata_types=,"
    Then the exit code is 1
     And stderr is
-    """
-    Cache-only enabled but no cache for repository "advisories-and-groups"
-    """
+        """
+        <REPOSYNC>
+        Cache-only enabled but no cache for repository "advisories-and-groups"
+        """
 
 
 Scenario: Filelists metadata are loaded when filepath spec is provided
   Given I execute dnf with args "repoquery /some/file --setopt=optional_metadata_types=,"
    Then the exit code is 0
-    And stdout matches line by line
-    """
-    Updating and loading repositories:
-     advisories-and-groups test repository .*
-    Repositories loaded.
-    """
+    And stderr matches line by line
+        """
+        Updating and loading repositories:
+         advisories-and-groups test repository .*
+        Repositories loaded.
+        """
    When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
     """
@@ -114,12 +120,12 @@ Scenario: Filelists metadata are loaded when filepath spec is provided
 Scenario: Comps metadata are loaded when group spec is provided
   Given I execute dnf with args "repoquery @group --setopt=optional_metadata_types=,"
    Then the exit code is 0
-    And stdout matches line by line
-    """
-    Updating and loading repositories:
-     advisories-and-groups test repository .*
-    Repositories loaded.
-    """
+    And stderr matches line by line
+        """
+        Updating and loading repositories:
+         advisories-and-groups test repository .*
+        Repositories loaded.
+        """
    When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
     """

--- a/dnf-behave-tests/dnf/plugins-core/builddep.feature
+++ b/dnf-behave-tests/dnf/plugins-core/builddep.feature
@@ -81,12 +81,13 @@ Scenario: Builddep with simple dependency (non-existent)
      Then the exit code is 1
       And dnf4 stderr contains "No matching package to install: 'flac = 15'"
       And dnf5 stderr is
-      """
-      Failed to resolve the transaction:
-      No match for argument: flac = 15
-      You can try to add to command line:
-        --skip-unavailable to skip unavailable packages
-      """
+          """
+          <REPOSYNC>
+          Failed to resolve the transaction:
+          No match for argument: flac = 15
+          You can try to add to command line:
+            --skip-unavailable to skip unavailable packages
+          """
 
 
 @bz1724668
@@ -115,11 +116,12 @@ Scenario: Builddep on SPEC with non-available Source0
    Error: Some packages could not be found.
    """
    And dnf5 stderr matches line by line
-   """
-   error: Unable to open .*/missingSource.spec: No such file or directory
-   Failed to parse spec file ".*/missingSource.spec".
-   Failed to parse some inputs.
-   """
+       """
+       <REPOSYNC>
+       error: Unable to open .*/missingSource.spec: No such file or directory
+       Failed to parse spec file ".*/missingSource.spec".
+       Failed to parse some inputs.
+       """
 
 
 @bz1758459
@@ -152,12 +154,13 @@ Scenario: Builddep with unavailable build dependency
      When I execute dnf with args "builddep {context.dnf.fixturesdir}/repos/dnf-ci-builddep/src/unavailable-requirement-1.0-1.src.rpm"
      Then the exit code is 1
       And stderr is
-      """
-      Failed to resolve the transaction:
-      No match for argument: this-lib-is-not-available
-      You can try to add to command line:
-        --skip-unavailable to skip unavailable packages
-      """
+          """
+          <REPOSYNC>
+          Failed to resolve the transaction:
+          No match for argument: this-lib-is-not-available
+          You can try to add to command line:
+            --skip-unavailable to skip unavailable packages
+          """
      When I execute dnf with args "builddep --skip-unavailable {context.dnf.fixturesdir}/repos/dnf-ci-builddep/src/unavailable-requirement-1.0-1.src.rpm"
      Then the exit code is 0
       And dnf4 stderr is
@@ -174,7 +177,7 @@ Scenario: Builddep using macros with source rpm
     Given I use repository "dnf-ci-fedora"
      When I execute dnf with args "builddep -D 'dummy_param 1' {context.dnf.fixturesdir}/repos/dnf-ci-thirdparty/src/SuperRipper-1.0-1.src.rpm"
      Then the exit code is 0
-      And stderr is
+      And stderr contains lines
       """
       Warning: -D/--define/--with/--without arguments have no effect on source rpm packages.
       Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora

--- a/dnf-behave-tests/dnf/plugins-core/changelog.feature
+++ b/dnf-behave-tests/dnf/plugins-core/changelog.feature
@@ -9,9 +9,12 @@ Background:
 Scenario: Listing changelogs since given date
    When I execute dnf with args "changelog pkg-with-changelogs --since 2023-01-01"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     Listing changelogs since Sun Jan  1 00:00:00 2023
     Changelogs for pkg-with-changelogs-1.0-3.src, pkg-with-changelogs-1.0-3.x86_64
     * Mon May 01 12:00:00 2023 DNF5 Team <pkgs@dnf.team> - 1.0-3

--- a/dnf-behave-tests/dnf/plugins-core/debug-restore.feature
+++ b/dnf-behave-tests/dnf/plugins-core/debug-restore.feature
@@ -13,12 +13,15 @@ Scenario: debug-restore does not do anything if there is no package set change
    When I execute dnf with args "debug-restore {context.dnf.tempdir}/dump.txt"
    Then the exit code is 0
     And transaction is empty
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    Complete!
+    """
+    And stdout is
+    """
     Dependencies resolved.
     Nothing to do.
-    Complete!
     """
 
 
@@ -45,12 +48,15 @@ Scenario: debug-restore does not install missing packages if 'install' not in fi
    When I execute dnf with args "debug-restore {context.dnf.tempdir}/dump.txt --filter-types=remove,replace"
    Then the exit code is 0
     And transaction is empty
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    Complete!
+    """
+    And stdout is
+    """
     Dependencies resolved.
     Nothing to do.
-    Complete!
     """
 
 
@@ -68,12 +74,15 @@ Scenario: debug-restore does not remove packages if 'remove' not in filter-types
    When I execute dnf with args "debug-restore {context.dnf.tempdir}/dump.txt --filter-types=install,replace"
    Then the exit code is 0
     And transaction is empty
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    Complete!
+    """
+    And stdout is
+    """
     Dependencies resolved.
     Nothing to do.
-    Complete!
     """
 
 
@@ -100,12 +109,16 @@ Scenario: debug-restore does not replace packages if 'replace' not in filter-typ
    When I execute dnf with args "debug-restore {context.dnf.tempdir}/dump.txt --filter-types=install,remove"
    Then the exit code is 0
     And transaction is empty
+    And stderr is
+    """
+    <REPOSYNC>
+    Complete!
+    """
     And stdout is
     """
     <REPOSYNC>
     Dependencies resolved.
     Nothing to do.
-    Complete!
     """
 
 @bz1844533
@@ -153,9 +166,12 @@ Scenario: debug-restore --output only prints what would be changed
    When I execute dnf with args "debug-restore --output {context.dnf.tempdir}/dump.txt"
    Then the exit code is 0
     And transaction is empty
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     install   kernel-0:4.20.1-fc29.x86_64
     replace   test-replace-0:2-fc29.x86_64
     """
@@ -168,9 +184,12 @@ Scenario: debug-restore --output only prints what would be changed (with --remov
    When I execute dnf with args "debug-restore --remove-installonly --output {context.dnf.tempdir}/dump.txt"
    Then the exit code is 0
     And transaction is empty
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     remove    kernel-0:4.18.1-fc29.x86_64
     install   kernel-0:4.20.1-fc29.x86_64
     replace   test-replace-0:2-fc29.x86_64

--- a/dnf-behave-tests/dnf/plugins-core/debuginfo-install.feature
+++ b/dnf-behave-tests/dnf/plugins-core/debuginfo-install.feature
@@ -10,6 +10,7 @@ Scenario: reports an error for a non-existent package
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       No match for argument: non-existent-package
       You can try to add to command line:
@@ -21,6 +22,7 @@ Scenario: reports an error for a package without debuginfo
  Then the exit code is 0
   And stderr is
       """
+      <REPOSYNC>
       Could not find debuginfo package for the following packages resolved from the argument 'nodebug': nodebug-0:1.0-1.x86_64
       Could not find debugsource package for the following packages resolved from the argument 'nodebug': nodebug-0:1.0-1.x86_64
       """
@@ -86,6 +88,7 @@ Given I successfully execute dnf with args "install bar-2.0"
  Then the exit code is 0
   And stderr is
       """
+      <REPOSYNC>
       Could not find debuginfo package for the following packages resolved from the argument 'bar': bar-0:2.0-1.x86_64
       Could not find debugsource package for the following packages resolved from the argument 'bar': bar-0:2.0-1.x86_64
       """
@@ -95,6 +98,7 @@ Scenario: can't find the requested version of debuginfo (multilib package, archi
  Then the exit code is 0
   And stderr is
       """
+      <REPOSYNC>
       Could not find debuginfo package for the following packages resolved from the argument 'baz-1.0': baz-0:1.0-1.i686, baz-0:1.0-1.x86_64
       Could not find debugsource package for the following packages resolved from the argument 'baz-1.0': baz-0:1.0-1.i686, baz-0:1.0-1.x86_64
       """

--- a/dnf-behave-tests/dnf/plugins-core/download-source.feature
+++ b/dnf-behave-tests/dnf/plugins-core/download-source.feature
@@ -18,7 +18,7 @@ Scenario: Download a source for an RPM that doesn't exist
 Scenario: Download a source for an existing RPM
    When I execute dnf with args "download --srpm setup"
    Then the exit code is 0
-    And stdout contains "setup-0:2.12.1-1.fc29.src"
+    And stderr contains "setup-0:2.12.1-1.fc29.src"
     And file sha256 checksums are following
         | Path                                              | sha256                                                                                |
         | {context.dnf.tempdir}/setup-2.12.1-1.fc29.src.rpm | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
@@ -27,7 +27,7 @@ Scenario: Download a source for an existing RPM
 Scenario: Download a source for an existing RPM with a different name
    When I execute dnf with args "download --srpm nscd"
    Then the exit code is 0
-    And stdout contains "glibc-0:2.28-9.fc29.src"
+    And stderr contains "glibc-0:2.28-9.fc29.src"
     And file sha256 checksums are following
         | Path                                              | sha256                                                                                |
         | {context.dnf.tempdir}/glibc-2.28-9.fc29.src.rpm   | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/glibc-2.28-9.fc29.src.rpm    |
@@ -38,7 +38,7 @@ Scenario: Download a source for an existing RPM with a different name
 Scenario: Download an existing --srpm RPM with --verbose option
    When I execute dnf with args "download --srpm setup --verbose"
    Then the exit code is 0
-    And stdout contains "setup-2.12.1-1.fc29.src.rpm"
+    And stderr contains "setup-2.12.1-1.fc29.src.rpm"
     And file sha256 checksums are following
         | Path                                              | sha256                                                                |
         | {context.dnf.tempdir}/setup-2.12.1-1.fc29.src.rpm | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
@@ -48,8 +48,8 @@ Scenario: Download an existing --srpm RPM with --verbose option
 Scenario: Download a specified source rpm
    When I execute dnf with args "download --destdir={context.dnf.tempdir}/downloaddir --srpm setup-2.12.1-1.fc29.src"
    Then the exit code is 0
-    And stdout contains "setup-0:2.12.1-1.fc29.src"
-    And stdout does not contain "setup-0:2.12.1-1.fc29.noarch"
+    And stderr contains "setup-0:2.12.1-1.fc29.src"
+    And stderr does not contain "setup-0:2.12.1-1.fc29.noarch"
     And file sha256 checksums are following
         | Path                                                              | sha256                                                                                |
         | {context.dnf.tempdir}/downloaddir/setup-2.12.1-1.fc29.src.rpm     | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora/src/setup-2.12.1-1.fc29.src.rpm  |
@@ -61,7 +61,7 @@ Scenario Outline: Download a source RPM when there are more versions available
   Given I use repository "dnf-ci-fedora-updates-testing" as http
    When I execute dnf with args "download --srpm <pkgspec>"
    Then the exit code is 0
-    And stdout contains "<srpm nevra>"
+    And stderr contains "<srpm nevra>"
     And file sha256 checksums are following
         | Path                          | sha256                                                                           |
         | {context.dnf.tempdir}/<srpm>  | file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates-testing/src/<srpm> |
@@ -81,7 +81,7 @@ Scenario Outline: Download a source RPM when there are more epochs available
   Given I use repository "dnf-ci-fedora-updates-testing" as http
    When I execute dnf with args "download --srpm <pkgspec>"
    Then the exit code is 0
-    And stdout contains "<srpm nevra>"
+    And stderr contains "<srpm nevra>"
     And file sha256 checksums are following
         | Path                          | sha256                                                    |
         | {context.dnf.tempdir}/<srpm>  | file://{context.dnf.fixturesdir}/repos/<repo>/src/<srpm>  |

--- a/dnf-behave-tests/dnf/plugins-core/groups-manager.feature
+++ b/dnf-behave-tests/dnf/plugins-core/groups-manager.feature
@@ -131,9 +131,12 @@ Scenario Outline: Package to add to a group can be specified by "<type>"
   Given I use repository "simple-base"
    When I execute dnf with args "groups-manager --name="New group" --print <spec>"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
     <comps>
@@ -231,9 +234,12 @@ Scenario: groups-manager --print is working
       </group>
     </comps>
     """
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE comps PUBLIC "-//Red Hat, Inc.//DTD Comps info//EN" "comps.dtd">
     <comps>

--- a/dnf-behave-tests/dnf/plugins-core/modulesync.feature
+++ b/dnf-behave-tests/dnf/plugins-core/modulesync.feature
@@ -17,9 +17,12 @@ Scenario: I can download a module
     And file "modulesync/nodejs-devel-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
     And file "modulesync/nodejs-docs-8.11.4-1.module_2030+42747d40.noarch.rpm" exists
     And file "modulesync/npm-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     Directory walk started
     Directory walk done - 5 packages
     Loaded information about 0 packages
@@ -40,9 +43,12 @@ Scenario: I can download a module using --downloaddir
     And file "modulesync/nodejs-devel-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
     And file "modulesync/nodejs-docs-8.11.4-1.module_2030+42747d40.noarch.rpm" exists
     And file "modulesync/npm-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     Directory walk started
     Directory walk done - 6 packages
     Loaded information about 0 packages
@@ -64,9 +70,12 @@ Scenario: I can download a module with option newest only
     And file "modulesync/nodejs-devel-8.11.4-1.module_2030+42747d40.x86_64.rpm" exists
     And file "modulesync/nodejs-docs-8.11.4-1.module_2030+42747d40.noarch.rpm" exists
     And file "modulesync/npm-8.14.0-1.module_2030+42747d41.x86_64.rpm" exists
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     Directory walk started
     Directory walk done - 5 packages
     Loaded information about 0 packages
@@ -90,9 +99,12 @@ Scenario: I can download a module and init a modular repository with modulesync
     And file "modulesync/setup-2.12.1-1.fc29.noarch.rpm" exists
    When I execute dnf with args "modulesync --downloaddir={context.dnf.installroot}/modulesync"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     Directory walk started
     Directory walk done - 8 packages
     Loaded information about 0 packages

--- a/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
+++ b/dnf-behave-tests/dnf/plugins-core/needs-restarting.feature
@@ -20,9 +20,12 @@ Scenario: Update core packages
       And I execute dnf with args "upgrade lame wget"
      When I execute dnf with args "needs-restarting"
      Then the exit code is 1
-      And stdout is
+      And stderr is
           """
           <REPOSYNC>
+          """
+      And stdout is
+          """
           Core libraries or services have been updated since boot-up:
             * glibc
             * kernel
@@ -37,9 +40,12 @@ Scenario: Install a package with an associated reboot_suggested advisory
     Given I execute dnf with args "upgrade --advisory=FEDORA-2999:003-03 \*"
      When I execute dnf with args "needs-restarting"
      Then the exit code is 1
-      And stdout is
+      And stderr is
           """
           <REPOSYNC>
+          """
+      And stdout is
+          """
           Core libraries or services have been updated since boot-up:
             * lz4
 
@@ -51,9 +57,12 @@ Scenario: Update non-core packages only
     Given I execute dnf with args "upgrade lame basesystem wget"
      When I execute dnf with args "needs-restarting"
      Then the exit code is 0
-      And stdout is
+      And stderr is
           """
           <REPOSYNC>
+          """
+      And stdout is
+          """
           No core libraries or services have been updated since boot-up.
           Reboot should not be necessary.
           """

--- a/dnf-behave-tests/dnf/plugins-core/repoclosure.feature
+++ b/dnf-behave-tests/dnf/plugins-core/repoclosure.feature
@@ -16,7 +16,6 @@ Scenario: Run repoclosure without any options
    Then the exit code is 1
     And stdout is
     """
-    <REPOSYNC>
     package: dedalo-1.0-1.fc29.noarch from repoclosure-lookaside
       unresolved deps (1):
         the-other-lib
@@ -26,6 +25,7 @@ Scenario: Run repoclosure without any options
     """
     And stderr is
         """
+        <REPOSYNC>
         Error: Repoclosure ended with unresolved dependencies (2) across 2 packages.
         """
 
@@ -37,13 +37,13 @@ Scenario: Run repoclosure with a package specified
    Then the exit code is 1
     And stdout is
     """
-    <REPOSYNC>
     package: dedalo-1.0-1.fc29.noarch from repoclosure-lookaside
       unresolved deps (1):
         the-other-lib
     """
     And stderr is
         """
+        <REPOSYNC>
         Error: Repoclosure ended with unresolved dependencies (1) across 1 packages.
         """
 
@@ -69,7 +69,6 @@ Scenario: Check closure with --newest (consider only the latest package in each 
    Then the exit code is 1
     And stdout is
     """
-    <REPOSYNC>
     package: dedalo-1.0-1.fc29.noarch from repoclosure-lookaside
       unresolved deps (1):
         the-other-lib
@@ -82,6 +81,7 @@ Scenario: Check closure with --newest (consider only the latest package in each 
     """
     And stderr is
         """
+        <REPOSYNC>
         Error: Repoclosure ended with unresolved dependencies (3) across 3 packages.
         """
 
@@ -93,7 +93,6 @@ Scenario: Check closure with --best
    Then the exit code is 1
     And stdout is
     """
-    <REPOSYNC>
     package: dedalo-1.0-1.fc29.noarch from repoclosure-lookaside
       unresolved deps (1):
         the-other-lib
@@ -112,6 +111,7 @@ Scenario: Check closure with --best
     """
     And stderr is
         """
+        <REPOSYNC>
         Error: Repoclosure ended with unresolved dependencies (5) across 5 packages.
         """
 
@@ -123,7 +123,6 @@ Scenario: Check closure with both --newest and --best
    Then the exit code is 1
     And stdout is
     """
-    <REPOSYNC>
     package: dedalo-1.0-1.fc29.noarch from repoclosure-lookaside
       unresolved deps (1):
         the-other-lib
@@ -139,5 +138,6 @@ Scenario: Check closure with both --newest and --best
     """
     And stderr is
         """
+        <REPOSYNC>
         Error: Repoclosure ended with unresolved dependencies (4) across 4 packages.
         """

--- a/dnf-behave-tests/dnf/plugins-core/reposync.feature
+++ b/dnf-behave-tests/dnf/plugins-core/reposync.feature
@@ -33,9 +33,12 @@ Scenario: Reposync with --downloadcomps option
     And I drop repository "dnf-ci-thirdparty-updates"
    When I execute dnf with args "group list"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
    """
-   <REPOSYNC>
    Available Groups:
       DNF-CI-Testgroup
    """
@@ -229,9 +232,12 @@ Scenario: Reposync --urls switch
   Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --urls"
    Then the exit code is 0
-    And stdout matches line by line
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout matches line by line
+    """
     http://localhost:[0-9]+/src/CQRlib-extension-1\.6-2\.src\.rpm
     http://localhost:[0-9]+/x86_64/CQRlib-extension-1\.6-2\.x86_64\.rpm
     http://localhost:[0-9]+/src/SuperRipper-1\.2-1\.src\.rpm
@@ -246,9 +252,12 @@ Scenario: Reposync --urls and --download-metadata switches
   Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --urls --download-metadata"
    Then the exit code is 0
-    And stdout matches line by line
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout matches line by line
+    """
     http://localhost:[0-9]+/repodata/primary.xml.gz
     http://localhost:[0-9]+/repodata/filelists.xml.gz
     http://localhost:[0-9]+/repodata/other.xml.gz

--- a/dnf-behave-tests/dnf/plugins-core/versionlock-exclude.feature
+++ b/dnf-behave-tests/dnf/plugins-core/versionlock-exclude.feature
@@ -18,9 +18,12 @@ Background: Set up versionlock infrastructure in the installroot
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "repoquery wget"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     wget-0:1.19.5-5.fc29.src
     wget-0:1.19.5-5.fc29.x86_64
     wget-0:1.19.6-5.fc29.src

--- a/dnf-behave-tests/dnf/plugins-core/versionlock-list-manipulation.feature
+++ b/dnf-behave-tests/dnf/plugins-core/versionlock-list-manipulation.feature
@@ -18,16 +18,22 @@ Scenario: Basic commands add/exclude/list/delete/clear for manipulation with ver
    # add command
    When I execute dnf with args "versionlock add wget"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     Adding versionlock on "wget = 1.19.5-5.fc29".
     """
    When I execute dnf with args "versionlock list"
    Then the exit code is 0
-    And stdout matches line by line
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout matches line by line
+    """
     # Added by 'versionlock add' command on .*
     Package name: wget
     evr = 1.19.5-5.fc29
@@ -35,16 +41,22 @@ Scenario: Basic commands add/exclude/list/delete/clear for manipulation with ver
    # exclude command
    When I execute dnf with args "versionlock exclude lame"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     Adding versionlock exclude on "lame = 3.100-4.fc29".
     """
    When I execute dnf with args "versionlock list"
    Then the exit code is 0
-    And stdout matches line by line
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout matches line by line
+    """
     # Added by 'versionlock add' command on .*
     Package name: wget
     evr = 1.19.5-5.fc29
@@ -56,9 +68,12 @@ Scenario: Basic commands add/exclude/list/delete/clear for manipulation with ver
    # delete command
    When I execute dnf with args "versionlock delete wget"
    Then the exit code is 0
-    And stdout matches line by line
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout matches line by line
+    """
     Deleting versionlock entry:
     # Added by 'versionlock add' command on .*
     Package name: wget
@@ -66,9 +81,12 @@ Scenario: Basic commands add/exclude/list/delete/clear for manipulation with ver
     """
    When I execute dnf with args "versionlock list"
    Then the exit code is 0
-    And stdout matches line by line
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout matches line by line
+    """
     # Added by 'versionlock exclude' command on .*
     Package name: lame
     evr != 3.100-4.fc29
@@ -76,9 +94,12 @@ Scenario: Basic commands add/exclude/list/delete/clear for manipulation with ver
    # delete command on excluded package
    When I execute dnf with args "versionlock delete lame"
    Then the exit code is 0
-    And stdout matches line by line
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout matches line by line
+    """
     Deleting versionlock entry:
     # Added by 'versionlock exclude' command on .*
     Package name: lame
@@ -86,30 +107,36 @@ Scenario: Basic commands add/exclude/list/delete/clear for manipulation with ver
     """
    When I execute dnf with args "versionlock list"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
     """
+    And stdout is empty
    # clear command
    When I execute dnf with args "versionlock add wget"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     Adding versionlock on "wget = 1.19.5-5.fc29".
     """
    When I execute dnf with args "versionlock clear"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
     """
+    And stdout is empty
    When I execute dnf with args "versionlock list"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
     """
+    And stdout is empty
 
 
 @dnf5
@@ -138,6 +165,7 @@ Scenario: Prevent duplicate entries in versionlock.list
    Then the exit code is 0
     And stderr is
     """
+    <REPOSYNC>
     Package "wget" is already locked.
     """
 
@@ -155,6 +183,7 @@ Scenario: Prevent conflicting entries in versionlock.list
    Then the exit code is 1
     And stderr is
     """
+    <REPOSYNC>
     Error: Package wget-0:1.19.5-5.fc29.* is already locked
     """
 
@@ -168,11 +197,11 @@ Scenario: I can exclude mutliple packages when one is already excluded
    Then the exit code is 0
     And stdout is
     """
-    <REPOSYNC>
     Adding versionlock exclude on "abcde = 2.9.2-1.fc29".
     """
     And stderr is
     """
+    <REPOSYNC>
     Package "wget" is already excluded.
     """
 
@@ -186,10 +215,10 @@ Scenario: I can lock mutliple packages when one is already locked
    Then the exit code is 0
     And stdout is
     """
-    <REPOSYNC>
     Adding versionlock on "abcde = 2.9.2-1.fc29".
     """
     And stderr is
     """
+    <REPOSYNC>
     Package "wget" is already locked.
     """

--- a/dnf-behave-tests/dnf/plugins-core/versionlock-lock.feature
+++ b/dnf-behave-tests/dnf/plugins-core/versionlock-lock.feature
@@ -18,9 +18,12 @@ Background: Set up versionlock infrastructure in the installroot
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "repoquery wget"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     wget-0:1.19.5-5.fc29.src
     wget-0:1.19.5-5.fc29.x86_64
     wget-0:1.19.6-5.fc29.src
@@ -30,9 +33,12 @@ Background: Set up versionlock infrastructure in the installroot
 
 Scenario: I can list all versions of locked package
    When I execute dnf with args "list --showduplicates wget"
-   Then stdout matches line by line
+   Then stderr is
     """
     <REPOSYNC>
+    """
+   And stdout matches line by line
+    """
     Available packages
     wget.src +1.19.5-5.fc29 +dnf-ci-fedora
     wget.x86_64 +1.19.5-5.fc29 +dnf-ci-fedora
@@ -110,10 +116,11 @@ Scenario: Locking does not require that the package exists in a repository
    When I execute dnf with args "install wget"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Argument 'wget' matches only packages excluded by versionlock.
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Argument 'wget' matches only packages excluded by versionlock.
+        """
 
 
 @bz1726712
@@ -156,9 +163,12 @@ Scenario: Versionlock can lock the package version to an interval
     """
    When I execute dnf with args "repoquery flac"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     flac-0:1.3.2-8.fc29.src
     flac-0:1.3.2-8.fc29.x86_64
     flac-0:1.3.3-1.fc29.src
@@ -193,9 +203,12 @@ Scenario: Check-update command does not report updates filtered out by the versi
     """
    When I execute dnf with args "check-upgrade"
    Then the exit code is 100
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     flac.x86_64 1.4.0-1.fc29 dnf-ci-fedora-updates-testing
     """
   # flac package versionlocked on specific minor version
@@ -215,9 +228,12 @@ Scenario: Check-update command does not report updates filtered out by the versi
     """
    When I execute dnf with args "check-upgrade"
    Then the exit code is 100
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     flac.x86_64 1.3.3-3.fc29 dnf-ci-fedora-updates
     """
   # flac package versionlocked on specific version
@@ -233,10 +249,11 @@ Scenario: Check-update command does not report updates filtered out by the versi
     """
    When I execute dnf with args "check-upgrade"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
     """
+    And stdout is empty
 
 
 # PackageB-Obsoleter obsoletes PackageB < 3.0
@@ -330,9 +347,12 @@ Scenario: The packages with minorbump part of release are correctly locked
     """
         # check that minorbump is available with version higher then locked
     And I successfully execute dnf with args "repoquery minorbump"
-   Then stdout is
+   Then stderr is
     """
     <REPOSYNC>
+    """
+   And stdout is
+    """
     minorbump-0:1.0-1.fc29.1.src
     minorbump-0:1.0-1.fc29.1.x86_64
     minorbump-0:1.0-1.fc29.src

--- a/dnf-behave-tests/dnf/protect-running-kernel.feature
+++ b/dnf-behave-tests/dnf/protect-running-kernel.feature
@@ -46,6 +46,7 @@ Scenario: Running kernel is protected against obsoleting
    Then the exit code is 1
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Problem: The operation would result in removing of running kernel: dnf-ci-kernel-0:1.0-1.x86_64
         You can try to add to command line:
@@ -69,6 +70,7 @@ Scenario: Running kernel is protected against removal as conflict
    Then the exit code is 1
     And stderr is
         """
+        <REPOSYNC>
         Failed to resolve the transaction:
         Problem: problem with installed package
           - installed package dnf-ci-kernel-1.0-1.x86_64 conflicts with dnf-ci-kernel = 1.0-1 provided by dnf-ci-conflict-1.0-1.x86_64 from protect-running-kernel

--- a/dnf-behave-tests/dnf/provides.feature
+++ b/dnf-behave-tests/dnf/provides.feature
@@ -42,9 +42,10 @@ Scenario: dnf provides nonexistentprovide
    Error: No matches found. If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
    """
    And dnf5 stderr is
-   """
-   No matches found. If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
-   """
+       """
+       <REPOSYNC>
+       No matches found. If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
+       """
 
 Scenario: test order of provides "dnf provides webclient A B C"
    When I execute dnf with args "provides webclient A B C"
@@ -53,12 +54,13 @@ Scenario: test order of provides "dnf provides webclient A B C"
     And stdout does not contain "(glibc)|(setup)"
     And dnf5 exit code is 1
     And dnf5 stderr is
-    """
-    No matches found for A.
-    No matches found for B.
-    No matches found for C.
-    If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
-    """
+        """
+        <REPOSYNC>
+        No matches found for A.
+        No matches found for B.
+        No matches found for C.
+        If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
+        """
 
 Scenario: test order of provides "dnf provides A webclient B C"
    When I execute dnf with args "provides A webclient B C"
@@ -67,12 +69,13 @@ Scenario: test order of provides "dnf provides A webclient B C"
     And stdout does not contain "(glibc)|(setup)"
     And dnf5 exit code is 1
     And dnf5 stderr is
-    """
-    No matches found for A.
-    No matches found for B.
-    No matches found for C.
-    If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
-    """
+        """
+        <REPOSYNC>
+        No matches found for A.
+        No matches found for B.
+        No matches found for C.
+        If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
+        """
 
 Scenario: test order of provides "dnf provides A B C webclient"
    When I execute dnf with args "provides A B C webclient"
@@ -81,12 +84,13 @@ Scenario: test order of provides "dnf provides A B C webclient"
     And stdout does not contain "(glibc)|(setup)"
     And dnf5 exit code is 1
     And dnf5 stderr is
-    """
-    No matches found for A.
-    No matches found for B.
-    No matches found for C.
-    If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
-    """
+        """
+        <REPOSYNC>
+        No matches found for A.
+        No matches found for B.
+        No matches found for C.
+        If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
+        """
 
 Scenario: try to match a package by binary if other provides do not match
   Given I use repository "dnf-ci-provides"

--- a/dnf-behave-tests/dnf/reinstall.feature
+++ b/dnf-behave-tests/dnf/reinstall.feature
@@ -57,24 +57,25 @@ Scenario: Reinstall list of packages, one of them is not available
    When I execute dnf with args "reinstall CQRlib nosuchpkg"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: nosuchpkg
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: nosuchpkg
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
     And Transaction is empty
 
 
 Scenario: Reinstall list of packages with --skip-unavailable, one of them is not available
    When I execute dnf with args "reinstall --skip-unavailable CQRlib nosuchpkg"
    Then the exit code is 0
-    And stderr is
-    """
-    No match for argument: nosuchpkg
+    And stderr contains lines
+        """
+        No match for argument: nosuchpkg
 
-    Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
-    """
+        Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
+        """
     And Transaction is following
         | Action        | Package                                   |
         | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |
@@ -84,22 +85,23 @@ Scenario: Reinstall list of packages, one of them is not installed
    When I execute dnf with args "reinstall abcde CQRlib"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Packages for argument 'abcde' available, but not installed.
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Packages for argument 'abcde' available, but not installed.
+        """
     And Transaction is empty
 
 
 Scenario: Reinstall list of packages with --skip-unavailable, one of them is not installed
    When I execute dnf with args "reinstall --skip-unavailable abcde CQRlib"
    Then the exit code is 0
-    And stderr is
-    """
-    Packages for argument 'abcde' available, but not installed.
+    And stderr contains lines
+        """
+        Packages for argument 'abcde' available, but not installed.
 
-    Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
-    """
+        Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
+        """
     And Transaction is following
         | Action        | Package                                   |
         | reinstall     | CQRlib-0:1.1.2-16.fc29.x86_64             |

--- a/dnf-behave-tests/dnf/repodata-compression.feature
+++ b/dnf-behave-tests/dnf/repodata-compression.feature
@@ -9,9 +9,12 @@ Given I copy repository "simple-base" for modification
   And I generate repodata for repository "simple-base" with extra arguments "--general-compress-type zstd"
  When I execute dnf with args "repoquery vagare"
  Then the exit code is 0
- And stdout is
- """
- <REPOSYNC>
- vagare-0:1.0-1.fc29.src
- vagare-0:1.0-1.fc29.x86_64
- """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      vagare-0:1.0-1.fc29.src
+      vagare-0:1.0-1.fc29.x86_64
+      """

--- a/dnf-behave-tests/dnf/repofrompath.feature
+++ b/dnf-behave-tests/dnf/repofrompath.feature
@@ -14,16 +14,19 @@ Scenario: The packages from --repofrompath repository are available
  Given I copy repository "simple-base" for modification
   When I execute dnf with args "repoquery --repofrompath=NEW_REPO,{context.dnf.tempdir}/repos/simple-base/"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-   """
-   <REPOSYNC>
-   dedalo-signed-0:1.0-1.fc29.src
-   dedalo-signed-0:1.0-1.fc29.x86_64
-   labirinto-0:1.0-1.fc29.src
-   labirinto-0:1.0-1.fc29.x86_64
-   vagare-0:1.0-1.fc29.src
-   vagare-0:1.0-1.fc29.x86_64
-   """
+       """
+       dedalo-signed-0:1.0-1.fc29.src
+       dedalo-signed-0:1.0-1.fc29.x86_64
+       labirinto-0:1.0-1.fc29.src
+       labirinto-0:1.0-1.fc29.x86_64
+       vagare-0:1.0-1.fc29.src
+       vagare-0:1.0-1.fc29.x86_64
+       """
 
 Scenario: I can use --repofrompath multiple times
   When I execute dnf with args "repo list --repofrompath=NEW_REPO,THE_PATH --repofrompath=ANOTHER_ID,ANOTHER_PATH"
@@ -49,16 +52,19 @@ Scenario: Variables in the path are substituted
    And I execute "mv {context.dnf.tempdir}/repos/simple-base {context.dnf.tempdir}/repos/simple-base-RLS"
   When I execute dnf with args "repoquery --releasever=RLS --repofrompath=NEW_REPO,{context.dnf.tempdir}/repos/simple-base-\$releasever/"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-   """
-   <REPOSYNC>
-   dedalo-signed-0:1.0-1.fc29.src
-   dedalo-signed-0:1.0-1.fc29.x86_64
-   labirinto-0:1.0-1.fc29.src
-   labirinto-0:1.0-1.fc29.x86_64
-   vagare-0:1.0-1.fc29.src
-   vagare-0:1.0-1.fc29.x86_64
-   """
+       """
+       dedalo-signed-0:1.0-1.fc29.src
+       dedalo-signed-0:1.0-1.fc29.x86_64
+       labirinto-0:1.0-1.fc29.src
+       labirinto-0:1.0-1.fc29.x86_64
+       vagare-0:1.0-1.fc29.src
+       vagare-0:1.0-1.fc29.x86_64
+       """
 
 Scenario: Variables in the repo id are substituted
   When I execute dnf with args "repo list --releasever=RLS --repofrompath=NEW_REPO_\${{releasever}},THE_PATH"

--- a/dnf-behave-tests/dnf/repoinfo.feature
+++ b/dnf-behave-tests/dnf/repoinfo.feature
@@ -16,178 +16,188 @@ Background: Using repositories dnf-ci-fedora and dnf-ci-thirdparty-updates
 Scenario: Repo info without arguments
    When I execute dnf with args "repo info"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-"""
-<REPOSYNC>
-Repo ID              : dnf-ci-fedora
-Name                 : dnf-ci-fedora test repository
-Status               : enabled
-Priority             : 99
-Cost                 : 1000
-Type                 : available
-Metadata expire      : .*
-Skip if unavailable  : false
-Config file          : .*/etc/yum.repos.d/dnf-ci-fedora.repo
-URLs                 :
-  Base URL           : .*/fixtures/repos/dnf-ci-fedora
-PGP                  :
-  Verify repodata    : false
-  Verify packages    : false
-Repodata info        :
-  Available packages : 289
-  Total packages     : 289
-  Size               : 2\.[0-9] MiB
-  Revision           : 1550000000
-  Updated            : .*
-
-Repo ID              : dnf-ci-thirdparty-updates
-Name                 : dnf-ci-thirdparty-updates test repository
-Status               : enabled
-Priority             : 99
-Cost                 : 1000
-Type                 : available
-Metadata expire      : .*
-Skip if unavailable  : false
-Config file          : .*/etc/yum.repos.d/dnf-ci-thirdparty-updates.repo
-URLs                 :
-  Base URL           : .*/fixtures/repos/dnf-ci-thirdparty-updates
-PGP                  :
-  Verify repodata    : false
-  Verify packages    : false
-Repodata info        :
-  Available packages : 6
-  Total packages     : 6
-  Size               : [0-9][0-9](\.[0-9])? KiB
-  Revision           : 1550000000
-  Updated            : .*
-"""
+        """
+        Repo ID              : dnf-ci-fedora
+        Name                 : dnf-ci-fedora test repository
+        Status               : enabled
+        Priority             : 99
+        Cost                 : 1000
+        Type                 : available
+        Metadata expire      : .*
+        Skip if unavailable  : false
+        Config file          : .*/etc/yum.repos.d/dnf-ci-fedora.repo
+        URLs                 :
+          Base URL           : .*/fixtures/repos/dnf-ci-fedora
+        PGP                  :
+          Verify repodata    : false
+          Verify packages    : false
+        Repodata info        :
+          Available packages : 289
+          Total packages     : 289
+          Size               : 2\.[0-9] MiB
+          Revision           : 1550000000
+          Updated            : .*
+        
+        Repo ID              : dnf-ci-thirdparty-updates
+        Name                 : dnf-ci-thirdparty-updates test repository
+        Status               : enabled
+        Priority             : 99
+        Cost                 : 1000
+        Type                 : available
+        Metadata expire      : .*
+        Skip if unavailable  : false
+        Config file          : .*/etc/yum.repos.d/dnf-ci-thirdparty-updates.repo
+        URLs                 :
+          Base URL           : .*/fixtures/repos/dnf-ci-thirdparty-updates
+        PGP                  :
+          Verify repodata    : false
+          Verify packages    : false
+        Repodata info        :
+          Available packages : 6
+          Total packages     : 6
+          Size               : [0-9][0-9](\.[0-9])? KiB
+          Revision           : 1550000000
+          Updated            : .*
+        """
 
 @bz1793950
 Scenario: Repo info without arguments and option --all
    When I execute dnf with args "repo info --all"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-"""
-<REPOSYNC>
-Repo ID              : dnf-ci-fedora
-Name                 : dnf-ci-fedora test repository
-Status               : enabled
-Priority             : 99
-Cost                 : 1000
-Type                 : available
-Metadata expire      : .*
-Skip if unavailable  : false
-Config file          : .*/etc/yum.repos.d/dnf-ci-fedora.repo
-URLs                 : 
-  Base URL           : .*/fixtures/repos/dnf-ci-fedora
-PGP                  : 
-  Verify repodata    : false
-  Verify packages    : false
-Repodata info        : 
-  Available packages : 289
-  Total packages     : 289
-  Size               : 2\.[0-9] MiB
-  Revision           : 1550000000
-  Updated            : .*
- 
-Repo ID             : dnf-ci-fedora-updates
-Name                : dnf-ci-fedora-updates test repository
-Status              : disabled
-Priority            : 99
-Cost                : 1000
-Type                : available
-Metadata expire     : .*
-Skip if unavailable : false
-Config file         : .*/etc/yum.repos.d/dnf-ci-fedora-updates.repo
-URLs                : 
-  Base URL          : .*/fixtures/repos/dnf-ci-fedora-updates
-PGP                 : 
-  Verify repodata   : false
-  Verify packages   : false
- 
-Repo ID             : dnf-ci-thirdparty
-Name                : dnf-ci-thirdparty test repository
-Status              : disabled
-Priority            : 99
-Cost                : 1000
-Type                : available
-Metadata expire     : .*
-Skip if unavailable : false
-Config file         : .*/etc/yum.repos.d/dnf-ci-thirdparty.repo
-URLs                : 
-  Base URL          : .*/fixtures/repos/dnf-ci-thirdparty
-PGP                 : 
-  Verify repodata   : false
-  Verify packages   : false
-
-Repo ID              : dnf-ci-thirdparty-updates
-Name                 : dnf-ci-thirdparty-updates test repository
-Status               : enabled
-Priority             : 99
-Cost                 : 1000
-Type                 : available
-Metadata expire      : .*
-Skip if unavailable  : false
-Config file          : .*/etc/yum.repos.d/dnf-ci-thirdparty-updates.repo
-URLs                 : 
-  Base URL           : .*/fixtures/repos/dnf-ci-thirdparty-updates
-PGP                  : 
-  Verify repodata    : false
-  Verify packages    : false
-Repodata info        : 
-  Available packages : 6
-  Total packages     : 6
-  Size               : [0-9][0-9](\.[0-9])? KiB
-  Revision           : 1550000000
-  Updated            : .*
-"""
+        """
+        Repo ID              : dnf-ci-fedora
+        Name                 : dnf-ci-fedora test repository
+        Status               : enabled
+        Priority             : 99
+        Cost                 : 1000
+        Type                 : available
+        Metadata expire      : .*
+        Skip if unavailable  : false
+        Config file          : .*/etc/yum.repos.d/dnf-ci-fedora.repo
+        URLs                 : 
+          Base URL           : .*/fixtures/repos/dnf-ci-fedora
+        PGP                  : 
+          Verify repodata    : false
+          Verify packages    : false
+        Repodata info        : 
+          Available packages : 289
+          Total packages     : 289
+          Size               : 2\.[0-9] MiB
+          Revision           : 1550000000
+          Updated            : .*
+         
+        Repo ID             : dnf-ci-fedora-updates
+        Name                : dnf-ci-fedora-updates test repository
+        Status              : disabled
+        Priority            : 99
+        Cost                : 1000
+        Type                : available
+        Metadata expire     : .*
+        Skip if unavailable : false
+        Config file         : .*/etc/yum.repos.d/dnf-ci-fedora-updates.repo
+        URLs                : 
+          Base URL          : .*/fixtures/repos/dnf-ci-fedora-updates
+        PGP                 : 
+          Verify repodata   : false
+          Verify packages   : false
+         
+        Repo ID             : dnf-ci-thirdparty
+        Name                : dnf-ci-thirdparty test repository
+        Status              : disabled
+        Priority            : 99
+        Cost                : 1000
+        Type                : available
+        Metadata expire     : .*
+        Skip if unavailable : false
+        Config file         : .*/etc/yum.repos.d/dnf-ci-thirdparty.repo
+        URLs                : 
+          Base URL          : .*/fixtures/repos/dnf-ci-thirdparty
+        PGP                 : 
+          Verify repodata   : false
+          Verify packages   : false
+        
+        Repo ID              : dnf-ci-thirdparty-updates
+        Name                 : dnf-ci-thirdparty-updates test repository
+        Status               : enabled
+        Priority             : 99
+        Cost                 : 1000
+        Type                 : available
+        Metadata expire      : .*
+        Skip if unavailable  : false
+        Config file          : .*/etc/yum.repos.d/dnf-ci-thirdparty-updates.repo
+        URLs                 : 
+          Base URL           : .*/fixtures/repos/dnf-ci-thirdparty-updates
+        PGP                  : 
+          Verify repodata    : false
+          Verify packages    : false
+        Repodata info        : 
+          Available packages : 6
+          Total packages     : 6
+          Size               : [0-9][0-9](\.[0-9])? KiB
+          Revision           : 1550000000
+          Updated            : .*
+        """
 
 @bz1793950
 Scenario: Repoinfo without arguments but with excludes
    When I execute dnf with args "repo info --exclude=*"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-"""
-<REPOSYNC>
-Repo ID              : dnf-ci-fedora
-Name                 : dnf-ci-fedora test repository
-Status               : enabled
-Priority             : 99
-Cost                 : 1000
-Type                 : available
-Metadata expire      : .*
-Skip if unavailable  : false
-Config file          : .*/etc/yum.repos.d/dnf-ci-fedora.repo
-URLs                 :
-  Base URL           : .*/fixtures/repos/dnf-ci-fedora
-PGP                  :
-  Verify repodata    : false
-  Verify packages    : false
-Repodata info        :
-  Available packages : 0
-  Total packages     : 289
-  Size               : 2\.[0-9] MiB
-  Revision           : 1550000000
-  Updated            : .*
-
-Repo ID              : dnf-ci-thirdparty-updates
-Name                 : dnf-ci-thirdparty-updates test repository
-Status               : enabled
-Priority             : 99
-Cost                 : 1000
-Type                 : available
-Metadata expire      : .*
-Skip if unavailable  : false
-Config file          : .*/etc/yum.repos.d/dnf-ci-thirdparty-updates.repo
-URLs                 :
-  Base URL           : .*/fixtures/repos/dnf-ci-thirdparty-updates
-PGP                  :
-  Verify repodata    : false
-  Verify packages    : false
-Repodata info        :
-  Available packages : 0
-  Total packages     : 6
-  Size               : [0-9][0-9](\.[0-9])? KiB
-  Revision           : 1550000000
-  Updated            : .*
-"""
+        """
+        <REPOSYNC>
+        Repo ID              : dnf-ci-fedora
+        Name                 : dnf-ci-fedora test repository
+        Status               : enabled
+        Priority             : 99
+        Cost                 : 1000
+        Type                 : available
+        Metadata expire      : .*
+        Skip if unavailable  : false
+        Config file          : .*/etc/yum.repos.d/dnf-ci-fedora.repo
+        URLs                 :
+          Base URL           : .*/fixtures/repos/dnf-ci-fedora
+        PGP                  :
+          Verify repodata    : false
+          Verify packages    : false
+        Repodata info        :
+          Available packages : 0
+          Total packages     : 289
+          Size               : 2\.[0-9] MiB
+          Revision           : 1550000000
+          Updated            : .*
+        
+        Repo ID              : dnf-ci-thirdparty-updates
+        Name                 : dnf-ci-thirdparty-updates test repository
+        Status               : enabled
+        Priority             : 99
+        Cost                 : 1000
+        Type                 : available
+        Metadata expire      : .*
+        Skip if unavailable  : false
+        Config file          : .*/etc/yum.repos.d/dnf-ci-thirdparty-updates.repo
+        URLs                 :
+          Base URL           : .*/fixtures/repos/dnf-ci-thirdparty-updates
+        PGP                  :
+          Verify repodata    : false
+          Verify packages    : false
+        Repodata info        :
+          Available packages : 0
+          Total packages     : 6
+          Size               : [0-9][0-9](\.[0-9])? KiB
+          Revision           : 1550000000
+          Updated            : .*
+        """

--- a/dnf-behave-tests/dnf/repoquery/deps.feature
+++ b/dnf-behave-tests/dnf/repoquery/deps.feature
@@ -11,9 +11,12 @@ Background:
 Scenario: repoquery --requires NAME
  When I execute dnf with args "repoquery --requires middle1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       /a/bottom4-file
       bottom1-prov1
       bottom1-prov2 = 1.0
@@ -25,9 +28,12 @@ Scenario: repoquery --requires NAME
 Scenario: repoquery --requires NAME-VERSION
  When I execute dnf with args "repoquery --requires middle1-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-prov1
       bottom1-prov2 = 1.0
       bottom2 = 1:1.0-1
@@ -37,9 +43,12 @@ Scenario: repoquery --requires NAME-VERSION
 Scenario: repoquery --providers-of=requires NAME
  When I execute dnf with args "repoquery --setopt=optional_metadata_types=filelists --providers-of=requires middle1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
@@ -49,9 +58,12 @@ Scenario: repoquery --providers-of=requires NAME
 Scenario: repoquery --providers-of=requires NAMEGLOB
  When I execute dnf with args "repoquery --setopt=optional_metadata_types=filelists --providers-of=requires middle[1]"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
@@ -61,9 +73,12 @@ Scenario: repoquery --providers-of=requires NAMEGLOB
 Scenario: repoquery --providers-of=requires --recursive NAME
  When I execute dnf with args "repoquery --setopt=optional_metadata_types=filelists --providers-of=requires --recursive top1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
@@ -75,9 +90,12 @@ Scenario: repoquery --providers-of=requires --recursive NAME
 Scenario: repoquery --providers-of=requires --recursive NAME-VERSION
  When I execute dnf with args "repoquery --setopt=optional_metadata_types=filelists --providers-of=requires --recursive top1-2.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
       bottom4-1:1.0-1.x86_64
@@ -107,9 +125,12 @@ Given I successfully execute dnf with args "install middle3"
 Scenario: repoquery --requires --resolve --recursive --tree NAME-VERSION
  When I execute dnf with args "repoquery --requires --resolve --recursive --tree top1-2.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       top1-1:2.0-1.src
       top1-1:2.0-1.x86_64
        \_ middle1-1:2.0-1.x86_64 [3: /a/bottom4-file, bottom2 = 1:1.0-1, bottom1-prov2 >= 2.0]
@@ -123,9 +144,12 @@ Scenario: repoquery --requires --resolve --recursive --tree NAME-VERSION
 Scenario: repoquery --requires NAME-VERSION NAME
  When I execute dnf with args "repoquery --requires middle1-1.0 middle2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-prov1
       bottom1-prov2 = 1.0
       bottom1-prov3 <= 1.2
@@ -138,9 +162,12 @@ Scenario: repoquery --requires NAME-VERSION NAME
 Scenario: repoquery --requires NAMEGLOB-VERSION NAME
  When I execute dnf with args "repoquery --requires middle[1]-1.0 middle2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-prov1
       bottom1-prov2 = 1.0
       bottom1-prov3 <= 1.2
@@ -153,9 +180,12 @@ Scenario: repoquery --requires NAMEGLOB-VERSION NAME
 Scenario: repoquery --requires with requires(pre/post/preun/postun)
  When I execute dnf with args "repoquery --requires middle3-1.0-1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-prov1
       bottom3-prov1
       bottom4-prov1
@@ -166,9 +196,12 @@ Scenario: repoquery --requires with requires(pre/post/preun/postun)
 Scenario: repoquery --requires with requires(pre/post/preun/postun)
  When I execute dnf with args "repoquery --qf '%{{requires}}' middle3-1.0-1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom5-prov1
       bottom4-prov1
       bottom3-prov1
@@ -180,9 +213,12 @@ Scenario: repoquery --requires with requires(pre/post/preun/postun)
 Scenario: repoquery --provides NAME
  When I execute dnf with args "repoquery --provides bottom1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a-common-provide
       bottom1 = 1:1.0-1
       bottom1 = 1:2.0-1
@@ -197,9 +233,12 @@ Scenario: repoquery --provides NAME
 Scenario: repoquery --provides NAME-VERSION
  When I execute dnf with args "repoquery --provides bottom1-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a-common-provide
       bottom1 = 1:1.0-1
       bottom1(x86-64) = 1:1.0-1
@@ -210,9 +249,12 @@ Scenario: repoquery --provides NAME-VERSION
 Scenario: repoquery --provides NAMEGLOB-VERSIONGLOB
  When I execute dnf with args "repoquery --provides bottom[2]-*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a-common-provide
       bottom2 = 1:1.0-1
       bottom2 = 1:2.0-1
@@ -226,9 +268,12 @@ Scenario: repoquery --provides NAMEGLOB-VERSIONGLOB
 Scenario: repoquery --conflicts NAME
  When I execute dnf with args "repoquery --conflicts bottom2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1
       bottom3 < 2.0
       bottom3 = 1:1.0-1
@@ -237,9 +282,12 @@ Scenario: repoquery --conflicts NAME
 Scenario: repoquery --conflicts NAME-VERSION
  When I execute dnf with args "repoquery --conflicts bottom2-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1
       bottom3 = 1:1.0-1
       """
@@ -247,9 +295,12 @@ Scenario: repoquery --conflicts NAME-VERSION
 Scenario: repoquery --conflicts NAMEGLOB-VERSIONGLOB
  When I execute dnf with args "repoquery --conflicts 'bottom*-?.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1
       bottom3 < 2.0
       bottom3 = 1:1.0-1
@@ -260,9 +311,12 @@ Scenario: repoquery --conflicts NAMEGLOB-VERSIONGLOB
 Scenario: repoquery --obsoletes NAME
  When I execute dnf with args "repoquery --obsoletes bottom3"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1 < 7
       bottom2
       bottom2 = 1:2.0-1
@@ -271,9 +325,12 @@ Scenario: repoquery --obsoletes NAME
 Scenario: repoquery --obsoletes NAME-VERSION
  When I execute dnf with args "repoquery --obsoletes bottom3-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1 < 7
       bottom2
       """
@@ -281,9 +338,12 @@ Scenario: repoquery --obsoletes NAME-VERSION
 Scenario: repoquery --obsoletes NAMEGLOB-VERSION
  When I execute dnf with args "repoquery --obsoletes bottom[3]-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1 < 7
       bottom2
       """
@@ -293,9 +353,12 @@ Scenario: repoquery --obsoletes NAMEGLOB-VERSION
 Scenario: repoquery --whatrequires NAME
  When I execute dnf with args "repoquery --whatrequires bottom1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       middle2-1:2.0-1.x86_64
@@ -306,9 +369,12 @@ Scenario: repoquery --whatrequires NAME
 Scenario: repoquery --whatrequires NAME-VERSION
  When I execute dnf with args "repoquery --whatrequires bottom1-2.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:2.0-1.x86_64
       middle2-1:2.0-1.x86_64
       """
@@ -317,9 +383,12 @@ Scenario: repoquery --whatrequires NAME-VERSION
 Scenario: repoquery --whatrequires NEVRA
  When I execute dnf with args "repoquery --whatrequires bottom2-1:1.0-1.x86_64"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       """
@@ -328,9 +397,12 @@ Scenario: repoquery --whatrequires NEVRA
 Scenario: repoquery --whatrequires NAME (file provide)
         When I execute dnf with args "repoquery --whatrequires bottom4 --setopt=optional_metadata_types=filelists"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:2.0-1.x86_64
       middle3-1:1.0-1.x86_64
       """
@@ -338,9 +410,12 @@ Scenario: repoquery --whatrequires NAME (file provide)
 Scenario: repoquery --whatrequires PROVIDE_NAME
  When I execute dnf with args "repoquery --whatrequires bottom1-prov2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       """
@@ -348,18 +423,24 @@ Scenario: repoquery --whatrequires PROVIDE_NAME
 Scenario: repoquery --whatrequires PROVIDE_NAME = VERSION
  When I execute dnf with args "repoquery --whatrequires 'bottom1-prov2 = 2.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:2.0-1.x86_64
       """
 
 Scenario: repoquery --whatrequires --recursive PROVIDE_NAME
  When I execute dnf with args "repoquery --recursive --whatrequires bottom1-prov2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       top1-1:1.0-1.x86_64
@@ -369,9 +450,12 @@ Scenario: repoquery --whatrequires --recursive PROVIDE_NAME
 Scenario: repoquery --exactdeps --whatrequires PROVIDE_NAME
  When I execute dnf with args "repoquery --exactdeps --whatrequires bottom1-prov3"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle2-1:1.0-1.x86_64
       middle2-1:2.0-1.x86_64
       """
@@ -379,9 +463,12 @@ Scenario: repoquery --exactdeps --whatrequires PROVIDE_NAME
 Scenario: repoquery --exactdeps --whatrequires PROVIDE_NAMEGLOB
  When I execute dnf with args "repoquery --exactdeps --whatrequires bottom1-prov[23]"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       middle2-1:1.0-1.x86_64
@@ -391,18 +478,24 @@ Scenario: repoquery --exactdeps --whatrequires PROVIDE_NAMEGLOB
 Scenario: repoquery --exactdeps --whatrequires PROVIDE_NAME >= VERSION (matches)
  When I execute dnf with args "repoquery --exactdeps --whatrequires 'bottom1-prov3 >= 11'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle2-1:1.0-1.x86_64
       """
 
 Scenario: repoquery --exactdeps --whatrequires PROVIDE_NAME < VERSION (doesn't match)
  When I execute dnf with args "repoquery --exactdeps --whatrequires 'bottom1-prov3 < 1'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle2-1:2.0-1.x86_64
       """
 
@@ -410,9 +503,12 @@ Scenario: repoquery --exactdeps --whatrequires PROVIDE_NAME < VERSION (doesn't m
 Scenario: repoquery --whatrequires NAME --whatrequires NAME
   When I execute dnf with args "-q repoquery --whatrequires 'bottom1-prov3 > 30' --whatrequires bottom2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle1-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       middle2-1:1.0-1.x86_64
@@ -421,9 +517,12 @@ Scenario: repoquery --whatrequires NAME --whatrequires NAME
 Scenario: repoquery --whatrequires NAME (buildrequires, srpm)
  When I execute dnf with args "repoquery --whatrequires bottom5-prov1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle3-1:1.0-1.x86_64
       middle4-1:1.0-1.src
       """
@@ -432,9 +531,12 @@ Scenario: repoquery --whatrequires NAME (buildrequires, srpm)
 Scenario: repoquery --whatrequires NEVRA (buildrequires, srpm)
  When I execute dnf with args "repoquery --whatrequires bottom5"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       middle3-1:1.0-1.x86_64
       middle4-1:1.0-1.src
       middle5-1:1.0-1.x86_64
@@ -445,18 +547,24 @@ Scenario: repoquery --whatrequires NEVRA (buildrequires, srpm)
 Scenario: repoquery --whatprovides NAME
  When I execute dnf with args "repoquery --whatprovides bottom1-prov1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:1.0-1.x86_64
       """
 
 Scenario: repoquery --whatprovides NAME (versioned provide in multiple packages)
  When I execute dnf with args "repoquery --whatprovides bottom1-prov2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:1.0-1.x86_64
       bottom1-1:2.0-1.x86_64
       """
@@ -464,9 +572,12 @@ Scenario: repoquery --whatprovides NAME (versioned provide in multiple packages)
 Scenario: repoquery --whatprovides NAME (a provide present in different packages)
  When I execute dnf with args "repoquery --whatprovides a-common-provide"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:1.0-1.x86_64
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
@@ -475,18 +586,24 @@ Scenario: repoquery --whatprovides NAME (a provide present in different packages
 Scenario: repoquery --whatprovides NAME = VERSION
  When I execute dnf with args "repoquery --whatprovides 'bottom1-prov2 = 2.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:2.0-1.x86_64
       """
 
 Scenario: repoquery --whatprovides NAME = VERSION (non-versioned provide)
  When I execute dnf with args "repoquery --whatprovides 'bottom2-prov1 = 1.3'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom2-1:1.0-1.x86_64
       bottom2-1:2.0-1.x86_64
       """
@@ -494,26 +611,33 @@ Scenario: repoquery --whatprovides NAME = VERSION (non-versioned provide)
 Scenario: repoquery --whatprovides NAME <= VERSION (matches)
  When I execute dnf with args "repoquery --whatprovides 'bottom1-prov3 <= 1.2'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:2.0-1.x86_64
       """
 
 Scenario: repoquery --whatprovides NAME > VERSION (doesn't match)
  When I execute dnf with args "repoquery --whatprovides 'bottom1-prov3 > 1.3'"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 Scenario: repoquery --whatprovides NAMEGLOB <= VERSION
  When I execute dnf with args "repoquery --whatprovides 'bottom[1-3]-prov? >= 1.2'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:1.0-1.x86_64
       bottom1-1:2.0-1.x86_64
       bottom2-1:1.0-1.x86_64
@@ -525,9 +649,12 @@ Scenario: repoquery --whatprovides NAMEGLOB <= VERSION
 Scenario: repoquery --whatprovides NAME = VERSION --whatprovides NAME
  When I execute dnf with args "repoquery --whatprovides 'bottom1-prov2 = 2.0' --whatprovides bottom3-prov1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:2.0-1.x86_64
       bottom3-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
@@ -537,9 +664,12 @@ Scenario: repoquery --whatprovides NAME = VERSION --whatprovides NAME
 Scenario: repoquery --whatprovides NAME = version, NAME
  When I execute dnf with args "repoquery --whatprovides 'bottom1-prov2 = 2.0, bottom3-prov1'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-1:2.0-1.x86_64
       bottom3-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
@@ -550,9 +680,12 @@ Scenario: repoquery --whatprovides NAME = version, NAME
 Scenario: repoquery --whatconflicts NAME
  When I execute dnf with args "repoquery --whatconflicts bottom1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom2-1:1.0-1.x86_64
       bottom2-1:2.0-1.x86_64
       """
@@ -560,9 +693,12 @@ Scenario: repoquery --whatconflicts NAME
 Scenario: repoquery --whatconflicts NAME (versioned conflict)
  When I execute dnf with args "repoquery --whatconflicts bottom3"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom2-1:1.0-1.x86_64
       bottom2-1:2.0-1.x86_64
       """
@@ -570,27 +706,36 @@ Scenario: repoquery --whatconflicts NAME (versioned conflict)
 Scenario: repoquery --whatconflicts NAME = VERSION
  When I execute dnf with args "repoquery --whatconflicts 'bottom3 = 1:1.0-1'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom2-1:1.0-1.x86_64
       """
 
 Scenario: repoquery --whatconflicts NAME < VERSION (one match)
  When I execute dnf with args "repoquery --whatconflicts 'bottom3 < 0.5'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom2-1:2.0-1.x86_64
       """
 
 Scenario: repoquery --whatconflicts NAME < VERSION (two matches)
  When I execute dnf with args "repoquery --whatconflicts 'bottom3 < 1:1.5'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom2-1:1.0-1.x86_64
       bottom2-1:2.0-1.x86_64
       """
@@ -600,9 +745,12 @@ Scenario: repoquery --whatconflicts NAME < VERSION (two matches)
 Scenario: repoquery --whatconflicts NAMEGLOB < VERSIONGLOB (two matches)
  When I execute dnf with args "repoquery --whatconflicts 'bottom[3] < 1:1.5'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom2-1:1.0-1.x86_64
       bottom2-1:2.0-1.x86_64
       """
@@ -611,9 +759,12 @@ Scenario: repoquery --whatconflicts NAMEGLOB < VERSIONGLOB (two matches)
 Scenario: repoquery --whatconflicts NAME --whatconflicts NAME = VERSION
  When I execute dnf with args "repoquery --whatconflicts middle2 --whatconflicts 'bottom3 = 1:1.0-1'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom2-1:1.0-1.x86_64
       middle1-1:2.0-1.x86_64
       """
@@ -623,9 +774,12 @@ Scenario: repoquery --whatconflicts NAME --whatconflicts NAME = VERSION
 Scenario: repoquery --whatobsoletes NAME
  When I execute dnf with args "repoquery --whatobsoletes bottom2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom3-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
       """
@@ -633,9 +787,12 @@ Scenario: repoquery --whatobsoletes NAME
 Scenario: repoquery --whatobsoletes NAME = VERSION (version obsolete exists)
  When I execute dnf with args "repoquery --whatobsoletes 'bottom2 = 1:2.0-1'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom3-1:1.0-1.x86_64
       bottom3-1:2.0-1.x86_64
       """
@@ -643,35 +800,45 @@ Scenario: repoquery --whatobsoletes NAME = VERSION (version obsolete exists)
 Scenario: repoquery --whatobsoletes NAME = VERSION (version obsolete doesn't exist)
  When I execute dnf with args "repoquery --whatobsoletes 'bottom2 = 2.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom3-1:1.0-1.x86_64
       """
 
 Scenario: repoquery --whatobsoletes NAME = VERSION (matches a range)
  When I execute dnf with args "repoquery --whatobsoletes 'bottom1 = 4'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom3-1:1.0-1.x86_64
       """
 
 Scenario: repoquery --whatobsoletes NAME = VERSION (doesn't match a range)
  When I execute dnf with args "repoquery --whatobsoletes 'bottom1 = 8'"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 Scenario: repoquery --whatobsoletes NAME <= VERSION (matches)
  When I execute dnf with args "repoquery --whatobsoletes 'bottom1 <= 4'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom3-1:1.0-1.x86_64
       """
 
@@ -680,9 +847,12 @@ Scenario: repoquery --whatobsoletes NAME <= VERSION (matches)
 Scenario: repoquery --whatobsoletes NAMEGLOB <= VERSION (matches)
  When I execute dnf with args "repoquery --whatobsoletes 'bottom[1] <= 4'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom3-1:1.0-1.x86_64
       """
 
@@ -690,9 +860,12 @@ Scenario: repoquery --whatobsoletes NAMEGLOB <= VERSION (matches)
 Scenario: repoquery --whatobsoletes NAME, NAME = VERSION
  When I execute dnf with args "repoquery --whatobsoletes 'middle1, bottom2 = 2.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom3-1:1.0-1.x86_64
       middle2-1:1.0-1.x86_64
       middle2-1:2.0-1.x86_64
@@ -703,9 +876,12 @@ Scenario: repoquery --whatobsoletes NAME, NAME = VERSION
 Scenario: repoquery --requires-pre
  When I execute dnf with args "repoquery --requires-pre middle3"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-prov1
       bottom3-prov1
       """
@@ -715,9 +891,12 @@ Given I successfully execute dnf with args "install middle3"
   And I drop repository "repoquery-deps"
  When I execute dnf with args "repoquery --installed --requires-pre middle3"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom1-prov1
       bottom3-prov1
       bottom4-prov1

--- a/dnf-behave-tests/dnf/repoquery/duplicates.feature
+++ b/dnf-behave-tests/dnf/repoquery/duplicates.feature
@@ -8,9 +8,12 @@ Given I use repository "repoquery-main"
   And I execute rpm with args "-i --nodeps {context.scenario.repos_location}/repoquery-main/x86_64/bottom-a3-2.0-1.x86_64.rpm"
  When I execute dnf with args "repoquery --duplicates"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a3-1:1.0-1.x86_64
       bottom-a3-1:2.0-1.x86_64
       """
@@ -23,9 +26,12 @@ Given I use repository "repoquery-main"
   And I execute rpm with args "-i --nodeps {context.scenario.repos_location}/repoquery-main/x86_64/bottom-a3-2.0-1.x86_64.rpm"
  When I execute dnf with args "repoquery --duplicates"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a3-1:1.0-1.x86_64
       bottom-a3-1:2.0-1.x86_64
       """
@@ -41,10 +47,11 @@ Given I use repository "repoquery-main"
       | installonlypkgs              | bottom-a3  |
  When I execute dnf with args "repoquery --duplicates"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 Scenario: don't resolve globs in installonlypkgs options
 #  it is important to ensure the identical behavior with libsolv
@@ -57,9 +64,12 @@ Given I use repository "repoquery-main"
       | installonlypkgs              | bottom-a3* |
  When I execute dnf with args "repoquery --duplicates"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a3-1:1.0-1.x86_64
       bottom-a3-1:2.0-1.x86_64
       """

--- a/dnf-behave-tests/dnf/repoquery/files.feature
+++ b/dnf-behave-tests/dnf/repoquery/files.feature
@@ -6,9 +6,12 @@ Scenario: list files in an rpm including files in filelists.xml
 Given I use repository "repoquery-files"
  When I execute dnf with args "repoquery a.x86_64 --files"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       /root-file
       /usr/bin/a-binary
       """
@@ -18,9 +21,12 @@ Scenario: list files using --queryformat in an rpm including files in filelists.
 Given I use repository "repoquery-files"
  When I execute dnf with args "repoquery a.x86_64 --qf %{{files}}"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       /root-file
       /usr/bin/a-binary
       """
@@ -30,9 +36,12 @@ Scenario: filter by file in primary.xml
 Given I use repository "repoquery-files"
  When I execute dnf with args "repoquery --file /usr/bin/a-binary"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a-0:1.0-1.fc29.x86_64
       """
 
@@ -41,8 +50,11 @@ Scenario: filter by file in filelists.xml
 Given I use repository "repoquery-files"
  When I execute dnf with args "repoquery --file /root-file"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a-0:1.0-1.fc29.x86_64
       """

--- a/dnf-behave-tests/dnf/repoquery/globs.feature
+++ b/dnf-behave-tests/dnf/repoquery/globs.feature
@@ -9,9 +9,12 @@ Background:
 Scenario: repoquery '*' (lists all available packages)
  When I execute dnf with args "repoquery '*'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.0-1.src
       desktop-utils-1:1.0-1.x86_64
       desktop-utils-1:1.23.9-1.src
@@ -34,9 +37,12 @@ Scenario: repoquery '*' (lists all available packages)
 Scenario: repoquery top*
  When I execute dnf with args "repoquery top*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       top-1:1.0-1.src
       top-1:1.0-1.x86_64
       toped-1:1.0-1.src
@@ -53,9 +59,12 @@ Scenario: repoquery top*
 Scenario: repoquery top?d
  When I execute dnf with args "repoquery top?d"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       toped-1:1.0-1.src
       toped-1:1.0-1.x86_64
       """
@@ -64,9 +73,12 @@ Scenario: repoquery top?d
 Scenario: repoquery top?{d,it}
  When I execute dnf with args "repoquery top?{{d,it}}"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       toped-1:1.0-1.src
       toped-1:1.0-1.x86_64
       topgit-1:1.0-1.src
@@ -79,9 +91,12 @@ Scenario: repoquery top?{d,it}
 Scenario: repoquery top[a-f]d
  When I execute dnf with args "repoquery top[a-f]d"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       toped-1:1.0-1.src
       toped-1:1.0-1.x86_64
       """
@@ -90,9 +105,12 @@ Scenario: repoquery top[a-f]d
 Scenario: repoquery top[a-fg]*
  When I execute dnf with args "repoquery top[a-fg]*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       toped-1:1.0-1.src
       toped-1:1.0-1.x86_64
       topgit-1:1.0-1.src
@@ -105,9 +123,12 @@ Scenario: repoquery top[a-fg]*
 Scenario: repoquery top[^a-g]*
  When I execute dnf with args "repoquery top[^a-g]*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       toppler-1:1.0-1.src
       toppler-1:1.0-1.x86_64
       """
@@ -116,9 +137,12 @@ Scenario: repoquery top[^a-g]*
 Scenario: repoquery top{ed,pler}
  When I execute dnf with args "repoquery top{{ed,pler}}"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       toped-1:1.0-1.src
       toped-1:1.0-1.x86_64
       toppler-1:1.0-1.src
@@ -129,9 +153,12 @@ Scenario: repoquery top{ed,pler}
 Scenario: repoquery top[!n-z]{d,aaa,it}
  When I execute dnf with args "repoquery top[!n-z]{{d,aaa,it}}"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       toped-1:1.0-1.src
       toped-1:1.0-1.x86_64
       topgit-1:1.0-1.src
@@ -145,9 +172,12 @@ Scenario: repoquery top[!n-z]{d,aaa,it}
 Scenario: repoquery *top[-a-f]*
  When I execute dnf with args "repoquery *top[-a-f]*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.0-1.src
       desktop-utils-1:1.0-1.x86_64
       desktop-utils-1:1.23.9-1.src
@@ -163,9 +193,12 @@ Scenario: repoquery *top[-a-f]*
 Scenario: repoquery *top[-a-f]*-1.0
  When I execute dnf with args "repoquery *top[-a-f]*-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.0-1.src
       desktop-utils-1:1.0-1.x86_64
       toped-1:1.0-1.src
@@ -177,9 +210,12 @@ Scenario: repoquery *top[-a-f]*-1.0
 Scenario: repoquery *top[-a-f]*-1.[1-4]*
  When I execute dnf with args "repoquery *top[-a-f]*-1.[1-4]*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.23.9-1.src
       desktop-utils-1:1.23.9-1.x86_64
       """
@@ -189,9 +225,12 @@ Scenario: repoquery *top[-a-f]*-1.[1-4]*
 Scenario: repoquery *top[-a-f]*-1.[!1-4]*.x86_64
  When I execute dnf with args "repoquery *top[-a-f]*-1.[!1-4]*.x86_64"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.0-1.x86_64
       toped-1:1.0-1.x86_64
       """
@@ -200,9 +239,12 @@ Scenario: repoquery *top[-a-f]*-1.[!1-4]*.x86_64
 Scenario: repoquery *top*-1.{17,23,99}*
  When I execute dnf with args "repoquery *top*-1.{{17,23,99}}*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.23.9-1.src
       desktop-utils-1:1.23.9-1.x86_64
       topgit-1:1.17.6-1.src
@@ -213,9 +255,12 @@ Scenario: repoquery *top*-1.{17,23,99}*
 Scenario: repoquery desktop-utils-[1-5].23.9
  When I execute dnf with args "repoquery desktop-utils-[1-5].23.9"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.23.9-1.src
       desktop-utils-1:1.23.9-1.x86_64
       """
@@ -226,9 +271,12 @@ Scenario: repoquery with argument with epoch 0 and replaced '-' by wild card
  Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "repoquery postgresql-devel-0:9.6.5*1.fc29.x86_64"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       postgresql-devel-0:9.6.5-1.fc29.x86_64
       """
 
@@ -238,9 +286,12 @@ Scenario: repoquery with argument without epoch 0 and replaced '-' by wild card
  Given I use repository "dnf-ci-fedora"
  When I execute dnf with args "repoquery postgresql-devel-9.6.5*1.fc29.x86_64"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       postgresql-devel-0:9.6.5-1.fc29.x86_64
       """
 
@@ -249,9 +300,12 @@ Scenario: repoquery with argument with epoch 1 and replaced '-' by wild card
 #  The test is aimed for full nevra query, because NEVRA parser cannot split an argument correctly
  When I execute dnf with args "repoquery desktop-utils-1:1.23.9*1.x86_64"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.23.9-1.x86_64
       """
 
@@ -260,8 +314,11 @@ Scenario: repoquery with argument without epoch 1 and replaced '-' by wild card
 #  The test is aimed for full nevra query, because NEVRA parser cannot split an argument correctly
  When I execute dnf with args "repoquery desktop-utils-1.23.9*1.x86_64"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       desktop-utils-1:1.23.9-1.x86_64
       """

--- a/dnf-behave-tests/dnf/repoquery/main.feature
+++ b/dnf-behave-tests/dnf/repoquery/main.feature
@@ -9,9 +9,12 @@ Background:
 Scenario: repoquery (no arguments, i.e. list all packages)
  When I execute dnf with args "repoquery"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1:1.0-1.noarch
       bottom-a1-1:1.0-1.src
       bottom-a1-1:2.0-1.noarch
@@ -40,18 +43,22 @@ Scenario: repoquery (no arguments, i.e. list all packages)
 Scenario: repoquery NAME (nonexisting package)
  When I execute dnf with args "repoquery dummy"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 @dnf5
 Scenario: repoquery NAME
  When I execute dnf with args "repoquery top-a"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       top-a-1:1.0-1.src
       top-a-1:1.0-1.x86_64
       top-a-1:2.0-1.src
@@ -64,9 +71,12 @@ Scenario: repoquery NAME
 Scenario: repoquery NAME-VERSION
  When I execute dnf with args "repoquery top-a-2.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       top-a-1:2.0-1.src
       top-a-1:2.0-1.x86_64
       top-a-2:2.0-2.src
@@ -77,9 +87,12 @@ Scenario: repoquery NAME-VERSION
 Scenario: repoquery NAME-VERSION-RELEASE
  When I execute dnf with args "repoquery top-a-2.0-2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       top-a-2:2.0-2.src
       top-a-2:2.0-2.x86_64
       """
@@ -88,9 +101,12 @@ Scenario: repoquery NAME-VERSION-RELEASE
 Scenario: repoquery NAME-EPOCH:VERSION-RELEASE
  When I execute dnf with args "repoquery top-a-2:2.0-2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       top-a-2:2.0-2.src
       top-a-2:2.0-2.x86_64
       """
@@ -99,18 +115,22 @@ Scenario: repoquery NAME-EPOCH:VERSION-RELEASE
 Scenario: repoquery NAME-EPOCH:VERSION-RELEASE old epoch
  When I execute dnf with args "repoquery top-a-1:2.0-2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 @dnf5
 Scenario: repoquery NAME NAME-EPOCH:VERSION-RELEASE
  When I execute dnf with args "repoquery bottom-a1 top-a-2:2.0-2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1:1.0-1.noarch
       bottom-a1-1:1.0-1.src
       bottom-a1-1:2.0-1.noarch
@@ -123,9 +143,12 @@ Scenario: repoquery NAME NAME-EPOCH:VERSION-RELEASE
 Scenario: repoquery NAME-VERSION NAME-EPOCH:VERSION_GLOB-RELEASE
  When I execute dnf with args "repoquery bottom-a1-1.0 top-a-1:[12].0-1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1:1.0-1.noarch
       bottom-a1-1:1.0-1.src
       top-a-1:1.0-1.src
@@ -199,9 +222,12 @@ Scenario: dnf repoquery --all NAME (illogical combination, --all is a compatibil
 Scenario: dnf repoquery --available NAME
  When I execute dnf with args "repoquery --available top-a-2.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       top-a-1:2.0-1.src
       top-a-1:2.0-1.x86_64
       top-a-2:2.0-2.src
@@ -214,9 +240,12 @@ Scenario: dnf repoquery --available NAME
 Scenario: repoquery --arch ARCH
  When I execute dnf with args "repoquery --arch noarch"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1:1.0-1.noarch
       bottom-a1-1:2.0-1.noarch
       """
@@ -225,46 +254,46 @@ Scenario: repoquery --arch ARCH
 Scenario: repoquery --arch ARCH (nonexisting arch)
  When I execute dnf with args "repoquery --arch yesarch"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 # --cacheonly
 @dnf5
 Scenario: repoquery -C (without any cache)
  When I execute dnf with args "repoquery --available -C"
  Then the exit code is 1
- Then stdout is
+  And stderr is
       """
       <REPOSYNC>
-      """
- Then stderr is
-      """
       Cache-only enabled but no cache for repository "repoquery-main"
       """
+  And stdout is empty
 
 @dnf5
 Scenario: repoquery -Cq (without any cache)
  When I execute dnf with args "repoquery --available -Cq"
  Then the exit code is 1
- Then stdout is
+  And stderr is
       """
       <REPOSYNC>
-      """
- Then stderr is
-      """
       Cache-only enabled but no cache for repository "repoquery-main"
       """
+  And stdout is empty
 
 @dnf5
 Scenario: repoquery -C (with cache)
 Given I successfully execute dnf with args "makecache"
  When I execute dnf with args "repoquery -C mid*"
  Then the exit code is 0
- Then stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+ Then stdout is
+      """
       mid-a1-1:1.0-1.src
       mid-a1-1:1.0-1.x86_64
       mid-a2-1:1.0-1.src
@@ -291,10 +320,11 @@ Given I successfully execute dnf with args "makecache"
 Given I drop repository "repoquery-main"
  When I execute dnf with args "repoquery --available -C"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 
 # --deplist
@@ -414,9 +444,12 @@ Scenario: repoquery --extras
 Given I successfully execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/miscellaneous/x86_64/dummy-1.0-1.x86_64.rpm"
  When I execute dnf with args "repoquery --extras"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       dummy-1:1.0-1.x86_64
       """
 
@@ -424,10 +457,11 @@ Given I successfully execute rpm with args "-i --nodeps {context.dnf.fixturesdir
 Scenario: repoquery --extras (no such packages)
  When I execute dnf with args "repoquery --extras"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 @dnf5
 Scenario: repoquery --extras NAME (package is installed)
@@ -435,9 +469,12 @@ Given I successfully execute rpm with args "-i --nodeps {context.dnf.fixturesdir
 Given I successfully execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/miscellaneous/x86_64/weird-1.0-1.x86_64.rpm"
  When I execute dnf with args "repoquery --extras dummy"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       dummy-1:1.0-1.x86_64
       """
 
@@ -445,10 +482,11 @@ Given I successfully execute rpm with args "-i --nodeps {context.dnf.fixturesdir
 Scenario: repoquery --extras NAME (package is not installed)
  When I execute dnf with args "repoquery --extras dummy"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
    # --extras: installed pkgs, different NEVRA in available repository
 @dnf5
@@ -457,17 +495,21 @@ Given I drop repository "repoquery-main"
  When I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/repoquery-main-multilib/x86_64/mid-a1-1.0-1.x86_64.rpm"
  Then the exit code is 0
  When I execute dnf with args "repoquery --installed"
- Then stdout is
- """
- <REPOSYNC>
- mid-a1-1:1.0-1.x86_64
- """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      mid-a1-1:1.0-1.x86_64
+      """
 Given I use repository "repoquery-main"
  When I execute dnf with args "repoquery --extras"
- Then stdout is
-  """
-  <REPOSYNC>
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
   # --extras: installed pkgs, no NA in available repository
 @dnf5
@@ -475,25 +517,32 @@ Scenario: dnf repoquery --extras (no NA in available repository)
  When I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/repoquery-main-multilib/i686/mid-a1-1.0-1.i686.rpm"
  Then the exit code is 0
  When I execute dnf with args "repoquery --installed"
- Then stdout is
- """
- <REPOSYNC>
- mid-a1-1:1.0-1.i686
- """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      mid-a1-1:1.0-1.i686
+      """
  When I execute dnf with args "repoquery --extras"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And stdout is
- """
- <REPOSYNC>
- mid-a1-1:1.0-1.i686
- """
+      """
+      mid-a1-1:1.0-1.i686
+      """
 Given I use repository "repoquery-main-multilib"
  When I execute dnf with args "repoquery --extras"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 # --installed: list only installed packages
 @dnf5
@@ -535,9 +584,12 @@ Scenario: repoquery --installed NAME (no such packages)
 Scenario: repoquery --location NAME
  When I execute dnf with args "repoquery --location top-a-2.0"
  Then the exit code is 0
-  And stdout matches line by line
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
       .+/fixtures/repos/repoquery-main/src/top-a-2.0-1.src.rpm$
       .+/fixtures/repos/repoquery-main/src/top-a-2.0-2.src.rpm$
       .+/fixtures/repos/repoquery-main/x86_64/top-a-2.0-1.x86_64.rpm$
@@ -549,9 +601,12 @@ Scenario: repoquery --location NAME (in an HTTP repo)
 Given I use repository "repoquery-main" as https
  When I execute dnf with args "repoquery --location top-a-2.0"
  Then the exit code is 0
-  And stdout matches line by line
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout matches line by line
+      """
       https://localhost:[0-9]+/src/top-a-2.0-1.src.rpm$
       https://localhost:[0-9]+/src/top-a-2.0-2.src.rpm$
       https://localhost:[0-9]+/x86_64/top-a-2.0-1.x86_64.rpm$
@@ -562,7 +617,7 @@ Given I use repository "repoquery-main" as https
 Scenario: repoquery --location NAME (no such package)
  When I execute dnf with args "repoquery --location dummy"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
@@ -573,18 +628,17 @@ Scenario: repoquery --location NAME (no such package)
 Scenario: repoquery --location for local package with file protocol is empty (no traceback)
  When I execute dnf with args "repoquery --location file://{context.dnf.fixturesdir}/repos/repoquery-main/noarch/bottom-a1-1.0-1.noarch.rpm"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
-
 
 @dnf5
 @bz1873146
 Scenario: repoquery --location for local package without file protocol is empty (no traceback)
  When I execute dnf with args "repoquery --location /{context.dnf.fixturesdir}/repos/repoquery-main/noarch/bottom-a1-1.0-1.noarch.rpm"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
@@ -596,7 +650,7 @@ Scenario: repoquery --location NAME for --installed is empty (no traceback)
 Given I successfully execute dnf with args "install bottom-a1"
  When I execute dnf with args "repoquery --installed bottom-a1 --location"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
@@ -607,9 +661,12 @@ Given I successfully execute dnf with args "install bottom-a1"
 Scenario: repoquery --srpm
  When I execute dnf with args "repoquery --srpm"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1:1.0-1.src
       bottom-a1-1:2.0-1.src
       bottom-a2-1:1.0-1.src
@@ -627,9 +684,12 @@ Scenario: repoquery --srpm
 Scenario: repoquery --srpm NAME
  When I execute dnf with args "repoquery --srpm bottom-a1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1:1.0-1.src
       bottom-a1-1:2.0-1.src
       """
@@ -669,9 +729,12 @@ Scenario: repoquery --upgrades
 Given I successfully execute dnf with args "install bottom-a1-1.0"
  When I execute dnf with args "repoquery --upgrades"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1:2.0-1.noarch
       """
 
@@ -680,19 +743,23 @@ Scenario: repoquery --upgrades (no such packages)
 Given I successfully execute dnf with args "install bottom-a2-1.0"
  When I execute dnf with args "repoquery --upgrades"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 @dnf5
 Scenario: repoquery --upgrades NAME
 Given I successfully execute dnf with args "install bottom-a1-1.0 bottom-a3-1.0"
  When I execute dnf with args "repoquery --upgrades bottom-a1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1:2.0-1.noarch
       """
 
@@ -701,10 +768,11 @@ Scenario: repoquery --upgrades NAME (no such packages)
 Given I successfully execute dnf with args "install bottom-a1-1.0 bottom-a2-1.0"
  When I execute dnf with args "repoquery --upgrades bottom-a2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 
 # --userinstalled
@@ -724,9 +792,12 @@ Given I successfully execute dnf with args "install top-a"
 Scenario: repoquery --queryformat NVR
  When I execute dnf with args "repoquery --queryformat "%{{name}}-%{{version}}-%{{release}}\n" bottom-a1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1.0-1
       bottom-a1-2.0-1
       """
@@ -736,9 +807,12 @@ Scenario: repoquery --queryformat NVR
 Scenario: repoquery --queryformat EVERYTHING
  When I execute dnf with args "repoquery --queryformat '%{{name}} | %{{arch}} | %{{epoch}} | %{{version}} | %{{release}} | %{{reponame}} | %{{repoid}} | %{{evr}} | %{{debug_name}} | %{{source_name}} | %{{source_debug_name}} | %{{provides}} | %{{requires}} | %{{obsoletes}} | %{{conflicts}} | %{{sourcerpm}} | %{{description}} | %{{summary}} | %{{license}} | %{{url}} | %{{reason}} | %{{depends}} | %{{files}} | %{{full_nevra}} | %{{prereq_ignoreinst}} | %{{requires_pre}} | %{{regular_requires}}\n\n' top*.x86_64"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       top-a | x86_64 | 1 | 1.0 | 1 | repoquery-main test repository | repoquery-main | 1:1.0-1 | top-a-debuginfo | top-a | top-a-debuginfo | top-a = 1:1.0-1
       top-a(x86-64) = 1:1.0-1
        | bottom-a1 = 1:1.0-1
@@ -786,9 +860,12 @@ Given I successfully execute dnf with args "install bottom-a1"
   And I successfully execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/repoquery-main/x86_64/bottom-a2-1.0-1.x86_64.rpm"
  When I execute dnf with args "repoquery --available --installed --queryformat '%{{name}}-%{{version}}-%{{release}} %{{repoid}} -%{{from_repo}}-\n' bottom-*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1.0-1 repoquery-main --
       bottom-a1-2.0-1 @System -repoquery-main-
       bottom-a1-2.0-1 repoquery-main --
@@ -803,9 +880,12 @@ Given I successfully execute dnf with args "install bottom-a1"
 Scenario: repoquery --queryformat upper-case tags
  When I execute dnf with args "repoquery --queryformat '%{{NAME}}-%{{VERSION}}-%{{release}} %{{RePoId}}\n' bottom-*"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       bottom-a1-1.0-1 repoquery-main
       bottom-a1-2.0-1 repoquery-main
       bottom-a2-1.0-1 repoquery-main
@@ -820,9 +900,12 @@ Scenario: repoquery --queryformat upper-case tags
 Scenario: dnf repoquery --querytags
  When I execute dnf with args "repoquery --querytags"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       arch
       buildtime
       conflicts

--- a/dnf-behave-tests/dnf/repoquery/modules.feature
+++ b/dnf-behave-tests/dnf/repoquery/modules.feature
@@ -8,16 +8,22 @@ Given I use repository "repoquery-modules"
 Scenario: Test --disable-modular-filtering with a default module stream
  When I execute dnf with args "repoquery nodejs"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-1:8.11.4-1.module_2030+42747d40.x86_64
       """
  When I execute dnf with args "repoquery nodejs --disable-modular-filtering"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-1:10.0.0-1.src
       nodejs-1:10.0.0-1.x86_64
       nodejs-1:5.3.1-1.module_2011+41787af0.src
@@ -30,16 +36,22 @@ Scenario: Test --disable-modular-filtering with an enabled module stream
  When I execute dnf with args "module enable nodejs:5"
  When I execute dnf with args "repoquery nodejs"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-1:5.3.1-1.module_2011+41787af0.x86_64
       """
  When I execute dnf with args "repoquery nodejs --disable-modular-filtering"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       nodejs-1:10.0.0-1.src
       nodejs-1:10.0.0-1.x86_64
       nodejs-1:5.3.1-1.module_2011+41787af0.src

--- a/dnf-behave-tests/dnf/repoquery/recent.feature
+++ b/dnf-behave-tests/dnf/repoquery/recent.feature
@@ -18,27 +18,34 @@ Background: prepare repository with recent package labirinto
 Scenario: dnf repoquery --recent vagare (when there's no such recent pkg)
    When I execute dnf with args "repoquery --recent vagare"
    Then the exit code is 0
-    And stdout is
-    """
-    <REPOSYNC>
-    """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is empty
 
 
 Scenario: dnf repoquery --recent labirinto (when recent pkg exists)
    When I execute dnf with args "repoquery --recent labirinto"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    labirinto-0:1.0-1.fc29.x86_64
-    """
+        """
+        labirinto-0:1.0-1.fc29.x86_64
+        """
 
 
 Scenario: dnf repoquery --recent --installed labirinto (when recent pkg exists)
    When I execute dnf with args "repoquery --recent --installed"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    labirinto-0:1.0-1.fc29.x86_64
-    """
+        """
+        labirinto-0:1.0-1.fc29.x86_64
+        """

--- a/dnf-behave-tests/dnf/repoquery/rich-deps.feature
+++ b/dnf-behave-tests/dnf/repoquery/rich-deps.feature
@@ -16,9 +16,12 @@ Given I use repository "repoquery-rich-deps"
 Scenario: repoquery --recommends NAME
  When I execute dnf with args "repoquery --recommends c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       (b1 and a1)
       """
 
@@ -27,9 +30,12 @@ Scenario: repoquery --recommends NAME
 Scenario: repoquery --whatrequires for "(a1-prov1 if b1)"
  When I execute dnf with args "repoquery --whatrequires a1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-0:1.0-1.x86_64
       c1-0:2.0-1.x86_64
       """
@@ -40,9 +46,12 @@ Scenario: repoquery --whatrequires for "(a1-prov1 if b1)"
 Scenario: repoquery --whatrequires NAME for "(b1-prov2 >= 1.0 with b1-prov2 < 2.0)"
  When I execute dnf with args "repoquery --whatrequires b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-0:1.0-1.x86_64
       """
 
@@ -51,9 +60,12 @@ Scenario: repoquery --whatrequires NAME for "(b1-prov2 >= 1.0 with b1-prov2 < 2.
 Scenario: repoquery --whatrequires PROVIDE_NAME = VERSION for "(b1-prov2 >= 1.0 with b1-prov2 < 2.0)"
  When I execute dnf with args "repoquery --whatrequires 'b1-prov2 = 1.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-0:1.0-1.x86_64
       """
 
@@ -62,45 +74,63 @@ Scenario: repoquery --whatrequires PROVIDE_NAME = VERSION for "(b1-prov2 >= 1.0 
 Scenario: repoquery --whatconflicts for "((b1 and x1) or c1)"
  When I execute dnf with args "repoquery --whatconflicts b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatconflicts c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatconflicts x1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
 Given I successfully execute dnf with args "install x1"
  When I execute dnf with args "repoquery --whatconflicts b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatconflicts c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatconflicts x1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
 
@@ -110,9 +140,12 @@ Given I successfully execute dnf with args "install x1"
 Scenario: repoquery --whatconflicts for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)"
  When I execute dnf with args "repoquery --whatconflicts d1-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-0:1.0-1.x86_64
       """
 
@@ -121,9 +154,12 @@ Scenario: repoquery --whatconflicts for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)"
 Scenario: repoquery --whatconflicts PROVIDE_NAME = VERSION for "(d1-prov1 >= 1.0 with d1-prov0 < 2.0)"
  When I execute dnf with args "repoquery --whatconflicts 'd1-prov1 = 1.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-0:1.0-1.x86_64
       """
 
@@ -132,32 +168,42 @@ Scenario: repoquery --whatconflicts PROVIDE_NAME = VERSION for "(d1-prov1 >= 1.0
 Scenario: repoquery --whatrecommends for "(b1 < 2.0 if x1 >= 2.0 else c1)"
  When I execute dnf with args "repoquery --whatrecommends b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       c1-0:1.0-1.x86_64
       c1-0:2.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatrecommends 'b1 > 2.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-0:1.0-1.x86_64
       c1-0:2.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatrecommends x1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
  When I execute dnf with args "repoquery --whatrecommends c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
 
@@ -166,16 +212,22 @@ Scenario: repoquery --whatrecommends for "(b1 < 2.0 if x1 >= 2.0 else c1)"
 Scenario: repoquery --whatsuggests for "((b1 with b1-prov2 > 1.7) or (c1 <= 1.0 without c1-prov1 > 0.5))"
  When I execute dnf with args "repoquery --whatsuggests b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatsuggests c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
 
@@ -185,9 +237,12 @@ Scenario: repoquery --whatsuggests for "((b1 with b1-prov2 > 1.7) or (c1 <= 1.0 
 Scenario: repoquery --whatsuggests for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" - only d1-1.0 should match
  When I execute dnf with args "repoquery --whatsuggests d1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-0:1.0-1.x86_64
       """
 
@@ -196,9 +251,12 @@ Scenario: repoquery --whatsuggests for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" -
 Scenario: repoquery --whatsuggests with provide for "(d1-prov1 >= 1.0 with d1-prov1 < 2.0)" - only b1-1.0 should match
 When I execute dnf with args "repoquery --whatsuggests 'd1-prov1 = 1.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-0:1.0-1.x86_64
       """
 
@@ -207,34 +265,44 @@ When I execute dnf with args "repoquery --whatsuggests 'd1-prov1 = 1.0'"
 Scenario: repoquery --whatsupplements for "((b1 < 2.0 with b1-prov2 > 1.7) or (c1 > 1.0 without c1-prov1 > 0.5))"
  When I execute dnf with args "repoquery --whatsupplements b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatsupplements 'c1 < 1.0'"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 
 # a1-1.0: Enhances: (b1 unless x1)
 Scenario: repoquery --whatenhances for "(b1 unless x1)"
  When I execute dnf with args "repoquery --whatenhances b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
 Given I successfully execute dnf with args "install x1"
  When I execute dnf with args "repoquery --whatenhances b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       """
 
@@ -243,31 +311,43 @@ Given I successfully execute dnf with args "install x1"
 Scenario: repoquery --whatenhances for "(a1 unless x1 else c1)"
  When I execute dnf with args "repoquery --whatenhances a1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-0:1.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatenhances c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-0:1.0-1.x86_64
       """
 Given I successfully execute dnf with args "install x1"
  When I execute dnf with args "repoquery --whatenhances c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-0:1.0-1.x86_64
       """
  When I execute dnf with args "repoquery --whatenhances a1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-0:1.0-1.x86_64
       """
 
@@ -276,9 +356,12 @@ Given I successfully execute dnf with args "install x1"
 Scenario: repoquery --whatdepends NAME
  When I execute dnf with args "repoquery --whatdepends c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-0:1.0-1.x86_64
       b1-0:1.0-1.x86_64
       """

--- a/dnf-behave-tests/dnf/repoquery/security-filters.feature
+++ b/dnf-behave-tests/dnf/repoquery/security-filters.feature
@@ -11,9 +11,12 @@ Given I use repository "repoquery-security-filters"
   <REPOSYNC>
   A-0:2-2.x86_64
   """
-  And dnf5 stdout is
+  And dnf5 stderr is
   """
   <REPOSYNC>
+  """
+  And dnf5 stdout is
+  """
   A-0:2-2.x86_64
   A-0:3-3.x86_64
   """
@@ -29,9 +32,12 @@ Given I use repository "repoquery-security-filters"
   <REPOSYNC>
   A-0:2-2.x86_64
   """
-  And dnf5 stdout is
+  And dnf5 stderr is
   """
   <REPOSYNC>
+  """
+  And dnf5 stdout is
+  """
   A-0:2-2.x86_64
   A-0:3-3.x86_64
   """
@@ -55,9 +61,12 @@ Given I use repository "repoquery-security-filters"
   <REPOSYNC>
   A-0:2-2.x86_64
   """
-  And dnf5 stdout is
+  And dnf5 stderr is
   """
   <REPOSYNC>
+  """
+  And dnf5 stdout is
+  """
   A-0:2-2.x86_64
   A-0:3-3.x86_64
   """
@@ -73,9 +82,12 @@ Given I use repository "repoquery-security-filters"
   <REPOSYNC>
   A-0:2-2.x86_64
   """
-  And dnf5 stdout is
+  And dnf5 stderr is
   """
   <REPOSYNC>
+  """
+  And dnf5 stdout is
+  """
   A-0:2-2.x86_64
   A-0:3-3.x86_64
   """
@@ -88,9 +100,12 @@ Given I use repository "repoquery-security-filters"
   And I execute dnf with args "install A-2-2"
  When I execute dnf with args "repoquery --security --available --installed A --info"
  Then the exit code is 0
- And stdout matches line by line
+ And stderr is
   """
   <REPOSYNC>
+  """
+ And stdout matches line by line
+  """
   Name            : A
   Epoch           : 0
   Version         : 2
@@ -141,9 +156,12 @@ Scenario: --security, --available with advisory for a missing pkg and newer vers
 Given I use repository "repoquery-security-filters"
  When I execute dnf with args "repoquery --security --available B"
  Then the exit code is 0
-  And stdout is
+  And stderr is
   """
   <REPOSYNC>
+  """
+  And stdout is
+  """
   B-0:2-2.x86_64
   """
 
@@ -160,9 +178,12 @@ Given I use repository "repoquery-security-filters"
   C-0:1-1.x86_64
   C-0:2-2.x86_64
   """
-  And dnf5 stdout is
+  And dnf5 stderr is
   """
   <REPOSYNC>
+  """
+  And dnf5 stdout is
+  """
   A-0:2-2.x86_64
   A-0:3-3.x86_64
   B-0:2-2.x86_64
@@ -175,9 +196,12 @@ Scenario: package C has two versions where each has advisory
 Given I use repository "repoquery-security-filters"
  When I execute dnf with args "repoquery --security C"
  Then the exit code is 0
-  And stdout is
+  And stderr is
   """
   <REPOSYNC>
+  """
+  And stdout is
+  """
   C-0:1-1.x86_64
   C-0:2-2.x86_64
   """
@@ -193,9 +217,12 @@ Scenario: repoquery shows a command line package when its present in an advisory
         | install       | advisory_B-0:1.0-1.x86_64 |
    When I execute dnf with args "repoquery --cve CVE-002 {context.scenario.repos_location}/dnf-ci-security/x86_64/advisory_B-1.0-4.x86_64.rpm"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
+    """
+    And stdout is
+    """
     advisory_B-0:1.0-4.x86_64
     """
 
@@ -210,7 +237,8 @@ Scenario: repoquery filters out a command line package when its not present in a
         | install       | advisory_B-0:1.0-1.x86_64 |
    When I execute dnf with args "repoquery --cve CVE-002 {context.scenario.repos_location}/dnf-ci-security/x86_64/advisory_A-1.0-1.x86_64.rpm"
    Then the exit code is 0
-    And stdout is
+    And stderr is
     """
     <REPOSYNC>
     """
+    And stdout is empty

--- a/dnf-behave-tests/dnf/repoquery/weak-deps.feature
+++ b/dnf-behave-tests/dnf/repoquery/weak-deps.feature
@@ -28,9 +28,12 @@ Given I use repository "repoquery-weak-deps"
 Scenario: repoquery --recommends NAME
  When I execute dnf with args "repoquery --recommends a2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1
       b1 > 1.0
       b2 = 2.0
@@ -39,18 +42,24 @@ Scenario: repoquery --recommends NAME
 Scenario: repoquery --recommends NAME-VERSION
  When I execute dnf with args "repoquery --recommends a2-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1
       """
 
 Scenario: repoquery --recommends NAMEGLOB-VERSION
  When I execute dnf with args "repoquery --recommends a?-2.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1 > 1.0
       b2 = 2.0
       """
@@ -58,19 +67,23 @@ Scenario: repoquery --recommends NAMEGLOB-VERSION
 Scenario: repoquery --recommends NAME (nonexisting package)
  When I execute dnf with args "repoquery --recommends dummy"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 
 # --supplements
 Scenario: repoquery --supplements NAME
  When I execute dnf with args "repoquery --supplements b2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1
       c1 >= 1.0
       c2 = 2.0
@@ -79,18 +92,24 @@ Scenario: repoquery --supplements NAME
 Scenario: repoquery --supplements NAME-VERSION
  When I execute dnf with args "repoquery --supplements b2-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1
       """
 
 Scenario: repoquery --supplements NAMEGLOB-VERSIONGLOB
  When I execute dnf with args "repoquery --supplements b?-?.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1
       c1 >= 1.0
       c2 = 1.0
@@ -100,19 +119,23 @@ Scenario: repoquery --supplements NAMEGLOB-VERSIONGLOB
 Scenario: repoquery --supplements NAME (nonexisting package)
  When I execute dnf with args "repoquery --supplements dummy"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 
 # --suggests
 Scenario: repoquery --suggests NAME
  When I execute dnf with args "repoquery --suggests c2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       d1
       d1 < 1.0
       d2 = 2.0
@@ -121,37 +144,47 @@ Scenario: repoquery --suggests NAME
 Scenario: repoquery --suggests NAME-VERSION
  When I execute dnf with args "repoquery --suggests c2-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       d1
       """
 
 Scenario: repoquery --suggests NAMEGLOB-VERSION
  When I execute dnf with args "repoquery --suggests c[2]-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       d1
       """
 
 Scenario: repoquery --suggests NAME (nonexisting package)
  When I execute dnf with args "repoquery --suggests dummy"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 
 # --enhances
 Scenario: repoquery --enhances NAME
  When I execute dnf with args "repoquery --enhances d2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1
       a1 <= 1.0
       a2 = 2.0
@@ -160,37 +193,47 @@ Scenario: repoquery --enhances NAME
 Scenario: repoquery --enhances NAME-VERSION
  When I execute dnf with args "repoquery --enhances d2-1.0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1
       """
 
 Scenario: repoquery --enhances NAMEGLOB-VERSIONGLOB
  When I execute dnf with args "repoquery --enhances d[2]-[1].0"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1
       """
 
 Scenario: repoquery --enhances NAME (nonexisting package)
  When I execute dnf with args "repoquery --enhances dummy"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
       """
+  And stdout is empty
 
 
 # --whatrecommends
 Scenario: repoquery --whatrecommends NAME
  When I execute dnf with args "repoquery --whatrecommends b2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-1:1.0-1.x86_64
       a2-1:2.0-1.x86_64
       """
@@ -198,9 +241,12 @@ Scenario: repoquery --whatrecommends NAME
 Scenario: repoquery --whatrecommends NAMEGLOB
  When I execute dnf with args "repoquery --whatrecommends b?"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-1:1.0-1.x86_64
       a2-1:1.0-1.x86_64
       a2-1:2.0-1.x86_64
@@ -209,9 +255,12 @@ Scenario: repoquery --whatrecommends NAMEGLOB
 Scenario: repoquery --whatrecommends NAMEGLOB > VERSION
  When I execute dnf with args "repoquery --whatrecommends 'b? < 1.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-1:1.0-1.x86_64
       a2-1:1.0-1.x86_64
       """
@@ -219,19 +268,23 @@ Scenario: repoquery --whatrecommends NAMEGLOB > VERSION
 Scenario: repoquery --whatrecommends NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatrecommends dummy"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 
 # --whatsupplements
 Scenario: repoquery --whatsupplements NAME
  When I execute dnf with args "repoquery --whatsupplements c2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-1:1.0-1.x86_64
       b2-1:2.0-1.x86_64
       """
@@ -239,9 +292,12 @@ Scenario: repoquery --whatsupplements NAME
 Scenario: repoquery --whatsupplements NAMEGLOB
  When I execute dnf with args "repoquery --whatsupplements c[2]"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-1:1.0-1.x86_64
       b2-1:2.0-1.x86_64
       """
@@ -249,28 +305,35 @@ Scenario: repoquery --whatsupplements NAMEGLOB
 Scenario: repoquery --whatsupplements NAMEGLOB >= VERSION
  When I execute dnf with args "repoquery --whatsupplements 'c[2] >= 1.5'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b2-1:2.0-1.x86_64
       """
 
 Scenario: repoquery --whatsupplements NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatsupplements dummy"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 
 # --whatsuggests
 Scenario: repoquery --whatsuggests NAME
  When I execute dnf with args "repoquery --whatsuggests d2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-1:1.0-1.x86_64
       c2-1:2.0-1.x86_64
       """
@@ -278,9 +341,12 @@ Scenario: repoquery --whatsuggests NAME
 Scenario: repoquery --whatsuggests NAMEGLOB
  When I execute dnf with args "repoquery --whatsuggests d[12]"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-1:1.0-1.x86_64
       c2-1:1.0-1.x86_64
       c2-1:2.0-1.x86_64
@@ -289,9 +355,12 @@ Scenario: repoquery --whatsuggests NAMEGLOB
 Scenario: repoquery --whatsuggests NAME >= VERSION
  When I execute dnf with args "repoquery --whatsuggests 'd1 >= 3.14'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-1:1.0-1.x86_64
       c2-1:1.0-1.x86_64
       """
@@ -299,19 +368,23 @@ Scenario: repoquery --whatsuggests NAME >= VERSION
 Scenario: repoquery --whatsuggests NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatsuggests dummy"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 
 # --whatenhances
 Scenario: repoquery --whatenhances NAME
  When I execute dnf with args "repoquery --whatenhances a2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       d1-1:1.0-1.x86_64
       d2-1:2.0-1.x86_64
       """
@@ -319,9 +392,12 @@ Scenario: repoquery --whatenhances NAME
 Scenario: repoquery --whatenhances NAMEGLOB
  When I execute dnf with args "repoquery --whatenhances a[2]"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       d1-1:1.0-1.x86_64
       d2-1:2.0-1.x86_64
       """
@@ -329,9 +405,12 @@ Scenario: repoquery --whatenhances NAMEGLOB
 Scenario: repoquery --whatenhances NAMEGLOB >= VERSION
  When I execute dnf with args "repoquery --whatenhances 'a? >= 3.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       d1-1:1.0-1.x86_64
       d2-1:1.0-1.x86_64
       """
@@ -339,19 +418,23 @@ Scenario: repoquery --whatenhances NAMEGLOB >= VERSION
 Scenario: repoquery --whatenhances NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatenhances dummy"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 
 # --whatdepends
 Scenario: repoquery --whatdepends NAME (requires + enhances)
  When I execute dnf with args "repoquery --whatdepends a1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       d1-1:1.0-1.x86_64
       d2-1:1.0-1.x86_64
       d2-1:2.0-1.x86_64
@@ -361,9 +444,12 @@ Scenario: repoquery --whatdepends NAME (requires + enhances)
 Scenario: repoquery --whatdepends NAME (requires + recommends)
  When I execute dnf with args "repoquery --whatdepends b1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-1:1.0-1.x86_64
       a2-1:1.0-1.x86_64
       a2-1:2.0-1.x86_64
@@ -373,9 +459,12 @@ Scenario: repoquery --whatdepends NAME (requires + recommends)
 Scenario: repoquery --whatdepends NAME (requires + supplements)
  When I execute dnf with args "repoquery --whatdepends c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-1:1.0-1.x86_64
       b2-1:1.0-1.x86_64
       b2-1:2.0-1.x86_64
@@ -385,9 +474,12 @@ Scenario: repoquery --whatdepends NAME (requires + supplements)
 Scenario: repoquery --whatdepends NAME (requires + suggests)
  When I execute dnf with args "repoquery --whatdepends d1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-1:1.0-1.x86_64
       c2-1:1.0-1.x86_64
       c2-1:2.0-1.x86_64
@@ -397,18 +489,24 @@ Scenario: repoquery --whatdepends NAME (requires + suggests)
 Scenario: repoquery --whatdepends NAME > VERSION
  When I execute dnf with args "repoquery --whatdepends 'd2 > 1.4'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c2-1:2.0-1.x86_64
       """
 
 Scenario: repoquery --whatdepends NAMEGLOB < VERSION
  When I execute dnf with args "repoquery --whatdepends '[abc]2 < 1.5'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-1:1.0-1.x86_64
       b1-1:1.0-1.x86_64
       d1-1:1.0-1.x86_64
@@ -417,9 +515,12 @@ Scenario: repoquery --whatdepends NAMEGLOB < VERSION
 Scenario: repoquery --whatdepends NAMEGLOB >= VERSION (ranged matching)
 When I execute dnf with args "repoquery --whatdepends '[abc]1 <= 1.0'"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       a1-1:1.0-1.x86_64
       a2-1:1.0-1.x86_64
       b1-1:1.0-1.x86_64
@@ -434,9 +535,12 @@ When I execute dnf with args "repoquery --whatdepends '[abc]1 <= 1.0'"
 Scenario: repoquery --exactdeps --whatdepends NAME
  When I execute dnf with args "repoquery --exactdeps --whatdepends c1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       b1-1:1.0-1.x86_64
       b2-1:1.0-1.x86_64
       b2-1:2.0-1.x86_64
@@ -445,9 +549,12 @@ Scenario: repoquery --exactdeps --whatdepends NAME
 Scenario: repoquery --exactdeps --whatdepends NAME (no nonexact deps)
  When I execute dnf with args "repoquery --exactdeps --whatdepends d1"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       c1-1:1.0-1.x86_64
       c2-1:1.0-1.x86_64
       c2-1:2.0-1.x86_64
@@ -457,7 +564,8 @@ Scenario: repoquery --exactdeps --whatdepends NAME (no nonexact deps)
 Scenario: repoquery --whatdepends NAME (nonexisting package)
  When I execute dnf with args "repoquery --whatdepends dummy"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty

--- a/dnf-behave-tests/dnf/repoquery/whatprovides.feature
+++ b/dnf-behave-tests/dnf/repoquery/whatprovides.feature
@@ -7,9 +7,12 @@ Scenario: List all profiders of file including real file provider and only provi
     And I use repository "dnf-ci-fedora"
    When I execute dnf with args "repoquery --whatprovides /etc/dummy.conf"
    Then the exit code is 0
-    And stdout is
+    And stderr is
       """
       <REPOSYNC>
+      """
+    And stdout is
+      """
       dnf-ci-alfa-0:1.0-1.noarch
       dnf-ci-beta-0:1.0-1.noarch
       """

--- a/dnf-behave-tests/dnf/resolve-hints.feature
+++ b/dnf-behave-tests/dnf/resolve-hints.feature
@@ -19,139 +19,150 @@ Scenario: --use-host-config is hinted if no repos are loaded from installroot
    When I execute dnf with args "install DoesNotExist"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config.
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config.
+        """
 
 Scenario: --skip-unavailable is hinted on non-existent package installation attempt
    When I execute dnf with args "install DoesNotExist"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
 
 Scenario: --skip-unavailable is not printed if the option is already present
    When I execute dnf with args "install DoesNotExist --skip-unavailable"
    Then the exit code is 0
     And transaction is empty
     And stderr is
-    """
-    No match for argument: DoesNotExist
-    """
+        """
+        <REPOSYNC>
+        No match for argument: DoesNotExist
+        """
 
 Scenario: --no-best is hinted if the best candidate cannot be installed
    When I execute dnf with args "install DoesNotExist NoBest"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    Problem: cannot install the best candidate for the job
-      - nothing provides DoesNotExist needed by NoBest-2.0-1.noarch from resolve-hints
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-      --no-best to not limit the transaction to the best candidates
-      --skip-broken to skip uninstallable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        Problem: cannot install the best candidate for the job
+          - nothing provides DoesNotExist needed by NoBest-2.0-1.noarch from resolve-hints
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+          --no-best to not limit the transaction to the best candidates
+          --skip-broken to skip uninstallable packages
+        """
 
 Scenario: --no-best is not printed if the option is already present
    When I execute dnf with args "install DoesNotExist NoBest --no-best"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    Problem: cannot install the best candidate for the job
-      - nothing provides DoesNotExist needed by NoBest-2.0-1.noarch from resolve-hints
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        Problem: cannot install the best candidate for the job
+          - nothing provides DoesNotExist needed by NoBest-2.0-1.noarch from resolve-hints
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
 
 Scenario: --allowerasing is hinted on attempt to install conflicting packages
   Given I successfully execute dnf with args "install ConflictingOne"
    When I execute dnf with args "install DoesNotExist ConflictingTwo"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    Problem: problem with installed package
-      - installed package ConflictingOne-1.0-1.noarch conflicts with ConflictingTwo provided by ConflictingTwo-1.0-1.noarch from resolve-hints
-      - package ConflictingOne-1.0-1.noarch from resolve-hints conflicts with ConflictingTwo provided by ConflictingTwo-1.0-1.noarch from resolve-hints
-      - conflicting requests
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-      --allowerasing to allow erasing of installed packages to resolve problems
-      --skip-broken to skip uninstallable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        Problem: problem with installed package
+          - installed package ConflictingOne-1.0-1.noarch conflicts with ConflictingTwo provided by ConflictingTwo-1.0-1.noarch from resolve-hints
+          - package ConflictingOne-1.0-1.noarch from resolve-hints conflicts with ConflictingTwo provided by ConflictingTwo-1.0-1.noarch from resolve-hints
+          - conflicting requests
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+          --allowerasing to allow erasing of installed packages to resolve problems
+          --skip-broken to skip uninstallable packages
+        """
 
 Scenario: --allowerasing is not printed if the option is already present
   Given I successfully execute dnf with args "install ConflictingOne"
    When I execute dnf with args "install DoesNotExist ConflictingTwo --allowerasing"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
 
 Scenario: filelists metadata is hinted on missing file dependency
    When I execute dnf with args "install DoesNotExist RequiresFileDep"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    Problem: conflicting requests
-      - nothing provides /var/ProvidesFileDep needed by RequiresFileDep-1.0-1.noarch from resolve-hints
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-      --setopt=optional_metadata_types=filelists to load additional filelists metadata
-      --skip-broken to skip uninstallable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        Problem: conflicting requests
+          - nothing provides /var/ProvidesFileDep needed by RequiresFileDep-1.0-1.noarch from resolve-hints
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+          --setopt=optional_metadata_types=filelists to load additional filelists metadata
+          --skip-broken to skip uninstallable packages
+        """
 
 Scenario: filelists metadata is not printed if the option is already present
    When I execute dnf with args "install DoesNotExist RequiresFileDep --setopt=optional_metadata_types=filelists"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
 
 Scenario: --skip-broken is hinted on non-installable package
    When I execute dnf with args "install DoesNotExist RequirementsUnmet"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    Problem: conflicting requests
-      - nothing provides DoesNotExist needed by RequirementsUnmet-1.0-1.noarch from resolve-hints
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-      --skip-broken to skip uninstallable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        Problem: conflicting requests
+          - nothing provides DoesNotExist needed by RequirementsUnmet-1.0-1.noarch from resolve-hints
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+          --skip-broken to skip uninstallable packages
+        """
 
 Scenario: --skip-broken is not printed if the option is already present
    When I execute dnf with args "install DoesNotExist RequirementsUnmet --skip-broken"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: DoesNotExist
-    Problem: conflicting requests
-      - nothing provides DoesNotExist needed by RequirementsUnmet-1.0-1.noarch from resolve-hints
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: DoesNotExist
+        Problem: conflicting requests
+          - nothing provides DoesNotExist needed by RequirementsUnmet-1.0-1.noarch from resolve-hints
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """

--- a/dnf-behave-tests/dnf/search-sort.feature
+++ b/dnf-behave-tests/dnf/search-sort.feature
@@ -10,87 +10,93 @@ Background:
 Scenario: sort alphanumerically
   When I execute dnf with args "search name"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-   """
-   <REPOSYNC>
-   Matched fields: name (exact)
-    name.src: Summary
-    name.x86_64: Summary
-   Matched fields: name, summary
-    name-summary.src: Summary of name
-    name-summary.x86_64: Summary of name
-    name-summary-description.src: Summary of name
-    name-summary-description.x86_64: Summary of name
-    name-summary-description-url.src: Summary of name
-    name-summary-description-url.x86_64: Summary of name
-    name-summary-url.src: Summary of name
-    name-summary-url.x86_64: Summary of name
-   Matched fields: name
-    name-description.src: Summary
-    name-description.x86_64: Summary
-    name-description-url.src: Summary
-    name-description-url.x86_64: Summary
-    name-url.src: Summary
-    name-url.x86_64: Summary
-   Matched fields: summary
-    summary.src: Summary of name
-    summary.x86_64: Summary of name
-    summary-description.src: Summary of name
-    summary-description.x86_64: Summary of name
-    summary-description-url.src: Summary of name
-    summary-description-url.x86_64: Summary of name
-    summary-url.src: Summary of name
-    summary-url.x86_64: Summary of name
-   """
+       """
+       Matched fields: name (exact)
+        name.src: Summary
+        name.x86_64: Summary
+       Matched fields: name, summary
+        name-summary.src: Summary of name
+        name-summary.x86_64: Summary of name
+        name-summary-description.src: Summary of name
+        name-summary-description.x86_64: Summary of name
+        name-summary-description-url.src: Summary of name
+        name-summary-description-url.x86_64: Summary of name
+        name-summary-url.src: Summary of name
+        name-summary-url.x86_64: Summary of name
+       Matched fields: name
+        name-description.src: Summary
+        name-description.x86_64: Summary
+        name-description-url.src: Summary
+        name-description-url.x86_64: Summary
+        name-url.src: Summary
+        name-url.x86_64: Summary
+       Matched fields: summary
+        summary.src: Summary of name
+        summary.x86_64: Summary of name
+        summary-description.src: Summary of name
+        summary-description.x86_64: Summary of name
+        summary-description-url.src: Summary of name
+        summary-description-url.x86_64: Summary of name
+        summary-url.src: Summary of name
+        summary-url.x86_64: Summary of name
+       """
 
 
 @bz1811802
 Scenario: sort --all alphanumerically
   When I execute dnf with args "search --all name"
   Then the exit code is 0
+   And stderr is
+       """
+       <REPOSYNC>
+       """
    And stdout is
-   """
-   <REPOSYNC>
-   Matched fields: name (exact)
-    name.src: Summary
-    name.x86_64: Summary
-   Matched fields: name, summary, description, url
-    name-summary-description-url.src: Summary of name
-    name-summary-description-url.x86_64: Summary of name
-   Matched fields: name, summary, description
-    name-summary-description.src: Summary of name
-    name-summary-description.x86_64: Summary of name
-   Matched fields: name, summary, url
-    name-summary-url.src: Summary of name
-    name-summary-url.x86_64: Summary of name
-   Matched fields: name, summary
-    name-summary.src: Summary of name
-    name-summary.x86_64: Summary of name
-   Matched fields: name, description, url
-    name-description-url.src: Summary
-    name-description-url.x86_64: Summary
-   Matched fields: name, description
-    name-description.src: Summary
-    name-description.x86_64: Summary
-   Matched fields: name, url
-    name-url.src: Summary
-    name-url.x86_64: Summary
-   Matched fields: summary, description, url
-    summary-description-url.src: Summary of name
-    summary-description-url.x86_64: Summary of name
-   Matched fields: summary, description
-    summary-description.src: Summary of name
-    summary-description.x86_64: Summary of name
-   Matched fields: summary, url
-    summary-url.src: Summary of name
-    summary-url.x86_64: Summary of name
-   Matched fields: summary
-    summary.src: Summary of name
-    summary.x86_64: Summary of name
-   Matched fields: description
-    description.src: Summary
-    description.x86_64: Summary
-   Matched fields: url
-    url.src: Summary
-    url.x86_64: Summary
-   """
+       """
+       Matched fields: name (exact)
+        name.src: Summary
+        name.x86_64: Summary
+       Matched fields: name, summary, description, url
+        name-summary-description-url.src: Summary of name
+        name-summary-description-url.x86_64: Summary of name
+       Matched fields: name, summary, description
+        name-summary-description.src: Summary of name
+        name-summary-description.x86_64: Summary of name
+       Matched fields: name, summary, url
+        name-summary-url.src: Summary of name
+        name-summary-url.x86_64: Summary of name
+       Matched fields: name, summary
+        name-summary.src: Summary of name
+        name-summary.x86_64: Summary of name
+       Matched fields: name, description, url
+        name-description-url.src: Summary
+        name-description-url.x86_64: Summary
+       Matched fields: name, description
+        name-description.src: Summary
+        name-description.x86_64: Summary
+       Matched fields: name, url
+        name-url.src: Summary
+        name-url.x86_64: Summary
+       Matched fields: summary, description, url
+        summary-description-url.src: Summary of name
+        summary-description-url.x86_64: Summary of name
+       Matched fields: summary, description
+        summary-description.src: Summary of name
+        summary-description.x86_64: Summary of name
+       Matched fields: summary, url
+        summary-url.src: Summary of name
+        summary-url.x86_64: Summary of name
+       Matched fields: summary
+        summary.src: Summary of name
+        summary.x86_64: Summary of name
+       Matched fields: description
+        description.src: Summary
+        description.x86_64: Summary
+       Matched fields: url
+        url.src: Summary
+        url.x86_64: Summary
+       """

--- a/dnf-behave-tests/dnf/search.feature
+++ b/dnf-behave-tests/dnf/search.feature
@@ -33,49 +33,58 @@ Scenario: with installed and available newest package doesn't duplicate results
         | install       | setup-0:2.12.1-1.fc29.noarch          |
    When I execute dnf with args "search setup"
    Then the exit code is 0
-   And stdout is
-   """
-   <REPOSYNC>
-   Matched fields: name (exact), summary
-    setup.noarch: A set of system configuration and setup files
-    setup.src: A set of system configuration and setup files
-   """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Matched fields: name (exact), summary
+         setup.noarch: A set of system configuration and setup files
+         setup.src: A set of system configuration and setup files
+        """
 
 
 Scenario: Only one occurence of a package is in the output when more versions are available
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "search flac"
    Then the exit code is 0
-   And stdout is
-   """
-   <REPOSYNC>
-   Matched fields: name (exact)
-    flac.src: An encoder/decoder for the Free Lossless Audio Codec
-    flac.x86_64: An encoder/decoder for the Free Lossless Audio Codec
-   Matched fields: name
-    flac-libs.x86_64: Libraries for the Free Lossless Audio Codec
-   """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Matched fields: name (exact)
+         flac.src: An encoder/decoder for the Free Lossless Audio Codec
+         flac.x86_64: An encoder/decoder for the Free Lossless Audio Codec
+        Matched fields: name
+         flac-libs.x86_64: Libraries for the Free Lossless Audio Codec
+        """
 
 
 Scenario: All versions of a package are in the output when using the --showduplicates option
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "search flac --showduplicates"
    Then the exit code is 0
-   And stdout is
-   """
-   <REPOSYNC>
-   Matched fields: name (exact)
-    flac-0:1.3.2-8.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
-    flac-0:1.3.2-8.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
-    flac-0:1.3.3-1.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
-    flac-0:1.3.3-1.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
-    flac-0:1.3.3-2.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
-    flac-0:1.3.3-2.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
-    flac-0:1.3.3-3.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
-    flac-0:1.3.3-3.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
-   Matched fields: name
-    flac-libs-0:1.3.2-8.fc29.x86_64: Libraries for the Free Lossless Audio Codec
-    flac-libs-0:1.3.3-1.fc29.x86_64: Libraries for the Free Lossless Audio Codec
-    flac-libs-0:1.3.3-2.fc29.x86_64: Libraries for the Free Lossless Audio Codec
-    flac-libs-0:1.3.3-3.fc29.x86_64: Libraries for the Free Lossless Audio Codec
-   """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Matched fields: name (exact)
+         flac-0:1.3.2-8.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.2-8.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-1.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-1.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-2.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-2.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-3.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-3.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
+        Matched fields: name
+         flac-libs-0:1.3.2-8.fc29.x86_64: Libraries for the Free Lossless Audio Codec
+         flac-libs-0:1.3.3-1.fc29.x86_64: Libraries for the Free Lossless Audio Codec
+         flac-libs-0:1.3.3-2.fc29.x86_64: Libraries for the Free Lossless Audio Codec
+         flac-libs-0:1.3.3-3.fc29.x86_64: Libraries for the Free Lossless Audio Codec
+        """

--- a/dnf-behave-tests/dnf/security-advisory.feature
+++ b/dnf-behave-tests/dnf/security-advisory.feature
@@ -23,12 +23,15 @@ Scenario: upgrade-minimal cve and advisory
 Scenario: check-upgrade --minimal cve and advisory
    When I execute dnf with args "check-upgrade --minimal --cves CVE-001 --advisories DNF-BUGFIX-001"
    Then the exit code is 100
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    advisory_A.x86_64 +1.0-2 +dnf-ci-security
-    advisory_B.x86_64 +1.0-2 +dnf-ci-security
-    """
+        """
+        advisory_A.x86_64 +1.0-2 +dnf-ci-security
+        advisory_B.x86_64 +1.0-2 +dnf-ci-security
+        """
 
 Scenario: upgrade-minimal with pkgs specified cve and advisory
    When I execute dnf with args "upgrade-minimal advisory_A advisory_B --cve CVE-001 --advisory DNF-BUGFIX-001"
@@ -41,12 +44,15 @@ Scenario: upgrade-minimal with pkgs specified cve and advisory
 Scenario: check-upgrade --minimal with pkgs specified cve and advisory
    When I execute dnf with args "check-upgrade --minimal advisory_A advisory_B --cves CVE-001 --advisories DNF-BUGFIX-001"
    Then the exit code is 100
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    advisory_A.x86_64 +1.0-2 +dnf-ci-security
-    advisory_B.x86_64 +1.0-2 +dnf-ci-security
-    """
+        """
+        advisory_A.x86_64 +1.0-2 +dnf-ci-security
+        advisory_B.x86_64 +1.0-2 +dnf-ci-security
+        """
 
 Scenario: upgrade advisories
    When I execute dnf with args "upgrade --advisories=DNF-BUGFIX-001 --advisories=DNF-SECURITY-004"
@@ -67,12 +73,15 @@ Scenario: upgrade --minimal advisories
 Scenario: check-upgrade --minimal advisories
    When I execute dnf with args "check-upgrade --minimal --advisories=DNF-BUGFIX-001 --advisories=DNF-SECURITY-004"
    Then the exit code is 100
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    advisory_A.x86_64 +1.0-2 +dnf-ci-security
-    advisory_B.x86_64 +1.0-4 +dnf-ci-security
-    """
+        """
+        advisory_A.x86_64 +1.0-2 +dnf-ci-security
+        advisory_B.x86_64 +1.0-4 +dnf-ci-security
+        """
 
 Scenario: upgrade cves
    When I execute dnf with args "upgrade --cve CVE-001 --cve CVE-002"
@@ -84,11 +93,14 @@ Scenario: upgrade cves
 Scenario: check-upgrade cves
    When I execute dnf with args "check-upgrade --cves CVE-001 --cves CVE-002"
    Then the exit code is 100
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    advisory_B.x86_64 +1.0-4 +dnf-ci-security
-    """
+        """
+        advisory_B.x86_64 +1.0-4 +dnf-ci-security
+        """
 
 Scenario: upgrade-minimal sec-severity
    When I execute dnf with args "upgrade-minimal --advisory-severities=Moderate"
@@ -100,11 +112,14 @@ Scenario: upgrade-minimal sec-severity
 Scenario: check-upgrade --minimal with sec-severity
    When I execute dnf with args "check-upgrade --minimal --advisory-severities=Moderate"
    Then the exit code is 100
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    advisory_B.x86_64 +1.0-2 +dnf-ci-security
-    """
+        """
+        advisory_B.x86_64 +1.0-2 +dnf-ci-security
+        """
 
 Scenario: upgrade-minimal with pkgs specified sec-severity
    When I execute dnf with args "upgrade-minimal advisory_B --advisory-severities=Moderate"
@@ -116,11 +131,14 @@ Scenario: upgrade-minimal with pkgs specified sec-severity
 Scenario: check-upgrade --minimal with pkgs specified sec-severity
    When I execute dnf with args "check-upgrade --minimal advisory_B --advisory-severities=Moderate"
    Then the exit code is 100
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    advisory_B.x86_64 +1.0-2 +dnf-ci-security
-    """
+        """
+        advisory_B.x86_64 +1.0-2 +dnf-ci-security
+        """
 
 Scenario: upgrade secseverity
    When I execute dnf with args "upgrade --advisory-severities Critical"
@@ -141,9 +159,12 @@ Scenario: upgrade-minimal security plus bugfix
 Scenario: check-upgrade --minimal security plus bugfix
    When I execute dnf with args "check-upgrade --minimal --security --bugfix"
    Then the exit code is 100
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout matches line by line
-    """
-    <REPOSYNC>
-    advisory_A.x86_64 +1.0-3 +dnf-ci-security
-    advisory_B.x86_64 +1.0-4 +dnf-ci-security
-    """
+        """
+        advisory_A.x86_64 +1.0-3 +dnf-ci-security
+        advisory_B.x86_64 +1.0-4 +dnf-ci-security
+        """

--- a/dnf-behave-tests/dnf/security-upgrade.feature
+++ b/dnf-behave-tests/dnf/security-upgrade.feature
@@ -33,15 +33,16 @@ Given I use repository "security-upgrade-noarch"
  When I execute dnf with args "upgrade --security"
  Then the exit code is 1
  And stderr is
- """
- Failed to resolve the transaction:
- Problem: cannot install both json-c-2-2.x86_64 from security-upgrade-noarch and json-c-2-2.noarch from security-upgrade-noarch
-   - package bind-libs-lite-2-2.x86_64 from security-upgrade-noarch requires libjson-c.so.4()(64bit), but none of the providers can be installed
-   - cannot install the best update candidate for package json-c-1-1.x86_64
-   - cannot install the best update candidate for package bind-libs-lite-1-1.x86_64
- You can try to add to command line:
-   --no-best to not limit the transaction to the best candidates
- """
+     """
+     <REPOSYNC>
+     Failed to resolve the transaction:
+     Problem: cannot install both json-c-2-2.x86_64 from security-upgrade-noarch and json-c-2-2.noarch from security-upgrade-noarch
+       - package bind-libs-lite-2-2.x86_64 from security-upgrade-noarch requires libjson-c.so.4()(64bit), but none of the providers can be installed
+       - cannot install the best update candidate for package json-c-1-1.x86_64
+       - cannot install the best update candidate for package bind-libs-lite-1-1.x86_64
+     You can try to add to command line:
+       --no-best to not limit the transaction to the best candidates
+     """
 
 
 @2097757
@@ -126,11 +127,14 @@ Given I use repository "security-upgrade"
   # Make sure change-arch-2-2.x86_64 is available since we are testing we don't upgrade to it.
   # It also has to have an available advisory. (We cannot verify that here because the updateinfo command is bugged when dealing with arch changes)
   And I successfully execute dnf with args "repoquery change-arch-2-2.x86_64"
-  Then stdout is
-  """
-  <REPOSYNC>
-  change-arch-0:2-2.x86_64
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      change-arch-0:2-2.x86_64
+      """
  When I execute dnf with args "upgrade --security"
  Then the exit code is 0
   And Transaction is empty
@@ -143,10 +147,13 @@ Given I use repository "security-upgrade"
   # Make sure change-arch-reversed-2-2.i686 is available and has an adivosry since we are testing we don't upgrade to it.
   # It also has to have an available advisory. (We cannot verify that here because the updateinfo command is bugged when dealing with arch changes)
   And I successfully execute dnf with args "repoquery change-arch-reversed-2-2.i686"
-  Then stdout is
-  """
-  <REPOSYNC>
-  change-arch-reversed-0:2-2.i686
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      change-arch-reversed-0:2-2.i686
   """
  When I execute dnf with args "upgrade --security"
  Then the exit code is 0
@@ -198,11 +205,14 @@ Given I use repository "security-upgrade-obsoletes"
   obsoleted-change-arch
   """
 Given I successfully execute dnf with args "repoquery obsoleter-change-arch-1-1.i686 --obsoletes"
-  Then stdout is
-  """
-  <REPOSYNC>
-  obsoleted-change-arch
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      obsoleted-change-arch
+      """
  When I execute dnf with args "upgrade --security"
  Then the exit code is 0
   And Transaction is empty
@@ -215,17 +225,23 @@ Given I use repository "security-upgrade-obsoletes"
   # Make sure obsoleter-change-arch-reversed-1-1.x86_64 and obsoleter-change-arch-reversed-1-1.i686 are available and obsolete obsoleted-change-arch-reversed since we are testing we don't upgrade to any of them.
   # There also should be an available advisory for obsoleter-change-arch-reversed-1-1.i686. (We cannot verify that here because the updateinfo command is bugged when dealing with obsoletes)
   And I successfully execute dnf with args "repoquery obsoleter-change-arch-reversed-1-1.x86_64 --obsoletes"
-  Then stdout is
-  """
-  <REPOSYNC>
-  obsoleted-change-arch-reversed
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      obsoleted-change-arch-reversed
+      """
 Given I successfully execute dnf with args "repoquery obsoleter-change-arch-reversed-1-1.i686 --obsoletes"
-  Then stdout is
-  """
-  <REPOSYNC>
-  obsoleted-change-arch-reversed
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      obsoleted-change-arch-reversed
+      """
  When I execute dnf with args "upgrade --security"
  Then the exit code is 0
   And Transaction is empty
@@ -237,12 +253,15 @@ Given I use repository "security-upgrade"
   # Make sure F-2-2 is available and obsoletes E since we are testing we don't upgrade to it.
   # There also should be an available advisory for it. (We cannot verify that here because the updateinfo command is bugged when dealing with obsoletes)
   And I successfully execute dnf with args "repoquery F-2-2.x86_64 --obsoletes"
-  Then stdout is
-  """
-  <REPOSYNC>
-  E
-  """
-  When I execute dnf with args "upgrade E --security --setopt=obsoletes=false"
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      E
+      """
+ When I execute dnf with args "upgrade E --security --setopt=obsoletes=false"
  Then the exit code is 0
   And Transaction is empty
 
@@ -253,12 +272,15 @@ Given I use repository "security-upgrade"
   # Make sure F-2-2 is available and obsoletes E since we are testing we don't upgrade to it.
   # There also should be an available advisory for it. (We cannot verify that here because the updateinfo command is bugged when dealing with obsoletes)
   And I successfully execute dnf with args "repoquery F-2-2.x86_64 --obsoletes"
-  Then stdout is
-  """
-  <REPOSYNC>
-  E
-  """
-  When I execute dnf with args "upgrade --security --setopt=obsoletes=false"
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      E
+      """
+ When I execute dnf with args "upgrade --security --setopt=obsoletes=false"
  Then the exit code is 0
   And Transaction is empty
 
@@ -329,13 +351,16 @@ Scenario: use both advisories even if they are duplicates but with different iss
    When I execute dnf with args "updateinfo list"
    # dnf5 shows only one date because libsolv provides only one in metadata,
    # it is the latest of issued vs updated date.
-   Then dnf5 stdout is
-   """
-   <REPOSYNC>
-   Name      Type     Severity      Package              Issued
-   custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
-   custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
-   """
+   Then dnf5 stderr is
+        """
+        <REPOSYNC>
+        """
+    And dnf5 stdout is
+        """
+        Name      Type     Severity      Package              Issued
+        custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
+        custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
+        """
    # dnf4 is deduplicating output based on advisory id, issued date, packages (and whether the packages are installed)
    # here only the updated/issued dates differ but libsolv selects only the higher one and those are all identical.
    # -> output is deduplicated
@@ -360,14 +385,17 @@ Scenario: use all (3) advisories even if they are duplicates but with different 
         | install       | E-0:1-1.x86_64 |
     And I use repository "security-upgrade-duplicates-2"
    When I execute dnf with args "updateinfo list"
-   Then dnf5 stdout is
-   """
-   <REPOSYNC>
-   Name      Type     Severity      Package              Issued
-   custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
-   custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
-   custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
-   """
+   Then dnf5 stderr is
+        """
+        <REPOSYNC>
+        """
+    And dnf5 stdout is
+        """
+        Name      Type     Severity      Package              Issued
+        custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
+        custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
+        custom_id security Moderate E-2-2.x86_64 2022-12-17 00:00:00
+        """
    # dnf4 is deduplicating output based on advisory id, issued date, packages (and whether the packages are installed)
    # here only the updated/issued dates differ but libsolv selects only the higher one and those are all identical.
    # -> output is deduplicated
@@ -392,13 +420,16 @@ Scenario: use both advisories even if they are duplicates but with just summary 
         | install       | F-0:1-1.x86_64 |
     And I use repository "security-upgrade-duplicates-2"
    When I execute dnf with args "updateinfo list"
-   Then dnf5 stdout is
-   """
-   <REPOSYNC>
-   Name        Type     Severity      Package              Issued
-   custom_id_F security Moderate F-2-2.x86_64 2019-08-19 22:00:00
-   custom_id_F security Moderate F-2-2.x86_64 2019-08-19 22:00:00
-   """
+   Then dnf5 stderr is
+        """
+        <REPOSYNC>
+        """
+    And dnf5 stdout is
+        """
+        Name        Type     Severity      Package              Issued
+        custom_id_F security Moderate F-2-2.x86_64 2019-08-19 22:00:00
+        custom_id_F security Moderate F-2-2.x86_64 2019-08-19 22:00:00
+        """
    # dnf4 is deduplicating output based on advisory id, issued date, packages (and whether the packages are installed)
    # here only the summary differs -> output is deduplicated
    Then dnf4 stdout is

--- a/dnf-behave-tests/dnf/setopt.feature
+++ b/dnf-behave-tests/dnf/setopt.feature
@@ -14,9 +14,12 @@ Background: Use repos setopt and setopt.ext
 Scenario: Without --setopt option, packages wget and flac are available
    When I execute dnf with args "repoquery"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         flac-0:1.0-1.fc29.src
         flac-0:1.0-1.fc29.x86_64
         flac-libs-0:1.0-1.fc29.x86_64
@@ -28,9 +31,12 @@ Scenario: Without --setopt option, packages wget and flac are available
 Scenario: --setopt option can be used to set config for specific repo (and repo id may contain dots)
    When I execute dnf with args "repoquery --setopt=setopt.ext.excludepkgs=*"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         wget-0:1.0-1.fc29.src
         wget-0:1.0-1.fc29.x86_64
         """
@@ -39,9 +45,12 @@ Scenario: --setopt option can be used to set config for specific repo (and repo 
 Scenario: --setopt option can be used with globs to set config for multiple repos
    When I execute dnf with args "repoquery --setopt=setopt*.excludepkgs=wget"
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         flac-0:1.0-1.fc29.src
         flac-0:1.0-1.fc29.x86_64
         flac-libs-0:1.0-1.fc29.x86_64

--- a/dnf-behave-tests/dnf/shared-root-cache.feature
+++ b/dnf-behave-tests/dnf/shared-root-cache.feature
@@ -11,32 +11,41 @@ Background:
     And I create directory "/{context.dnf.installroot}/var/cache/dnf-user"
     And I successfully execute "chmod 777 {context.dnf.installroot}/var/cache/dnf-user"
     And I successfully execute dnf with args "makecache"
-   Then stdout matches line by line
-   """
-   Updating and loading repositories:
-    dnf-ci-fedora test repository .*
-   Repositories loaded.
-   Metadata cache created.
-   """
+   Then stderr matches line by line
+        """
+        Updating and loading repositories:
+         dnf-ci-fedora test repository .*
+        Repositories loaded.
+        """
+    And stdout is
+        """
+        Metadata cache created.
+        """
 
 
 Scenario: Root cache is shared when user metadata are empty
    When I execute dnf with args "makecache --setopt=system_cachedir={context.dnf.installroot}/var/cache/dnf --setopt=cachedir={context.dnf.installroot}/var/cache/dnf-user" as an unprivileged user
-   Then stdout matches line by line
-   """
-   Updating and loading repositories:
-   Repositories loaded.
-   Metadata cache created.
-   """
+   Then stderr matches line by line
+        """
+        Updating and loading repositories:
+        Repositories loaded.
+        """
+    And stdout is
+        """
+        Metadata cache created.
+        """
 
 
 Scenario: Root cache is not shared when the user doesn't have permissions
    When I successfully execute "chmod 700 {context.dnf.installroot}/var/cache/dnf"
     And I execute dnf with args "makecache --setopt=system_cachedir={context.dnf.installroot}/var/cache/dnf --setopt=cachedir={context.dnf.installroot}/var/cache/dnf-user" as an unprivileged user
-   Then stdout matches line by line
-   """
-   Updating and loading repositories:
-    dnf-ci-fedora test repository .*
-   Repositories loaded.
-   Metadata cache created.
-   """
+   Then stderr matches line by line
+        """
+        Updating and loading repositories:
+         dnf-ci-fedora test repository .*
+        Repositories loaded.
+        """
+    And stdout is
+        """
+        Metadata cache created.
+        """

--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -265,6 +265,18 @@ def then_stdout_contains_lines(context):
             raise AssertionError("Stdout doesn't contain line: %s" % line)
 
 
+@behave.then("stdout contains lines matching")
+def then_stdout_contains_lines_matching(context):
+    out_lines = context.cmd_stdout.split('\n')
+    test_lines = context.text.split('\n')
+    for line in test_lines:
+        for outline in out_lines:
+            if re.search(line.strip(), outline.strip()):
+                break
+        else:
+            raise AssertionError("Stderr doesn't contain line matching: %s" % line)
+
+
 @behave.then("stdout does not contain lines")
 def then_stdout_does_not_contain_lines(context):
     out_lines = [l.strip() for l in context.cmd_stdout.split('\n')]
@@ -316,6 +328,17 @@ def then_stderr_contains_lines(context):
         else:
             raise AssertionError("Stderr doesn't contain line: %s" % line)
 
+
+@behave.then("stderr contains lines matching")
+def then_stderr_contains_lines_matching(context):
+    out_lines = context.cmd_stderr.split('\n')
+    test_lines = context.text.split('\n')
+    for line in test_lines:
+        for outline in out_lines:
+            if re.search(line.strip(), outline.strip()):
+                break
+        else:
+            raise AssertionError("Stderr doesn't contain line matching: %s" % line)
 
 @behave.then("{dnf_version:dnf_version} {std_stream:std_stream} contains \"{text}\"")
 def then_dnf_stream_contains(context, dnf_version, std_stream, text):
@@ -387,6 +410,30 @@ def then_dnf_stream_contains_lines(context, dnf_version, std_stream):
         then_stream_contains_lines(context)
     if dnf_version == "dnf4" and not dnf5_mode:
         then_stream_contains_lines(context)
+
+
+@behave.then("{dnf_version:dnf_version} {std_stream:std_stream} contains lines matching")
+def then_dnf_stream_contains_lines_matching(context, dnf_version, std_stream):
+    """
+    Check that stdout/stderr contains lines matching regex
+    Works only if running in the appropriate mode otherwise
+    the step is skipped
+    Produce the steps:
+        then dnf4 stdout contains lines matching
+        then dnf4 stderr contains lines matching
+        then dnf5 stdout contains lines matching
+        then dnf5 stderr contains lines matching
+    """
+    if std_stream == "stdout":
+        then_stream_contains_lines_matching = then_stdout_contains_lines_matching
+    if std_stream == "stderr":
+        then_stream_contains_lines_matching = then_stderr_contains_lines_matching
+
+    dnf5_mode = hasattr(context, "dnf5_mode") and context.dnf5_mode
+    if dnf_version == "dnf5" and dnf5_mode:
+        then_stream_contains_lines_matching(context)
+    if dnf_version == "dnf4" and not dnf5_mode:
+        then_stream_contains_lines_matching(context)
 
 
 @behave.then("{dnf_version:dnf_version} {std_stream:std_stream} does not contain lines")

--- a/dnf-behave-tests/dnf/stick-to-vendor.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor.feature
@@ -53,16 +53,15 @@ Scenario: Downgrade is unable to resolve transaction
    Then the exit code is 1
    And transaction is empty
    And stdout is
-   """
-   <REPOSYNC>
-   (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
-   """
+       """
+       (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
+       """
    And stderr is
-   """
-   allow_vendor_change is disabled. This option is currently not supported for downgrade and distro-sync commands
-   Error: 
-    Problem: problem with installed package vendor-1.1-1.x86_64
-     - cannot install both vendor-1.0-1.x86_64 and vendor-1.1-1.x86_64
-     - conflicting requests
-   """
-
+       """
+       <REPOSYNC>
+       allow_vendor_change is disabled. This option is currently not supported for downgrade and distro-sync commands
+       Error: 
+        Problem: problem with installed package vendor-1.1-1.x86_64
+         - cannot install both vendor-1.0-1.x86_64 and vendor-1.1-1.x86_64
+         - conflicting requests
+       """

--- a/dnf-behave-tests/dnf/system-upgrade.feature
+++ b/dnf-behave-tests/dnf/system-upgrade.feature
@@ -29,7 +29,7 @@ Scenario: Test system-upgrade when reboot wasn't performed
       | upgrade       | pkg-a-2.0-1.noarch    |
       | upgrade       | pkg-both-2.0-1.noarch |
       | downgrade     | pkg-b-1.0-1.noarch    |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -50,7 +50,7 @@ Scenario: Test system-upgrade basic functionality
       | upgrade       | pkg-a-2.0-1.noarch    |
       | upgrade       | pkg-both-2.0-1.noarch |
       | downgrade     | pkg-b-1.0-1.noarch    |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -75,7 +75,7 @@ Scenario: Test system-upgrade with --cachedir
       | upgrade       | pkg-a-2.0-1.noarch    |
       | upgrade       | pkg-both-2.0-1.noarch |
       | downgrade     | pkg-b-1.0-1.noarch    |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -99,7 +99,7 @@ Scenario: Test system-upgrade with --no-downgrade
       | Action        | Package               |
       | upgrade       | pkg-a-2.0-1.noarch    |
       | upgrade       | pkg-both-2.0-1.noarch |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -123,7 +123,7 @@ Scenario: Test system-upgrade transaction file not found
       | upgrade       | pkg-a-2.0-1.noarch    |
       | upgrade       | pkg-both-2.0-1.noarch |
       | downgrade     | pkg-b-1.0-1.noarch    |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """
@@ -146,7 +146,7 @@ Scenario: Test system-upgrade downloading a package from a different repo
       | upgrade       | pkg-a-2.0-1.noarch    |
       | upgrade       | pkg-both-2.0-1.noarch |
       | downgrade     | pkg-b-1.0-1.noarch    |
-  And stdout contains lines
+  And stderr contains lines
       """
       Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
       """

--- a/dnf-behave-tests/dnf/transaction-gpg-checking.feature
+++ b/dnf-behave-tests/dnf/transaction-gpg-checking.feature
@@ -24,4 +24,4 @@ Scenario: Check GPG signatures with recovery when keys are imported
     And Transaction is following
         | Action        | Package                        |
         | install       | setup-0:2.12.1-1.fc29.noarch   |
-    And stdout contains "The key was successfully imported."
+    And stderr contains "The key was successfully imported."

--- a/dnf-behave-tests/dnf/transaction-output.feature
+++ b/dnf-behave-tests/dnf/transaction-output.feature
@@ -22,9 +22,12 @@ Scenario: Packages in transaction are sorted by NEVRA
     And I use repository "dnf-ci-thirdparty"
    When I execute dnf with args "install wget glibc flac SuperRipper"
    Then the exit code is 0
-    And stdout matches line by line
+    And stderr is
       """
       <REPOSYNC>
+      """
+    And stdout matches line by line
+      """
       Dependencies resolved.
       ================================================================================
        Package                Arch      Version            Repository            Size

--- a/dnf-behave-tests/dnf/transaction-sr/replay-errors.feature
+++ b/dnf-behave-tests/dnf/transaction-sr/replay-errors.feature
@@ -26,6 +26,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Install action, no match for: does-not-exist-1.0-1.noarch.
       You can try to add to command line:
@@ -52,6 +53,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Install action, no match for: top-a-1:3.0-1.x86_64.
       You can try to add to command line:
@@ -78,6 +80,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Package "bottom-a2-1.0-1.x86_64" is already installed.
       """
@@ -108,6 +111,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Install action, no match for: does-not-exist-2.0-1.x86_64.
       Cannot perform Remove action, no match for: does-not-exist-1.0-1.x86_64.
@@ -141,6 +145,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Install action, no match for: top-a-1:3.0-1.x86_64.
       You can try to add to command line:
@@ -173,6 +178,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Remove action because 'top-a-1:2.0-1.x86_64' is installed in a different version: 'top-a-1:1.0-1.x86_64'.
       Extra package 'bottom-a1-2.0-1.noarch' (with action 'Install') which is not present in the stored transaction was pulled into the transaction.
@@ -204,6 +210,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Remove action, no match for: does-not-exist-1.0-1.x86_64.
       You can try to add to command line:
@@ -230,6 +237,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Remove action for Package 'top-c-1.0-1.x86_64' because it is not installed.
       You can try to add to command line:
@@ -262,6 +270,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Extra package 'bottom-a1-2.0-1.noarch' (with action 'Install') which is not present in the stored transaction was pulled into the transaction.
 
@@ -307,6 +316,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Problem: package top-a-1:2.0-1.x86_64 from transaction-sr requires bottom-a1 = 2.0-1, but none of the providers can be installed
         - cannot install both bottom-a1-2.0-1.noarch from transaction-sr and bottom-a1-1.0-1.noarch from transaction-sr
@@ -335,6 +345,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Problem: conflicting requests
         - nothing provides nonexistent needed by broken-dep-1.0-1.x86_64 from transaction-sr
@@ -376,6 +387,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       No match for argument: nonexistent
       Extra package 'bottom-a1-2.0-1.noarch' (with action 'Install') which is not present in the stored transaction was pulled into the transaction.
@@ -406,6 +418,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Remove action for Group 'nonexistent' because it is not installed.
       No groups to remove for argument: nonexistent
@@ -433,6 +446,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Upgrade action for Group 'nonexistent' because it is not installed.
       No match for argument: nonexistent
@@ -463,6 +477,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 0
   And stderr is
       """
+      <REPOSYNC>
       Packages for argument 'test-group' installed, but not available.
       """
 
@@ -499,6 +514,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       No match for argument: nonexistent
       Extra package 'bottom-a1-2.0-1.noarch' (with action 'Install') which is not present in the stored transaction was pulled into the transaction.
@@ -527,6 +543,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Remove action for Environment 'nonexistent' because it is not installed.
       No groups to remove for argument: nonexistent
@@ -553,6 +570,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot perform Upgrade action for Environment 'nonexistent' because it is not installed.
       No match for argument: nonexistent
@@ -605,6 +623,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Missing object key "id" in a group.
       """

--- a/dnf-behave-tests/dnf/transaction-sr/replay-validation.feature
+++ b/dnf-behave-tests/dnf/transaction-sr/replay-validation.feature
@@ -11,6 +11,7 @@ Scenario: Replay a non-existant transaction dir
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       cannot open file: (2) - No such file or directory [nonexistent/transaction.json]
       """
 
@@ -27,6 +28,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Error during transaction replay JSON parsing : object value separator ',' expected.
       """
@@ -43,6 +45,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Missing key "version".
       """
@@ -59,6 +62,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Unexpected version format: "1", supported version is "1.0".
       """
@@ -75,6 +79,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Incompatible major version: "a", supported major version is "1".
       """
@@ -91,6 +96,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Invalid minor version: "a", number expected.
       """
@@ -107,6 +113,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Incompatible major version: "5", supported major version is "1".
       """
@@ -124,6 +131,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Unexpected type of "rpms", array expected.
       """
@@ -147,6 +155,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Missing object key "action" in an rpm.
       """
@@ -170,6 +179,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Either "nevra" or "package_path" object key is required in an rpm.
       """
@@ -193,6 +203,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Missing object key "reason" in an rpm.
       """
@@ -217,6 +228,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Invalid transaction item action: Fixxit
       """
 
@@ -240,6 +252,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Cannot parse NEVRA for rpm "wakaka".
       """
@@ -264,6 +277,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Invalid transaction item reason: dumb
       """
 
@@ -280,6 +294,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Unexpected type of "groups", array expected.
       """
@@ -301,6 +316,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Missing object key "id" in a group.
       """
@@ -324,6 +340,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Missing object key "action" in a group.
       """
@@ -349,6 +366,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Invalid transaction item action: Invalid
       """
 
@@ -372,6 +390,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Invalid package type: aaa
       """
 
@@ -388,6 +407,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Unexpected type of "environments", array expected.
       """
@@ -409,6 +429,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Missing object key "id" in an environment.
       """
@@ -430,6 +451,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Failed to resolve the transaction:
       Cannot parse file: './transaction/transaction.json': Missing object key "action" in an environment.
       """
@@ -453,5 +475,6 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 1
   And stderr is
       """
+      <REPOSYNC>
       Invalid transaction item action: Invalid
       """

--- a/dnf-behave-tests/dnf/transaction-sr/replay.feature
+++ b/dnf-behave-tests/dnf/transaction-sr/replay.feature
@@ -292,10 +292,11 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  When I execute dnf with args "replay ./transaction"
  Then the exit code is 1
   And stderr is
-  """
-  Failed to resolve the transaction:
-  Argument 'top-b-1.0-1.x86_64' matches only excluded packages.
-  """
+      """
+      <REPOSYNC>
+      Failed to resolve the transaction:
+      Argument 'top-b-1.0-1.x86_64' matches only excluded packages.
+      """
 
 
 Scenario: Replay a reason change transaction on a package being installed
@@ -322,10 +323,11 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  When I execute dnf with args "replay ./transaction"
  Then the exit code is 1
   And stderr is
-  """
-  Failed to resolve the transaction:
-  Argument 'top-b-1.0-1.x86_64' matches only excluded packages.
-  """
+      """
+      <REPOSYNC>
+      Failed to resolve the transaction:
+      Argument 'top-b-1.0-1.x86_64' matches only excluded packages.
+      """
 
 
 Scenario: Replay a reason change transaction on a package being removed
@@ -1217,7 +1219,7 @@ Given I successfully execute dnf with args "install bottom-a1-1.0"
       """
  When I execute dnf with args "replay ./transaction --ignore-installed"
  Then the exit code is 0
-  And stderr is
+  And stderr contains lines
       """
       Cannot perform Install action because 'bottom-a1-2.0-1.noarch' is installed in a different version: 'bottom-a1-1.0-1.noarch'.
 
@@ -1286,6 +1288,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 0
   And stderr is
       """
+      <REPOSYNC>
       Package "bottom-a2-1.0-1.x86_64" is already installed.
       Package "bottom-a3-1.0-1.x86_64" is already installed.
       Package "mid-a1-1.0-1.x86_64" is already installed.
@@ -1330,7 +1333,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
       """
  When I execute dnf with args "replay ./transaction --ignore-installed"
  Then the exit code is 0
- And stderr is
+ And stderr contains lines
      """
      Cannot perform Remove action for Package 'bottom-a1-1.0-1.noarch' because it is not installed.
 
@@ -1374,6 +1377,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
  Then the exit code is 0
  And stderr is
      """
+     <REPOSYNC>
      Cannot perform Remove action for Package 'bottom-a1-2.0-1.noarch' because it is not installed.
      """
   And Transaction is empty
@@ -1402,7 +1406,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
       """
  When I execute dnf with args "replay ./transaction --skip-unavailable"
  Then the exit code is 0
-  And stderr is
+  And stderr contains lines
       """
       Cannot perform Install action, no match for: does-not-exist-1.0-1.noarch.
 
@@ -1451,6 +1455,7 @@ Given I successfully execute dnf with args "install bottom-a1-2.0"
  Then the exit code is 0
   And stderr is
       """
+      <REPOSYNC>
       Packages for argument 'bottom-a1-2.0-1.noarch' installed, but not available.
       """
   And Transaction is empty

--- a/dnf-behave-tests/dnf/transaction-sr/store-option.feature
+++ b/dnf-behave-tests/dnf/transaction-sr/store-option.feature
@@ -9,7 +9,6 @@ Given I set working directory to "{context.dnf.tempdir}"
 Scenario: Store an install transaction
   When I execute dnf with args "install top-a-1.0 --store ./transaction"
  Then the exit code is 0
-  And stderr is empty
   And file "/{context.dnf.tempdir}/transaction/transaction.json" contents is
       """
       {

--- a/dnf-behave-tests/dnf/transaction-sr/store.feature
+++ b/dnf-behave-tests/dnf/transaction-sr/store.feature
@@ -10,7 +10,7 @@ Given I use repository "transaction-sr"
 Scenario: Store a transaction
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -67,7 +67,7 @@ Scenario: Store an upgrade transaction
 Given I successfully execute dnf with args "upgrade top-a"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -103,7 +103,7 @@ Scenario: Store a reinstall transaction
 Given I successfully execute dnf with args "reinstall top-a"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -134,7 +134,7 @@ Given I successfully execute dnf with args "upgrade top-a"
 Given I successfully execute dnf with args "downgrade top-a"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -164,7 +164,7 @@ Scenario: Store a remove transaction
 Given I successfully execute dnf with args "remove top-a"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -212,7 +212,7 @@ Scenario: Store a reason change transaction
 Given I successfully execute dnf with args "mark dependency top-a"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -236,7 +236,7 @@ Scenario: Store a transaction with a group install
 Given I successfully execute dnf with args "install @test-group"
  When I execute dnf with args "history store 2"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -288,7 +288,7 @@ Given I successfully execute dnf with args "install @test-group"
   And I successfully execute dnf with args "remove @test-group"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -325,7 +325,7 @@ Given I successfully execute dnf with args "mark group test-group top-a-1.0"
 Given I successfully execute dnf with args "upgrade @test-group"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -364,7 +364,7 @@ Scenario: Store a transaction with an enviroment group install
 Given I successfully execute dnf with args "install @test-env"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -417,7 +417,7 @@ Given I successfully execute dnf with args "install @test-env"
   And I successfully execute dnf with args "remove @test-env"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -471,7 +471,7 @@ Given I successfully execute dnf with args "install @test-env"
   And I successfully execute dnf with args "upgrade @test-env"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -529,7 +529,7 @@ Scenario: Store a transaction installing multiple installonly package versions
 Given I successfully execute dnf with args "install installonly-1.0 installonly-2.0"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -560,7 +560,7 @@ Given I successfully execute dnf with args "install installonly-1.0 installonly-
   And I successfully execute dnf with args "remove installonly-1.0 installonly-2.0"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -597,7 +597,7 @@ Given I successfully execute dnf with args "install installonly-1.0"
   And I execute in dnf shell "run"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -628,7 +628,7 @@ Given I successfully execute dnf with args "install installonly-1.0"
   And I successfully execute dnf with args "upgrade installonly"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -653,7 +653,7 @@ Given I successfully execute dnf with args "install obsoleted-a-1.0"
   And I successfully execute dnf with args "upgrade obsoleted-a"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -684,7 +684,7 @@ Given I successfully execute dnf with args "install obsoleted-a-1.0 obsoleted-b-
   And I successfully execute dnf with args "upgrade obsoleted-a obsoleted-b"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -727,7 +727,7 @@ Given I successfully execute dnf with args "install archchange-1.0"
   And I successfully execute dnf with args "upgrade archchange"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -764,7 +764,7 @@ Given I successfully execute dnf with args "install @test-group supertop-b"
   And I execute in dnf shell "run"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -814,7 +814,7 @@ Given I successfully execute dnf with args "install @test-group"
   And I execute in dnf shell "run"
  When I execute dnf with args "history store last"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to ./transaction.
       """
@@ -850,7 +850,7 @@ Given I successfully execute dnf with args "install @test-group"
 Scenario: Store a transaction with specifying the output file
  When I execute dnf with args "history store last -o {context.dnf.tempdir}/out"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       Transaction saved to {context.dnf.tempdir}/out.
       """
@@ -901,7 +901,7 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
       """
  When I execute dnf with args "history store last -y"
  Then the exit code is 0
-  And stdout is
+  And stderr is
       """
       File "./transaction/transaction.json" already exists, it will be overwritten.
       Transaction saved to ./transaction.
@@ -915,7 +915,8 @@ Given I create file "/{context.dnf.tempdir}/transaction/transaction.json" with
       """
  When I execute dnf with args "history store last --assumeno"
  Then the exit code is 1
-  And stdout is
+  And stderr is
       """
       File "./transaction/transaction.json" already exists, it will be overwritten.
+      Operation aborted by the user.
       """

--- a/dnf-behave-tests/dnf/unprivileged.feature
+++ b/dnf-behave-tests/dnf/unprivileged.feature
@@ -12,8 +12,11 @@ Scenario: unprivileged user can create a cache even without system state
     And I delete directory "/usr/lib/sysimage/libdnf5"
    When I execute dnf with args "makecache" as an unprivileged user
    Then the exit code is 0
-    And stdout is
+    And stderr is
         """
         <REPOSYNC>
+        """
+    And stdout is
+        """
         Metadata cache created.
         """

--- a/dnf-behave-tests/dnf/updateinfo.feature
+++ b/dnf-behave-tests/dnf/updateinfo.feature
@@ -22,13 +22,16 @@ Scenario: Listing available updates
   Given I use repository "dnf-ci-fedora-updates"
    Then I execute dnf with args "advisory list"
     And the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type        Severity                   Package              Issued
-    FEDORA-2018-318f184000 bugfix      none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    FEDORA-2999:002-02     enhancement Moderate  flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        Name                   Type        Severity                   Package              Issued
+        FEDORA-2018-318f184000 bugfix      none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        FEDORA-2999:002-02     enhancement Moderate  flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 Scenario: advisory summary (when there's nothing to report)
@@ -36,20 +39,23 @@ Scenario: advisory summary (when there's nothing to report)
    Then the exit code is 0
    When I execute dnf with args "advisory summary"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Available advisory information summary:
-    Security    : 0
-      Critical  : 0
-      Important : 0
-      Moderate  : 0
-      Low       : 0
-      Other     : 0
-    Bugfix      : 0
-    Enhancement : 0
-    Other       : 0
-    """
+        """
+        Available advisory information summary:
+        Security    : 0
+          Critical  : 0
+          Important : 0
+          Moderate  : 0
+          Low       : 0
+          Other     : 0
+        Bugfix      : 0
+        Enhancement : 0
+        Other       : 0
+        """
 
 
 Scenario: advisory summary --available (when there is an available update)
@@ -58,20 +64,23 @@ Scenario: advisory summary --available (when there is an available update)
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory summary --available"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Available advisory information summary:
-    Security    : 0
-      Critical  : 0
-      Important : 0
-      Moderate  : 0
-      Low       : 0
-      Other     : 0
-    Bugfix      : 1
-    Enhancement : 1
-    Other       : 0
-    """
+        """
+        Available advisory information summary:
+        Security    : 0
+          Critical  : 0
+          Important : 0
+          Moderate  : 0
+          Low       : 0
+          Other     : 0
+        Bugfix      : 1
+        Enhancement : 1
+        Other       : 0
+        """
 
 
 # @dnf5daemon
@@ -81,55 +90,58 @@ Scenario: advisory info
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory info --available"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name        : FEDORA-2018-318f184000
-    Title       : glibc bug fix
-    Severity    : none
-    Type        : bugfix
-    Status      : final
-    Vendor      : secresponseteam@foo.bar
-    Issued      : 2019-01-17 00:00:00
-    Description : Fix some stuff
-    Message     : 
-    Rights      : 
-    Reference   : 
-      Title     : 222
-      Id        : 222
-      Type      : bugzilla
-      Url       : https://foobar/foobarupdate_1
-    Reference   : 
-      Title     : CVE-2999
-      Id        : 2999
-      Type      : cve
-      Url       : https://foobar/foobarupdate_1
-    Reference   : 
-      Title     : CVE-2999
-      Id        : CVE-2999
-      Type      : cve
-      Url       : https://foobar/foobarupdate_1
-    Collection  : 
-      Packages  : glibc-2.28-26.fc29.x86_64
+        """
+        Name        : FEDORA-2018-318f184000
+        Title       : glibc bug fix
+        Severity    : none
+        Type        : bugfix
+        Status      : final
+        Vendor      : secresponseteam@foo.bar
+        Issued      : 2019-01-17 00:00:00
+        Description : Fix some stuff
+        Message     : 
+        Rights      : 
+        Reference   : 
+          Title     : 222
+          Id        : 222
+          Type      : bugzilla
+          Url       : https://foobar/foobarupdate_1
+        Reference   : 
+          Title     : CVE-2999
+          Id        : 2999
+          Type      : cve
+          Url       : https://foobar/foobarupdate_1
+        Reference   : 
+          Title     : CVE-2999
+          Id        : CVE-2999
+          Type      : cve
+          Url       : https://foobar/foobarupdate_1
+        Collection  : 
+          Packages  : glibc-2.28-26.fc29.x86_64
 
-    Name        : FEDORA-2999:002-02
-    Title       : flac enhacements
-    Severity    : Moderate
-    Type        : enhancement
-    Status      : final
-    Vendor      : secresponseteam@foo.bar
-    Issued      : 2019-01-17 00:00:00
-    Description : Enhance some stuff
-    Message     : 
-    Rights      : 
-    Reference   : 
-      Title     : update_1
-      Id        : 1
-      Type      : self
-      Url       : https://foobar/foobarupdate_1
-    Collection  : 
-      Packages  : flac-1.3.3-8.fc29.x86_64
-    """
+        Name        : FEDORA-2999:002-02
+        Title       : flac enhacements
+        Severity    : Moderate
+        Type        : enhancement
+        Status      : final
+        Vendor      : secresponseteam@foo.bar
+        Issued      : 2019-01-17 00:00:00
+        Description : Enhance some stuff
+        Message     : 
+        Rights      : 
+        Reference   : 
+          Title     : update_1
+          Id        : 1
+          Type      : self
+          Url       : https://foobar/foobarupdate_1
+        Collection  : 
+          Packages  : flac-1.3.3-8.fc29.x86_64
+        """
 
 
 # @dnf5daemon
@@ -139,10 +151,11 @@ Scenario: advisory info security (when there's nothing to report)
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory info --security"
    Then the exit code is 0
-   And stdout is
-   """
-   <REPOSYNC>
-   """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is empty
 
 
 # @dnf5daemon
@@ -152,13 +165,16 @@ Scenario: advisory list
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory list"
    Then the exit code is 0
+    And dnf5 stderr is
+        """
+        <REPOSYNC>
+        """
     And dnf5 stdout is
-    """
-    <REPOSYNC>
-    Name                   Type        Severity                   Package              Issued
-    FEDORA-2018-318f184000 bugfix      none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    FEDORA-2999:002-02     enhancement Moderate  flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        Name                   Type        Severity                   Package              Issued
+        FEDORA-2018-318f184000 bugfix      none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        FEDORA-2999:002-02     enhancement Moderate  flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 # @dnf5daemon
@@ -169,12 +185,15 @@ Scenario: advisory list all security
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory list --all --security"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type     Severity                     Package              Issued
-    FEDORA-2018-318f184113 security Moderate CQRlib-1.1.2-16.fc29.x86_64 2019-01-20 00:00:00
-    """
+        """
+        Name                   Type     Severity                     Package              Issued
+        FEDORA-2018-318f184113 security Moderate CQRlib-1.1.2-16.fc29.x86_64 2019-01-20 00:00:00
+        """
 
 
 # @dnf5daemon
@@ -187,13 +206,16 @@ Scenario: advisory list updates
   Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "advisory list --updates"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type        Severity                  Package              Issued
-    FEDORA-2018-318f184112 enhancement Moderate flac-1.4.0-1.fc29.x86_64 2019-01-19 00:00:00
-    FEDORA-2999:002-02     enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        Name                   Type        Severity                  Package              Issued
+        FEDORA-2018-318f184112 enhancement Moderate flac-1.4.0-1.fc29.x86_64 2019-01-19 00:00:00
+        FEDORA-2999:002-02     enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 # @dnf5daemon
@@ -206,12 +228,15 @@ Scenario: advisory list installed
   Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "advisory list --installed"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type   Severity                   Package              Issued
-    FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        Name                   Type   Severity                   Package              Issued
+        FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 # @dnf5daemon
@@ -222,13 +247,17 @@ Scenario: advisory list available enhancement
   Given I use repository "dnf-ci-fedora-updates-testing"
    When I execute dnf with args "advisory list --available --enhancement"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type        Severity                  Package              Issued
-    FEDORA-2018-318f184112 enhancement Moderate flac-1.4.0-1.fc29.x86_64 2019-01-19 00:00:00
-    FEDORA-2999:002-02     enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        <REPOSYNC>
+        Name                   Type        Severity                  Package              Issued
+        FEDORA-2018-318f184112 enhancement Moderate flac-1.4.0-1.fc29.x86_64 2019-01-19 00:00:00
+        FEDORA-2999:002-02     enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 # @dnf5daemon
@@ -238,12 +267,16 @@ Scenario: advisory list all bugfix
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory list --all --bugfix"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type   Severity                   Package              Issued
-    FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        <REPOSYNC>
+        Name                   Type   Severity                   Package              Issued
+        FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 # @dnf5daemon
@@ -253,12 +286,15 @@ Scenario Outline: advisory list updates plus <option>
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory list --updates <option> <value>"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type   Severity                   Package              Issued
-    FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        Name                   Type   Severity                   Package              Issued
+        FEDORA-2018-318f184000 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 Examples:
         | option | value                  |
@@ -275,37 +311,40 @@ Scenario: advisory info <advisory>
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory info FEDORA-2018-318f184000"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name        : FEDORA-2018-318f184000
-    Title       : glibc bug fix
-    Severity    : none
-    Type        : bugfix
-    Status      : final
-    Vendor      : secresponseteam@foo.bar
-    Issued      : 2019-01-17 00:00:00
-    Description : Fix some stuff
-    Message     : 
-    Rights      : 
-    Reference   : 
-      Title     : 222
-      Id        : 222
-      Type      : bugzilla
-      Url       : https://foobar/foobarupdate_1
-    Reference   : 
-      Title     : CVE-2999
-      Id        : 2999
-      Type      : cve
-      Url       : https://foobar/foobarupdate_1
-    Reference   : 
-      Title     : CVE-2999
-      Id        : CVE-2999
-      Type      : cve
-      Url       : https://foobar/foobarupdate_1
-    Collection  : 
-      Packages  : glibc-2.28-26.fc29.x86_64
-    """
+        """
+        Name        : FEDORA-2018-318f184000
+        Title       : glibc bug fix
+        Severity    : none
+        Type        : bugfix
+        Status      : final
+        Vendor      : secresponseteam@foo.bar
+        Issued      : 2019-01-17 00:00:00
+        Description : Fix some stuff
+        Message     : 
+        Rights      : 
+        Reference   : 
+          Title     : 222
+          Id        : 222
+          Type      : bugzilla
+          Url       : https://foobar/foobarupdate_1
+        Reference   : 
+          Title     : CVE-2999
+          Id        : 2999
+          Type      : cve
+          Url       : https://foobar/foobarupdate_1
+        Reference   : 
+          Title     : CVE-2999
+          Id        : CVE-2999
+          Type      : cve
+          Url       : https://foobar/foobarupdate_1
+        Collection  : 
+          Packages  : glibc-2.28-26.fc29.x86_64
+        """
 
 
 # @dnf5daemon
@@ -315,27 +354,30 @@ Scenario: advisory info <advisory-with-respin-suffix>
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory info FEDORA-2999:002-02"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name        : FEDORA-2999:002-02
-    Title       : flac enhacements
-    Severity    : Moderate
-    Type        : enhancement
-    Status      : final
-    Vendor      : secresponseteam@foo.bar
-    Issued      : 2019-01-17 00:00:00
-    Description : Enhance some stuff
-    Message     : 
-    Rights      : 
-    Reference   : 
-      Title     : update_1
-      Id        : 1
-      Type      : self
-      Url       : https://foobar/foobarupdate_1
-    Collection  : 
-      Packages  : flac-1.3.3-8.fc29.x86_64
-    """
+        """
+        Name        : FEDORA-2999:002-02
+        Title       : flac enhacements
+        Severity    : Moderate
+        Type        : enhancement
+        Status      : final
+        Vendor      : secresponseteam@foo.bar
+        Issued      : 2019-01-17 00:00:00
+        Description : Enhance some stuff
+        Message     : 
+        Rights      : 
+        Reference   : 
+          Title     : update_1
+          Id        : 1
+          Type      : self
+          Url       : https://foobar/foobarupdate_1
+        Collection  : 
+          Packages  : flac-1.3.3-8.fc29.x86_64
+        """
 
 
 @bz1750528
@@ -344,13 +386,16 @@ Scenario: advisory lists advisories referencing CVE
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory list --with-cve"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    CVE      Type   Severity                   Package              Issued
-    2999     bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    CVE-2999 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        CVE      Type   Severity                   Package              Issued
+        2999     bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        CVE-2999 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 Scenario: advisory lists advisories referencing bugzilla
@@ -358,12 +403,15 @@ Scenario: advisory lists advisories referencing bugzilla
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory list --with-bz"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Bugzilla Type   Severity                   Package              Issued
-    222      bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        Bugzilla Type   Severity                   Package              Issued
+        222      bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 @bz1728004
@@ -380,12 +428,15 @@ Scenario: advisory show <advisory> of the running kernel after a kernel update
    # updated kernel is available
    When I execute dnf5 with args "advisory list --contains-pkgs=kernel"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type   Severity                        Package              Issued
-    FEDORA-2019-348e185000 bugfix Moderate kernel-4.19.15-300.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        Name                   Type   Severity                        Package              Issued
+        FEDORA-2019-348e185000 bugfix Moderate kernel-4.19.15-300.fc29.x86_64 2019-01-17 00:00:00
+        """
   Given I successfully execute dnf with args "upgrade kernel"
    Then Transaction is following
         | Action        | Package                                  |
@@ -395,20 +446,24 @@ Scenario: advisory show <advisory> of the running kernel after a kernel update
    # updated kernel is installed, but the running kernel is still the older one
    When I execute dnf5 with args "advisory list --contains-pkgs=kernel"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Name                   Type   Severity                        Package              Issued
-    FEDORA-2019-348e185000 bugfix Moderate kernel-4.19.15-300.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        Name                   Type   Severity                        Package              Issued
+        FEDORA-2019-348e185000 bugfix Moderate kernel-4.19.15-300.fc29.x86_64 2019-01-17 00:00:00
+        """
   Given I fake kernel release to "4.19.15-300.fc29.x86_64"
    # updated kernel is installed and running
    When I execute dnf5 with args "advisory list --contains-pkgs=kernel"
    Then the exit code is 0
-    And stdout is
-    """
-    <REPOSYNC>
-    """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is empty
 
 
 @bz1801092
@@ -417,13 +472,16 @@ Scenario: advisory lists advisories referencing CVE with dates
     And I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "advisory list --with-cve"
    Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    CVE      Type   Severity                   Package              Issued
-    2999     bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    CVE-2999 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
-    """
+        """
+        CVE      Type   Severity                   Package              Issued
+        2999     bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        CVE-2999 bugfix none     glibc-2.28-26.fc29.x86_64 2019-01-17 00:00:00
+        """
 
 
 # @dnf5daemon
@@ -433,16 +491,19 @@ Scenario: advisory lists advisories with custom type and severity
     And I use repository "advisories-updates"
    When I execute dnf with args "advisory list"
    Then the exit code is 0
+    And dnf5 stderr is
+        """
+        <REPOSYNC>
+        """
     And dnf5 stdout is
-    """
-    <REPOSYNC>
-    Name                   Type        Severity                               Package              Issued
-    FEDORA-2019-57b5902ed1 security    Critical        labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
-    FEDORA-2019-f4eb34cf4c security    Moderate        labirinto-1.56.2-1.fc30.x86_64 2019-05-12 01:21:43
-    FEDORA-2022-2222222222 custom_type custom_severity labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
-    FEDORA-2022-2222222223 security    custom_severity labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
-    FEDORA-2022-2222222224 custom_type Critical        labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
-    """
+        """
+        Name                   Type        Severity                               Package              Issued
+        FEDORA-2019-57b5902ed1 security    Critical        labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
+        FEDORA-2019-f4eb34cf4c security    Moderate        labirinto-1.56.2-1.fc30.x86_64 2019-05-12 01:21:43
+        FEDORA-2022-2222222222 custom_type custom_severity labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
+        FEDORA-2022-2222222223 security    custom_severity labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
+        FEDORA-2022-2222222224 custom_type Critical        labirinto-1.56.2-6.fc30.x86_64 2019-09-15 01:34:29
+        """
 
 
 Scenario: advisory prints info for advisories with custom type and severity
@@ -451,89 +512,92 @@ Scenario: advisory prints info for advisories with custom type and severity
     And I use repository "advisories-updates"
    When I execute dnf with args "advisory info"
    Then the exit code is 0
+    And dnf5 stderr is
+        """
+        <REPOSYNC>
+        """
     And dnf5 stdout is
-    """
-    <REPOSYNC>
-    Name        : FEDORA-2019-f4eb34cf4c
-    Title       : labirinto-1.56.2-1.fc30
-    Severity    : Moderate
-    Type        : security
-    Status      : stable
-    Vendor      : updates@fedoraproject.org
-    Issued      : 2019-05-12 01:21:43
-    Description : GNOME 3.32.2
-    Message     : 
-    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
-    Reference   : 
-      Title     : [abrt] epiphany: ephy_suggestion_get_unescaped_title(): epiphany-search-provider killed by SIGABRT
-      Id        : 1696529
-      Type      : bugzilla
-      Url       : https://bugzilla.redhat.com/show_bug.cgi?id=1696529
-    Collection  : 
-      Packages  : labirinto-1.56.2-1.fc30.i686
-                : labirinto-1.56.2-1.fc30.x86_64
-                : labirinto-1.56.2-1.fc30.src
+        """
+        Name        : FEDORA-2019-f4eb34cf4c
+        Title       : labirinto-1.56.2-1.fc30
+        Severity    : Moderate
+        Type        : security
+        Status      : stable
+        Vendor      : updates@fedoraproject.org
+        Issued      : 2019-05-12 01:21:43
+        Description : GNOME 3.32.2
+        Message     : 
+        Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+        Reference   : 
+          Title     : [abrt] epiphany: ephy_suggestion_get_unescaped_title(): epiphany-search-provider killed by SIGABRT
+          Id        : 1696529
+          Type      : bugzilla
+          Url       : https://bugzilla.redhat.com/show_bug.cgi?id=1696529
+        Collection  : 
+          Packages  : labirinto-1.56.2-1.fc30.i686
+                    : labirinto-1.56.2-1.fc30.x86_64
+                    : labirinto-1.56.2-1.fc30.src
 
-    Name        : FEDORA-2019-57b5902ed1
-    Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
-    Severity    : Critical
-    Type        : security
-    Status      : stable
-    Vendor      : updates@fedoraproject.org
-    Issued      : 2019-09-15 01:34:29
-    Description : mozjs60 60.9.0, including various security, stability and regression fixes from Firefox 60.9.0 ESR. For details, see https://www.mozilla.org/en-US/firefox/60.9.0/releasenotes/
-    Message     : 
-    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
-    Collection  : 
-      Packages  : labirinto-1.56.2-6.fc30.i686
-                : labirinto-1.56.2-6.fc30.src
-                : labirinto-1.56.2-6.fc30.x86_64
+        Name        : FEDORA-2019-57b5902ed1
+        Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
+        Severity    : Critical
+        Type        : security
+        Status      : stable
+        Vendor      : updates@fedoraproject.org
+        Issued      : 2019-09-15 01:34:29
+        Description : mozjs60 60.9.0, including various security, stability and regression fixes from Firefox 60.9.0 ESR. For details, see https://www.mozilla.org/en-US/firefox/60.9.0/releasenotes/
+        Message     : 
+        Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+        Collection  : 
+          Packages  : labirinto-1.56.2-6.fc30.i686
+                    : labirinto-1.56.2-6.fc30.src
+                    : labirinto-1.56.2-6.fc30.x86_64
 
-    Name        : FEDORA-2022-2222222222
-    Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
-    Severity    : custom_severity
-    Type        : custom_type
-    Status      : stable
-    Vendor      : updates@fedoraproject.org
-    Issued      : 2019-09-15 01:34:29
-    Description : advisory with custom type and seveirity
-    Message     : 
-    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
-    Collection  : 
-      Packages  : labirinto-1.56.2-6.fc30.i686
-                : labirinto-1.56.2-6.fc30.src
-                : labirinto-1.56.2-6.fc30.x86_64
+        Name        : FEDORA-2022-2222222222
+        Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
+        Severity    : custom_severity
+        Type        : custom_type
+        Status      : stable
+        Vendor      : updates@fedoraproject.org
+        Issued      : 2019-09-15 01:34:29
+        Description : advisory with custom type and seveirity
+        Message     : 
+        Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+        Collection  : 
+          Packages  : labirinto-1.56.2-6.fc30.i686
+                    : labirinto-1.56.2-6.fc30.src
+                    : labirinto-1.56.2-6.fc30.x86_64
 
-    Name        : FEDORA-2022-2222222223
-    Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
-    Severity    : custom_severity
-    Type        : security
-    Status      : stable
-    Vendor      : updates@fedoraproject.org
-    Issued      : 2019-09-15 01:34:29
-    Description : advisory with custom seveirity
-    Message     : 
-    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
-    Collection  : 
-      Packages  : labirinto-1.56.2-6.fc30.i686
-                : labirinto-1.56.2-6.fc30.src
-                : labirinto-1.56.2-6.fc30.x86_64
+        Name        : FEDORA-2022-2222222223
+        Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
+        Severity    : custom_severity
+        Type        : security
+        Status      : stable
+        Vendor      : updates@fedoraproject.org
+        Issued      : 2019-09-15 01:34:29
+        Description : advisory with custom seveirity
+        Message     : 
+        Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+        Collection  : 
+          Packages  : labirinto-1.56.2-6.fc30.i686
+                    : labirinto-1.56.2-6.fc30.src
+                    : labirinto-1.56.2-6.fc30.x86_64
 
-    Name        : FEDORA-2022-2222222224
-    Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
-    Severity    : Critical
-    Type        : custom_type
-    Status      : stable
-    Vendor      : updates@fedoraproject.org
-    Issued      : 2019-09-15 01:34:29
-    Description : advisory with custom type
-    Message     : 
-    Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
-    Collection  : 
-      Packages  : labirinto-1.56.2-6.fc30.i686
-                : labirinto-1.56.2-6.fc30.src
-                : labirinto-1.56.2-6.fc30.x86_64
-    """
+        Name        : FEDORA-2022-2222222224
+        Title       : labirinto-1.56.2-6.fc30 mozjs60-60.9.0-2.fc30 polkit-0.116-2.fc30
+        Severity    : Critical
+        Type        : custom_type
+        Status      : stable
+        Vendor      : updates@fedoraproject.org
+        Issued      : 2019-09-15 01:34:29
+        Description : advisory with custom type
+        Message     : 
+        Rights      : Copyright (C) 2020 Red Hat, Inc. and others.
+        Collection  : 
+          Packages  : labirinto-1.56.2-6.fc30.i686
+                    : labirinto-1.56.2-6.fc30.src
+                    : labirinto-1.56.2-6.fc30.x86_64
+        """
 
 
 Scenario: advisory prints summary of advisories with custom type and severity
@@ -542,20 +606,23 @@ Scenario: advisory prints summary of advisories with custom type and severity
     And I use repository "advisories-updates"
    When I execute dnf with args "updateinfo summary"
    Then the exit code is 0
+    And dnf5 stderr is
+        """
+        <REPOSYNC>
+        """
     And dnf5 stdout is
-    """
-    <REPOSYNC>
-    Available advisory information summary:
-    Security    : 3
-      Critical  : 1
-      Important : 0
-      Moderate  : 1
-      Low       : 0
-      Other     : 1
-    Bugfix      : 0
-    Enhancement : 0
-    Other       : 2
-    """
+        """
+        Available advisory information summary:
+        Security    : 3
+          Critical  : 1
+          Important : 0
+          Moderate  : 1
+          Low       : 0
+          Other     : 1
+        Bugfix      : 0
+        Enhancement : 0
+        Other       : 2
+        """
 
 
 # @dnf5daemon
@@ -565,10 +632,11 @@ Given I use repository "updateinfo"
 # The test requires that advisory for A-2-2.x86_64 is available
  When I execute dnf with args "advisory list --installed"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 
 @xfail
@@ -579,12 +647,15 @@ Given I use repository "security-upgrade"
   And I execute dnf with args "install C-1-1"
  When I execute dnf with args "updateinfo list --updates"
  Then the exit code is 0
+  And stderr is
+      """
+      <REPOSYNC>
+      """
   And dnf5 stdout is
-  """
-  <REPOSYNC>
-  Name         Type     Severity      Package              Issued
-  DNF-D-2022-9 security          D-1-1.x86_64 1970-01-01 00:00:00
-  """
+      """
+      Name         Type     Severity      Package              Issued
+      DNF-D-2022-9 security          D-1-1.x86_64 1970-01-01 00:00:00
+      """
 
 
 Scenario: advisory --updates with advisory for obsoleter when obsoleted installed
@@ -593,17 +664,21 @@ Given I use repository "security-upgrade"
   # Make sure D-1-1 is available and obsoletes C since we are testing we don't list it.
   # There also should be an available advisory for it. (We cannot verify that here because the advisory command is bugged when dealing with obsoletes)
   And I successfully execute dnf with args "repoquery D-1-1.x86_64 --obsoletes"
-  Then stdout is
-  """
-  <REPOSYNC>
-  C
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      C
+      """
  When I execute dnf with args "advisory list --updates --setopt=obsoletes=false"
  Then the exit code is 0
-  And stdout is
-  """
-  <REPOSYNC>
-  """
+  And stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is empty
 
 
 @xfail
@@ -614,12 +689,15 @@ Given I use repository "security-upgrade"
   And I execute dnf with args "install change-arch-noarch-1-1.noarch"
  When I execute dnf with args "updateinfo list --updates"
  Then the exit code is 0
+  And dnf5 stderr is
+      """
+      <REPOSYNC>
+      """
   And dnf5 stdout is
-  """
-  <REPOSYNC>
-  Name       Type     Severity                       Package              Issued
-  DNF-2019-4 security          change-arch-noarch-2-2.x86_64 1970-01-01 00:00:00
-  """
+      """
+      Name       Type     Severity                       Package              Issued
+      DNF-2019-4 security          change-arch-noarch-2-2.x86_64 1970-01-01 00:00:00
+      """
 
 
 # @dnf5daemon
@@ -628,9 +706,12 @@ Given I successfully execute dnf with args "install kernel flac glibc"
   And I fake kernel release to "4.18.16-300.fc29.x86_64"
   And I use repository "dnf-ci-fedora-updates"
  When I execute dnf with args "advisory list --contains-pkgs=flac"
- Then stdout is
-  """
-  <REPOSYNC>
-  Name               Type        Severity                  Package              Issued
-  FEDORA-2999:002-02 enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
-  """
+ Then stderr is
+      """
+      <REPOSYNC>
+      """
+  And stdout is
+      """
+      Name               Type        Severity                  Package              Issued
+      FEDORA-2999:002-02 enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
+      """

--- a/dnf-behave-tests/dnf/upgrade-conflicts.feature
+++ b/dnf-behave-tests/dnf/upgrade-conflicts.feature
@@ -6,13 +6,14 @@ Scenario: Conflicts are reported even if the transaction would involve removal o
    And I successfully execute dnf with args "install diamond-1-1 spade-1-1"
   When I execute dnf with args "upgrade --setopt=protected_packages=diamond"
   Then stderr is
-   """
-   Failed to resolve the transaction:
-   Problem: installed package diamond-1-1.x86_64 requires spade = 1-1, but none of the providers can be installed
-     - cannot install both spade-2-1.x86_64 from upgrade-conflicts and spade-1-1.x86_64 from @System
-     - cannot install both spade-2-1.x86_64 from upgrade-conflicts and spade-1-1.x86_64 from upgrade-conflicts
-     - cannot install the best update candidate for package spade-1-1.x86_64
-     - cannot install the best update candidate for package diamond-1-1.x86_64
-   You can try to add to command line:
-     --no-best to not limit the transaction to the best candidates
-   """
+       """
+       <REPOSYNC>
+       Failed to resolve the transaction:
+       Problem: installed package diamond-1-1.x86_64 requires spade = 1-1, but none of the providers can be installed
+         - cannot install both spade-2-1.x86_64 from upgrade-conflicts and spade-1-1.x86_64 from @System
+         - cannot install both spade-2-1.x86_64 from upgrade-conflicts and spade-1-1.x86_64 from upgrade-conflicts
+         - cannot install the best update candidate for package spade-1-1.x86_64
+         - cannot install the best update candidate for package diamond-1-1.x86_64
+       You can try to add to command line:
+         --no-best to not limit the transaction to the best candidates
+       """

--- a/dnf-behave-tests/dnf/upgrade.feature
+++ b/dnf-behave-tests/dnf/upgrade.feature
@@ -65,12 +65,13 @@ Scenario: Upgrade list of packages, one of them is not available
    When I execute dnf with args "upgrade flac nosuchpkg"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    No match for argument: nosuchpkg
-    You can try to add to command line:
-      --skip-unavailable to skip unavailable packages
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        No match for argument: nosuchpkg
+        You can try to add to command line:
+          --skip-unavailable to skip unavailable packages
+        """
     And Transaction is empty
 
 
@@ -79,12 +80,12 @@ Scenario: Upgrade list of packages with --skip-unavailable, one of them is not a
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade --skip-unavailable nosuchpkg flac"
    Then the exit code is 0
-    And stderr is
-    """
-    No match for argument: nosuchpkg
+    And stderr contains lines
+        """
+        No match for argument: nosuchpkg
 
-    Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
-    """
+        Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
+        """
     And Transaction is following
         | Action        | Package                                   |
         | upgrade       | flac-0:1.3.3-3.fc29.x86_64                |
@@ -96,10 +97,11 @@ Scenario: Upgrade list of packages, one of them is not installed
    When I execute dnf with args "upgrade flac dwm"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Packages for argument 'dwm' available, but not installed.
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Packages for argument 'dwm' available, but not installed.
+        """
     And Transaction is empty
 
 
@@ -108,12 +110,12 @@ Scenario: Upgrade list of packages with --skip-unavailable, one of them is not i
   Given I use repository "dnf-ci-fedora-updates"
    When I execute dnf with args "upgrade --skip-unavailable dwm flac"
    Then the exit code is 0
-    And stderr is
-    """
-    Packages for argument 'dwm' available, but not installed.
+    And stderr contains lines
+        """
+        Packages for argument 'dwm' available, but not installed.
 
-    Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
-    """
+        Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
+        """
     And Transaction is following
         | Action        | Package                                   |
         | upgrade       | flac-0:1.3.3-3.fc29.x86_64                |
@@ -131,7 +133,7 @@ Scenario: Upgrade all RPMs from multiple repositories with best=False
         | best | False |
    When I execute dnf with args "--nogpgcheck upgrade"
    Then the exit code is 0
-    And stderr is
+    And stderr contains lines
     """
     Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
       - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
@@ -163,13 +165,14 @@ Scenario: Upgrade all RPMs from multiple repositories with best=True
    When I execute dnf with args "upgrade"
    Then the exit code is 1
     And stderr is
-    """
-    Failed to resolve the transaction:
-    Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
-      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
-    You can try to add to command line:
-      --no-best to not limit the transaction to the best candidates
-    """
+        """
+        <REPOSYNC>
+        Failed to resolve the transaction:
+        Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
+          - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
+        You can try to add to command line:
+          --no-best to not limit the transaction to the best candidates
+        """
    When I execute dnf with args "upgrade --no-best"
    Then the exit code is 0
     And Transaction is following
@@ -182,13 +185,13 @@ Scenario: Upgrade all RPMs from multiple repositories with best=True
         | upgrade       | SuperRipper-0:1.2-1.x86_64                |
         | upgrade       | abcde-0:2.9.3-1.fc29.noarch               |
         | broken        | SuperRipper-1.3-1.x86_64                  |
-    And stderr is
-    """
-    Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
-      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
+    And stderr contains lines
+        """
+        Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
+          - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
  
-    Warning: skipped PGP checks for 7 packages from repositories: dnf-ci-fedora-updates, dnf-ci-fedora-updates-testing, dnf-ci-thirdparty-updates
-    """
+        Warning: skipped PGP checks for 7 packages from repositories: dnf-ci-fedora-updates, dnf-ci-fedora-updates-testing, dnf-ci-thirdparty-updates
+        """
 
 
 @dnf5
@@ -201,13 +204,13 @@ Scenario: Print information about skipped packages
         | Action        | Package                                   |
         | upgrade       | SuperRipper-0:1.2-1.x86_64                |
         | broken        | SuperRipper-1.3-1.x86_64                  |
-   Then stderr is
-    """
-    Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
-      - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
+   Then stderr contains lines
+        """
+        Problem: cannot install the best update candidate for package SuperRipper-1.0-1.x86_64
+          - nothing provides unsatisfiable needed by SuperRipper-1.3-1.x86_64 from dnf-ci-thirdparty-updates
 
-    Warning: skipped PGP checks for 1 package from repository: dnf-ci-thirdparty-updates
-    """
+        Warning: skipped PGP checks for 1 package from repository: dnf-ci-thirdparty-updates
+        """
 
 
 # @dnf5
@@ -225,11 +228,14 @@ Scenario Outline: Print correct number of available updates if update <type> is 
    Then the exit code is 0
     And Transaction is empty
     And stderr contains "No security updates needed, but 2 updates available"
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+        """
+        Nothing to do.
+        """
 
 Examples:
         | type          |
@@ -249,11 +255,14 @@ Scenario Outline: Print correct number of available updates if update <type> is 
    Then the exit code is 0
     And Transaction is empty
     And stderr contains "No security updates needed, but 7 updates available"
+    And stderr is
+        """
+        <REPOSYNC>
+        """
     And stdout is
-    """
-    <REPOSYNC>
-    Nothing to do.
-    """
+        """
+        Nothing to do.
+        """
 
 Examples:
         | type          |

--- a/dnf-behave-tests/dnf/vars.feature
+++ b/dnf-behave-tests/dnf/vars.feature
@@ -107,7 +107,8 @@ Scenario: Ignoring variable files with invalid encoding
     And I use repository "dnf-ci-fedora"
    When I execute dnf with args "repoquery empty --setopt=varsdir={context.dnf.installroot}/etc/dnf/vars"
    Then the exit code is 0
-   And stdout is
-   """
-   <REPOSYNC>
-   """
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is empty

--- a/dnf-behave-tests/dnf/yum-compat.feature
+++ b/dnf-behave-tests/dnf/yum-compat.feature
@@ -23,12 +23,12 @@ Scenario: using install-n doesn't allow additional NEVRA parts
  Then the exit code is 1
   And stdout is
       """
-      <REPOSYNC>
       No match for argument: labirinto.x86_64
         * Maybe you meant: labirinto
       """
   And stderr is
       """
+      <REPOSYNC>
       Error: Unable to find a match: labirinto.x86_64
       """
 
@@ -51,12 +51,12 @@ Scenario: using install-na doesn't allow additional nevra parts
  Then the exit code is 1
   And stdout is
       """
-      <REPOSYNC>
       No match for argument: labirinto-1.0-1.fc29.x86_64
         * Maybe you meant: labirinto
       """
   And stderr is
       """
+      <REPOSYNC>
       Error: Unable to find a match: labirinto-1.0-1.fc29.x86_64
       """
 
@@ -78,12 +78,12 @@ Scenario: install using install-nevra doesn't work without full nevra
  Then the exit code is 1
   And stdout is
       """
-      <REPOSYNC>
       No match for argument: labirinto-1.0-1.fc29
         * Maybe you meant: labirinto
       """
   And stderr is
       """
+      <REPOSYNC>
       Error: Unable to find a match: labirinto-1.0-1.fc29
       """
 
@@ -104,9 +104,12 @@ Scenario: install using localinstall
 Scenario: install using localinstall fails with just available package name
  When I execute dnf with args "localinstall labirinto"
  Then the exit code is 1
-  And stdout is
+  And stderr is
       """
       <REPOSYNC>
+      """
+  And stdout is
+      """
       Not a valid rpm file path: labirinto
       """
 


### PR DESCRIPTION
For https://github.com/rpm-software-management/dnf5/pull/1641.

Adds support for the `<REPOSYNC>` shorthand to `Then stderr is` and `Then stderr matches line by line`.

Introduces `Then stdout contains lines matching` and `Then stderr contains lines matching` steps which are similar to `Then stdout contains lines` but treat each expected line as a regex, like `Then stdout matches line by line`.

This patchset strengthens many tests; there were many instances of the pattern:

```cucumber
Then stdout is
     """
     <REPOSYNC>
     foo
     bar
     """
```

that were replaced with

```cucumber
Then stderr is
     """
     <REPOSYNC>
     """
 And stdout is
     """
     foo
     bar
     """
```

so now stderr is checked in many places where it wasn't before.

However, some tests were weakened, notably those following the pattern:

```cucumber
Then stderr is
     """
     No match for argument: nosuchpkg

     Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
     """
```

Because stderr now includes lots of other (non-error) information including progress bars for downloads and RPM transactions, these occurrences were changed to:

```cucumber
Then stderr contains lines
     """
     No match for argument: nosuchpkg
     Warning: skipped PGP checks for 1 package from repository: dnf-ci-fedora-updates
     """
```

We could maybe make `<RPMDOWNLOAD>` and `<RPMTRANSACTION>` markers that work similar to `<REPOSYNC>` to allow us to use `Then stderr is` again, but I'd rather do that in a follow-up issue.

These changes were made mostly manually with the help of Neovim macros.