### PR TITLE
microdnf: Test reinstalling non-installed package

### DIFF
--- a/dnf-behave-tests/dnf/microdnf/reinstall-not-installed.feature
+++ b/dnf-behave-tests/dnf/microdnf/reinstall-not-installed.feature
@@ -1,0 +1,17 @@
+@no_installroot
+Feature: Reinstall
+
+
+Background: Set up repositories
+  Given I use repository "dnf-ci-fedora"
+    And I use repository "dnf-ci-fedora-updates"
+
+
+Scenario: Reinstall an RPM that is available, but not installed
+   When I execute microdnf with args "reinstall CQRlib"
+   Then the exit code is 1
+    And RPMDB Transaction is empty
+    And stdout is
+        """
+        Package for argument CQRlib available, but not installed.
+        """


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/microdnf/pull/144.
For https://issues.redhat.com/browse/RHEL-53430.