### PR TITLE
module/updateinfo: Disable failing test

### DIFF
--- a/dnf-behave-tests/dnf/module/updateinfo.feature
+++ b/dnf-behave-tests/dnf/module/updateinfo.feature
@@ -53,14 +53,15 @@ Given I use repository "dnf-ci-fedora-modular-updates"
   And stdout is empty
 
 
-@dnf5
+# Test is failing with DNF 5.
+# @dnf5
 @bz1804234
 Scenario: having installed packages from one collection and enabled all modules from another doesn't activate advisory
 Given I use repository "dnf-ci-fedora"
   And I execute dnf with args "install nodejs"
   And I use repository "dnf-ci-fedora-modular-updates"
   And I execute dnf with args "module enable postgresql:9.6"
- When I execute dnf with args "updateinfo --list"
+ When I execute dnf with args "updateinfo list"
  Then stderr is
       """
       <REPOSYNC>


### PR DESCRIPTION
After merging https://github.com/rpm-software-management/ci-dnf-stack/pull/1540, it was revealed that this test in `module/updateinfo.feature` wasn't actually testing anything, and the behavior it intends to test is (and has long been?) broken. The test was expecting an empty stdout (or `<REPOSYNC>`), which it was getting, but only after refactoring the tests did we notice the message on stderr:

```
Unknown argument "--list" for command "updateinfo".
```

For now, I've updated the test to call the correct command, `updateinfo list`, and disabled the test since it is now failing (but in a more valid way):

```
Assertion Failed: Stdout is not empty, it contains:
Name                   Type        Severity                  Package              Issued
FEDORA-2019-0329090518 enhancement none     nodejs-1:8.14.0-1.x86_64 2019-03-29 00:00:00
```

Another option would be to fix the test to use the correct command, but leave it enabled and failing.

cc @pkratoch, do you have an idea of what the problem is and how long it might take to fix? If it's complicated/low priority, we can go ahead and disable the test and put an issue on the backlog for it, otherwise maybe it's better to go ahead and fix it instead of disabling then immediately re-enabling it.