### PR TITLE
Add missing `Recommends` to simulate real debuginfo pkgs

### DIFF
--- a/dnf-behave-tests/fixtures/specs/debuginfo-install/bar-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/debuginfo-install/bar-1.0.spec
@@ -16,6 +16,7 @@ Dummy.
 
 %package debuginfo
 Summary:        Debug information for foo.
+Recommends:     %{name}-debugsource(x86-64) = %{version}-%{release}
 
 %description debuginfo
 Dummy.

--- a/dnf-behave-tests/fixtures/specs/debuginfo-install/bar-3.0.spec
+++ b/dnf-behave-tests/fixtures/specs/debuginfo-install/bar-3.0.spec
@@ -16,6 +16,7 @@ Dummy.
 
 %package debuginfo
 Summary:        Debug information for foo.
+Recommends:     %{name}-debugsource(x86-64) = %{version}-%{release}
 
 %description debuginfo
 Dummy.

--- a/dnf-behave-tests/fixtures/specs/debuginfo-install/baz-2.0.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/debuginfo-install/baz-2.0.i686.spec
@@ -18,6 +18,7 @@ Dummy.
 
 %package debuginfo
 Summary:        Debug information for foo.
+Recommends:     %{name}-debugsource(i686) = %{version}-%{release}
 
 %description debuginfo
 Dummy.

--- a/dnf-behave-tests/fixtures/specs/debuginfo-install/foo-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/debuginfo-install/foo-1.0.spec
@@ -24,6 +24,7 @@ Dummy.
 
 %package debuginfo
 Summary:        Debug information for foo.
+Recommends:     %{name}-debugsource(x86-64) = %{version}-%{release}
 
 %description debuginfo
 Dummy.

--- a/dnf-behave-tests/fixtures/specs/debuginfo-install/foo-2.0.spec
+++ b/dnf-behave-tests/fixtures/specs/debuginfo-install/foo-2.0.spec
@@ -24,6 +24,7 @@ Dummy.
 
 %package debuginfo
 Summary:        Debug information for foo.
+Recommends:     %{name}-debugsource(x86-64) = %{version}-%{release}
 
 %description debuginfo
 Dummy.

--- a/dnf-behave-tests/fixtures/specs/debuginfo-install/kernel-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/debuginfo-install/kernel-1.0.spec
@@ -18,6 +18,7 @@ Dummy.
 
 %package debuginfo
 Summary:        Debug information for kernel.
+Recommends:     %{name}-debugsource(x86-64) = %{version}-%{release}
 
 %description debuginfo
 Dummy.

--- a/dnf-behave-tests/fixtures/specs/debuginfo-install/kernel-2.0.spec
+++ b/dnf-behave-tests/fixtures/specs/debuginfo-install/kernel-2.0.spec
@@ -18,6 +18,7 @@ Dummy.
 
 %package debuginfo
 Summary:        Debug information for kernel.
+Recommends:     %{name}-debugsource(x86-64) = %{version}-%{release}
 
 %description debuginfo
 Dummy.


### PR DESCRIPTION
Since `rpm-4.19.94-1.fc42` the rpm debuginfo code logic is not always executed. To match real debuginfo pkgs add debugsource recommends manually.

More details: https://github.com/rpm-software-management/rpm/issues/3310

Backport of https://github.com/rpm-software-management/ci-dnf-stack/pull/1550