### PR TITLE
Update tests to match curl error messages

### DIFF
--- a/dnf-behave-tests/dnf/config.feature
+++ b/dnf-behave-tests/dnf/config.feature
@@ -203,7 +203,7 @@ Scenario: Dnf prints reasonable error when remote config file is not downloadabl
    And stderr matches line by line
    """
    Config error: Configuration file URL "http://the_host:[\d]+/does-not-exist\.conf" could not be downloaded:
-     Curl error \(6\): Couldn't resolve host name for http://the_host:[\d]+/does-not-exist\.conf \[Could not resolve host: the_host\]
+     Curl error \(6\): Could not resolve hostname for http://the_host:[\d]+/does-not-exist\.conf \[Could not resolve host: the_host\]
    """
 
 

--- a/dnf-behave-tests/dnf/download-source.feature
+++ b/dnf-behave-tests/dnf/download-source.feature
@@ -71,9 +71,9 @@ Given I create directory "/baseurlrepo"
  When I execute dnf with args "makecache"
  Then the exit code is 1
   And stderr contains "Errors during downloading metadata for repository 'testrepo':"
-  And stderr contains "- Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
-  And stderr contains "- Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Couldn't connect to server]"
-  And stderr contains "- Curl error \(37\): Couldn't read a file:// file for file:///tmp/dnf_ci_installroot_.*/I_dont_exist/repodata/repomd.xml \[Couldn't open file /tmp/dnf_ci_installroot_.*/I_dont_exist/repodata/repomd.xml\]"
+  And stderr contains "- Curl error \(37\): Could not read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
+  And stderr contains "- Curl error \(7\): Could not connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Could not connect to server]"
+  And stderr contains "- Curl error \(37\): Could not read a file:// file for file:///tmp/dnf_ci_installroot_.*/I_dont_exist/repodata/repomd.xml \[Couldn't open file /tmp/dnf_ci_installroot_.*/I_dont_exist/repodata/repomd.xml\]"
   And stderr contains "Error: Failed to download metadata for repo 'testrepo': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
 
 

--- a/dnf-behave-tests/dnf/microdnf/makecache.feature
+++ b/dnf-behave-tests/dnf/microdnf/makecache.feature
@@ -48,5 +48,5 @@ Given I configure a new repository "non-existent" with
       """
   And stderr is
       """
-      error: cannot update repo 'non-existent': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried; Last error: Curl error (6): Couldn't resolve host name for https://www.not-available-repo.com/repodata/repomd.xml [Could not resolve host: www.not-available-repo.com]
+      error: cannot update repo 'non-existent': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried; Last error: Curl error (6): Could not resolve hostname for https://www.not-available-repo.com/repodata/repomd.xml [Could not resolve host: www.not-available-repo.com]
       """

--- a/dnf-behave-tests/dnf/microdnf/reinstall4.feature
+++ b/dnf-behave-tests/dnf/microdnf/reinstall4.feature
@@ -12,5 +12,5 @@ Scenario: Try to reinstall a pkg if repo not available
    Then the exit code is 1
    And stderr is
        """
-       error: cannot update repo 'simple-base': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried; Last error: Curl error (6): Couldn't resolve host name for https://www.not-available-repo.com/repodata/repomd.xml [Could not resolve host: www.not-available-repo.com]
+       error: cannot update repo 'simple-base': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried; Last error: Curl error (6): Could not resolve hostname for https://www.not-available-repo.com/repodata/repomd.xml [Could not resolve host: www.not-available-repo.com]
        """

--- a/dnf-behave-tests/dnf/microdnf/reinstall5.feature
+++ b/dnf-behave-tests/dnf/microdnf/reinstall5.feature
@@ -14,5 +14,5 @@ Scenario: Try to reinstall a pkg if repo not available
    Then the exit code is 1
    And stderr is
        """
-       error: cannot update repo 'non-existent': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried; Last error: Curl error (6): Couldn't resolve host name for https://www.not-available-repo.com/repodata/repomd.xml [Could not resolve host: www.not-available-repo.com]
+       error: cannot update repo 'non-existent': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried; Last error: Curl error (6): Could not resolve hostname for https://www.not-available-repo.com/repodata/repomd.xml [Could not resolve host: www.not-available-repo.com]
        """

--- a/dnf-behave-tests/dnf/repo-sync.feature
+++ b/dnf-behave-tests/dnf/repo-sync.feature
@@ -17,7 +17,7 @@ Scenario: The default value of skip_if_unavailable is False
     And stderr is
     """
     Errors during downloading metadata for repository 'testrepo':
-      - Curl error (37): Couldn't read a file:// file for file:///non/existent/repo/repodata/repomd.xml [Couldn't open file /non/existent/repo/repodata/repomd.xml]
+      - Curl error (37): Could not read a file:// file for file:///non/existent/repo/repodata/repomd.xml [Couldn't open file /non/existent/repo/repodata/repomd.xml]
     Error: Failed to download metadata for repo 'testrepo': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
     """
 
@@ -41,7 +41,7 @@ Scenario: There is global skip_if_unavailable option
     And stderr is
     """
     Errors during downloading metadata for repository 'testrepo':
-      - Curl error (37): Couldn't read a file:// file for file:///non/existent/repo/repodata/repomd.xml [Couldn't open file /non/existent/repo/repodata/repomd.xml]
+      - Curl error (37): Could not read a file:// file for file:///non/existent/repo/repodata/repomd.xml [Couldn't open file /non/existent/repo/repodata/repomd.xml]
     Error: Failed to download metadata for repo 'testrepo': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
     Ignoring repositories: testrepo
     """
@@ -65,7 +65,7 @@ Scenario: Per repo skip_if_unavailable configuration
     And stderr is
     """
     Errors during downloading metadata for repository 'testrepo':
-      - Curl error (37): Couldn't read a file:// file for file:///non/existent/repo/repodata/repomd.xml [Couldn't open file /non/existent/repo/repodata/repomd.xml]
+      - Curl error (37): Could not read a file:// file for file:///non/existent/repo/repodata/repomd.xml [Couldn't open file /non/existent/repo/repodata/repomd.xml]
     Error: Failed to download metadata for repo 'testrepo': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
     Ignoring repositories: testrepo
     """
@@ -86,7 +86,7 @@ Scenario: The repo configuration takes precedence over the global one
     And stderr is
     """
     Errors during downloading metadata for repository 'testrepo':
-      - Curl error (37): Couldn't read a file:// file for file:///non/existent/repo/repodata/repomd.xml [Couldn't open file /non/existent/repo/repodata/repomd.xml]
+      - Curl error (37): Could not read a file:// file for file:///non/existent/repo/repodata/repomd.xml [Couldn't open file /non/existent/repo/repodata/repomd.xml]
     Error: Failed to download metadata for repo 'testrepo': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
     """
 
@@ -100,8 +100,8 @@ Given I use repository "dnf-ci-fedora" with configuration
  When I execute dnf with args "makecache"
  Then the exit code is 1
   And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
-  And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file://.*/dnf-ci-fedora/repodata/repomd.xml.asc \[Couldn't open file .*/dnf-ci-fedora/repodata/repomd.xml.asc\]"
-  And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': GPG verification is enabled, but GPG signature is not available. This may be an error or the repository does not support GPG verification: Curl error \(37\): Couldn't read a file:// file for file://.*/dnf-ci-fedora/repodata/repomd.xml.asc \[Couldn't open file .*/dnf-ci-fedora/repodata/repomd.xml.asc\]"
+  And stderr contains "  - Curl error \(37\): Could not read a file:// file for file://.*/dnf-ci-fedora/repodata/repomd.xml.asc \[Couldn't open file .*/dnf-ci-fedora/repodata/repomd.xml.asc\]"
+  And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': GPG verification is enabled, but GPG signature is not available. This may be an error or the repository does not support GPG verification: Curl error \(37\): Could not read a file:// file for file://.*/dnf-ci-fedora/repodata/repomd.xml.asc \[Couldn't open file .*/dnf-ci-fedora/repodata/repomd.xml.asc\]"
 
 
 @bz1713627
@@ -133,14 +133,14 @@ Scenario: Nonexistent GPG key
    When I execute dnf with args "makecache"
    Then the exit code is 1
     And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
-    And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistentkey \[Couldn't open file /nonexistentkey\]"
-    And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for .*repomd.xml.asc \[Couldn't open file .*repomd.xml.asc\]"
+    And stderr contains "  - Curl error \(37\): Could not read a file:// file for file:///nonexistentkey \[Couldn't open file /nonexistentkey\]"
+    And stderr contains "  - Curl error \(37\): Could not read a file:// file for .*repomd.xml.asc \[Couldn't open file .*repomd.xml.asc\]"
     And stderr contains "Error: Failed to retrieve GPG key for repo 'dnf-ci-fedora'"
    When I execute dnf with args "makecache --setopt=*.skip_if_unavailable=1"
    Then the exit code is 0
     And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
-    And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistentkey \[Couldn't open file /nonexistentkey\]"
-    And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for .*repomd.xml.asc \[Couldn't open file .*repomd.xml.asc\]"
+    And stderr contains "  - Curl error \(37\): Could not read a file:// file for file:///nonexistentkey \[Couldn't open file /nonexistentkey\]"
+    And stderr contains "  - Curl error \(37\): Could not read a file:// file for .*repomd.xml.asc \[Couldn't open file .*repomd.xml.asc\]"
     And stderr contains "Error: Failed to retrieve GPG key for repo 'dnf-ci-fedora'"
     And stderr contains "Ignoring repositories: dnf-ci-fedora"
 
@@ -160,16 +160,16 @@ Scenario: Mirrorlist with invalid mirrors
    When I execute dnf with args "makecache"
    Then the exit code is 1
     And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
-    And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
-    And stderr contains "  - Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Couldn't connect to server\]"
-    And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
+    And stderr contains "  - Curl error \(37\): Could not read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
+    And stderr contains "  - Curl error \(7\): Could not connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Could not connect to server\]"
+    And stderr contains "  - Curl error \(37\): Could not read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
     And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
    When I execute dnf with args "makecache --setopt=*.skip_if_unavailable=1"
    Then the exit code is 0
     And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
-    And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
-    And stderr contains "  - Curl error \(7\): Couldn't connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Couldn't connect to server\]"
-    And stderr contains "  - Curl error \(37\): Couldn't read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
+    And stderr contains "  - Curl error \(37\): Could not read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
+    And stderr contains "  - Curl error \(7\): Could not connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Could not connect to server\]"
+    And stderr contains "  - Curl error \(37\): Could not read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[Couldn't open file /nonexistent.repo/repodata/repomd.xml\]"
     And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
     And stderr contains "Ignoring repositories: dnf-ci-fedora"
 


### PR DESCRIPTION
Error messages in new curl changed and the test needed to be updated. The diffs were mostly "Couldn't" -> "Could not" and "host name" -> "hostname"