### PR TITLE
Consistently use "removing" instead of "erasing" packages

### DIFF
--- a/dnf-behave-tests/dnf/resolve-hints.feature
+++ b/dnf-behave-tests/dnf/resolve-hints.feature
@@ -93,7 +93,7 @@ Scenario: --allowerasing is hinted on attempt to install conflicting packages
           - conflicting requests
         You can try to add to command line:
           --skip-unavailable to skip unavailable packages
-          --allowerasing to allow erasing of installed packages to resolve problems
+          --allowerasing to allow removing of installed packages to resolve problems
           --skip-broken to skip uninstallable packages
         """
 


### PR DESCRIPTION
Adapt "--allowerasing is hinted on attempt to install conflicting packages" dnf/resolve-hints.feature scenario to a changed output of the conflict hint. The output was changed in "Consistently use "removing" instead of "erasing" packages" DNF5 commit.

Related: https://github.com/rpm-software-management/dnf5/pull/1732