### PR TITLE
Lowercase branches when constructing an image identifier

### DIFF
--- a/plans/integration/behave-createrepo_c.fmf
+++ b/plans/integration/behave-createrepo_c.fmf
@@ -5,4 +5,4 @@ execute:
     script: |
         $TMT_PLANS_DATA/ci-dnf-stack/container-test \
         --suite createrepo_c \
-        -c container-test-$PACKIT_SOURCE_BRANCH-$PACKIT_TARGET_BRANCH run
+        -c container-test-${PACKIT_SOURCE_BRANCH,,?}-${PACKIT_TARGET_BRANCH,,?} run

--- a/plans/integration/behave-dnf.fmf
+++ b/plans/integration/behave-dnf.fmf
@@ -4,5 +4,5 @@ execute:
     how: tmt
     script: |
         $TMT_PLANS_DATA/ci-dnf-stack/container-test \
-        -c container-test-$PACKIT_SOURCE_BRANCH-$PACKIT_TARGET_BRANCH run
+        -c container-test-${PACKIT_SOURCE_BRANCH,,?}-${PACKIT_TARGET_BRANCH,,?} run
 

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -27,7 +27,7 @@ prepare:
       how: shell
       script: |
         $TMT_PLANS_DATA/ci-dnf-stack/container-test \
-        -c container-test-$PACKIT_SOURCE_BRANCH-$PACKIT_TARGET_BRANCH build \
+        -c container-test-${PACKIT_SOURCE_BRANCH,,?}-${PACKIT_TARGET_BRANCH,,?} build \
         --base $( echo "$@distro" | tr '-' ':') \
         --container-arg="--env=COPR=$PACKIT_COPR_PROJECT" \
         --container-arg="--env=COPR_RPMS=$PACKIT_COPR_RPMS"


### PR DESCRIPTION
Executing a pull request test from a branch with upper case letters ended up with this error:

        Command '/var/ARTIFACTS/work-behave-createrepo_crye9wxe5/plans/integration/behave-createrepo_c/tree/tmt-prepare-wrapper.sh-Build-testing-container-default-0' returned 1.

        stderr (2 lines)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        Error: tag container-test-unistd-for-STDOUT_FILENO-master: invalid reference format: repository name must be lowercase
        Error: Failed to build the container.
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

The cause was that -c argument of container-test script was built from a "container-test-unistd-for-STDOUT_FILENO" branch name. The container-test -c value is then directly passed as an image identifier to podman build and podman run commands. Problem is that podman, as well as docker, does not allow upper-case characters in the OCI identifier.

I wanted to circumvent it in the container-test script, to have a fix at one place. But one can pass a tag name there (foo/bar:tag) and the tag is handled case sensitively by docker.

So this patch fixes it on the invocation side.

NOTE: I could not really test it. I only tried a prepare phase of locally run TMT and it correctly transliterated the branch names. You should be able to fix by rerunning tests for
<https://github.com/rpm-software-management/createrepo_c/pull/439>.