### PR TITLE
revise config.feature for dnf5

### DIFF
--- a/dnf-behave-tests/dnf/config.feature
+++ b/dnf-behave-tests/dnf/config.feature
@@ -204,12 +204,10 @@ Scenario: Create dnf.conf file and test if host is using /etc/dnf/dnf.conf
     """
    When I execute dnf with args "install vagare"
    Then the exit code is 1
-    And stderr is
-        """
-        <REPOSYNC>
-        Failed to resolve the transaction:
-        Argument 'vagare' matches only excluded packages.
-        """
+    # rhsm plugin is polluting stderr with messages, we cannot use "stderr is" step
+    # librhsm-WARNING **: 12:59:28.478: Found 0 entitlement certificates
+    # librhsm-WARNING **: 12:59:28.478: Found 0 product certificates
+    And stderr contains "Argument 'vagare' matches only excluded packages."
 
 
 @dnf5
@@ -234,12 +232,10 @@ Scenario: Create dnf.conf file and test if host is taking option --config /test/
         | install-dep   | labirinto-1.0-1.fc29.x86_64           |
    When I execute dnf with args "--config /test/dnf.conf install dedalo-signed"
    Then the exit code is 1
-    And stderr is
-        """
-        <REPOSYNC>
-        Failed to resolve the transaction:
-        Argument 'dedalo-signed' matches only excluded packages.
-        """
+    # rhsm plugin is polluting stderr with messages, we cannot use "stderr is" step
+    # librhsm-WARNING **: 12:59:28.478: Found 0 entitlement certificates
+    # librhsm-WARNING **: 12:59:28.478: Found 0 product certificates
+    And stderr contains "Argument 'dedalo-signed' matches only excluded packages."
 
 
 @dnf5

--- a/dnf-behave-tests/dnf/config.feature
+++ b/dnf-behave-tests/dnf/config.feature
@@ -1,19 +1,20 @@
 Feature: DNF config files testing
 
 
+@dnf5
 Scenario: Test removal of dependency when clean_requirements_on_remove=false
   Given I use repository "dnf-ci-fedora"
     And I configure dnf with
         | key                          | value      |
         | exclude                      | filesystem |
         | clean_requirements_on_remove | False      |
-    When I execute dnf with args "install --disableexcludes=main filesystem"
+   When I execute dnf with args "install --setopt=disable_excludes=main filesystem"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                           |
         | install       | filesystem-0:3.9-2.fc29.x86_64    |
         | install-dep   | setup-0:2.12.1-1.fc29.noarch      |
-   When I execute dnf with args "remove --disableexcludes=all filesystem"
+   When I execute dnf with args "remove --setopt=disable_excludes=* filesystem"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                           |

--- a/dnf-behave-tests/dnf/config.feature
+++ b/dnf-behave-tests/dnf/config.feature
@@ -60,6 +60,7 @@ Scenario: Test with dnf.conf in installroot and --config (dnf.conf is taken from
         """
 
 
+@dnf5
 Scenario: Reposdir option in dnf.conf file in installroot
   Given I configure dnf with
         | key      | value      |
@@ -76,6 +77,7 @@ Scenario: Reposdir option in dnf.conf file in installroot
         | install-dep   | setup-0:2.12.1-1.fc29.noarch      |
 
 
+@dnf5
 Scenario: Reposdir option in dnf.conf file with --config option in installroot
   Given I create file "/test/dnf.conf" with
     """
@@ -94,6 +96,7 @@ Scenario: Reposdir option in dnf.conf file with --config option in installroot
         | install-dep   | setup-0:2.12.1-1.fc29.noarch      |
 
 
+@dnf5
 Scenario: Reposdir option set by --setopt
   Given I configure a new repository "testrepo" in "{context.dnf.installroot}/testrepos" with
         | key     | value                                                   |
@@ -151,6 +154,8 @@ Scenario: Lines that contain only whitespaces do not spoil previous config optio
    """
 
 
+# dnf5 does not support remote config files
+# https://github.com/rpm-software-management/dnf5/issues/1767
 @bz1721091
 Scenario: Dnf can use config file from remote location
   Given I create directory "/remotedir"
@@ -188,6 +193,7 @@ Scenario: Dnf prints reasonable error when remote config file is not downloadabl
    And stderr contains "Configuration file.*not found"
 
 
+@dnf5
 @no_installroot
 Scenario: Create dnf.conf file and test if host is using /etc/dnf/dnf.conf
   Given I use repository "simple-base"
@@ -198,17 +204,15 @@ Scenario: Create dnf.conf file and test if host is using /etc/dnf/dnf.conf
     """
    When I execute dnf with args "install vagare"
    Then the exit code is 1
-    And stdout is
-        """
-        All matches were filtered out by exclude filtering for argument: vagare
-        """
     And stderr is
         """
         <REPOSYNC>
-        Error: Unable to find a match: vagare
+        Failed to resolve the transaction:
+        Argument 'vagare' matches only excluded packages.
         """
 
 
+@dnf5
 @no_installroot
 Scenario: Create dnf.conf file and test if host is taking option --config /test/dnf.conf file
   Given I use repository "simple-base"
@@ -230,14 +234,11 @@ Scenario: Create dnf.conf file and test if host is taking option --config /test/
         | install-dep   | labirinto-1.0-1.fc29.x86_64           |
    When I execute dnf with args "--config /test/dnf.conf install dedalo-signed"
    Then the exit code is 1
-    And stdout is
-        """
-        All matches were filtered out by exclude filtering for argument: dedalo-signed
-        """
     And stderr is
         """
         <REPOSYNC>
-        Error: Unable to find a match: dedalo-signed
+        Failed to resolve the transaction:
+        Argument 'dedalo-signed' matches only excluded packages.
         """
 
 
@@ -285,6 +286,7 @@ Scenario: dnf.conf is taken from host if --use-host-config is used
     """
 
 
+@dnf5
 @no_installroot
 Scenario: Reposdir option in dnf.conf file in host
   Given I configure dnf with


### PR DESCRIPTION
- there still is one failing scenario (remote config files, https://github.com/rpm-software-management/dnf5/issues/1767)
- passing scenarios were tagged with dnf5 (with some small adjustments)
- dnf5 does not support automatic search of the config file in host/installroot location, such tests were dropped / replaced with test for `--use-host-config` option