### PR TITLE
Fix expected repodata file names because of different compression format

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/reposync.feature
+++ b/dnf-behave-tests/dnf/plugins-core/reposync.feature
@@ -327,7 +327,7 @@ Scenario: Reposync with --norepopath and --metadata-path ad --download-metadata 
   Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --norepopath --metadata-path={context.dnf.tempdir}/downloadedmetadata --download-metadata"
    Then the exit code is 0
-    And the text file contents of "/{context.dnf.tempdir}/downloadedmetadata/repodata/primary.xml.zst" and "/{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/primary.xml.zst" do not differ
+    And the files "{context.dnf.tempdir}/downloadedmetadata/repodata/primary.xml.gz" and "{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/primary.xml.gz" do not differ
 
 
 @RHEL-40914
@@ -335,7 +335,7 @@ Scenario: Reposync with --norepopath and --metadata-path ad --downloadcomps opti
   Given I use repository "dnf-ci-thirdparty-updates" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --norepopath --metadata-path={context.dnf.tempdir}/downloadedmetadata --downloadcomps"
    Then the exit code is 0
-    And the text file contents of "/{context.dnf.tempdir}/downloadedmetadata/comps.xml" and "/{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/comps.xml.zst" do not differ
+    And the text file contents of "/{context.dnf.tempdir}/downloadedmetadata/comps.xml" and "/{context.dnf.fixturesdir}/repos/dnf-ci-thirdparty-updates/repodata/comps.xml" do not differ
 
 
 @bz1856818


### PR DESCRIPTION
There is a different createrepo_c compression default on RHEL 9 and CentOS Stream 9 than on Fedora.

The change in reposync tests was done first in commit 8a88d356a4d9ba4b86192b315d7dc8847366ef3c , and the tests for RHEL-40914 on the testing branch used for Fedora were done according to that. This fixes the tests for RHEL and CentOS Stream.