### PR TITLE
Add obsoletes tests for yum behavior

### DIFF
--- a/dnf-behave-tests/dnf/install-obsoletes.feature
+++ b/dnf-behave-tests/dnf/install-obsoletes.feature
@@ -146,3 +146,25 @@ Scenario: Install obsoleting package and inherit the best reason - user
         """
         glibc-0:2.28-9.fc29.x86_64
         """
+
+
+# dnf-3 fails this test, it incorrectly installs the new packages
+# as dependencies.
+Scenario: install all obsoleters (as user installed), obsoles behavior specified by `SOLVER_FLAG_YUM_OBSOLETES` libsolv flag
+  Given I use repository "obsoletes-yum"
+    And I successfully execute dnf with args "install wood-1.0"
+   When I execute dnf with args "upgrade"
+   Then the exit code is 0
+    And Transaction is following
+        | Action  | Package                    |
+        | install | copper-0:1.0-1.fc29.x86_64 |
+        | install | iron-0:1.0-1.fc29.x86_64   |
+        | upgrade | wood-0:2.0-1.fc29.x86_64   |
+   When I execute dnf with args "rq --installed --qf '%{{name}} - %{{reason}}\n'"
+   Then stdout is
+   """
+   copper - User
+   iron - User
+   wood - User
+   """
+

--- a/dnf-behave-tests/fixtures/specs/obsoletes-yum/copper-1.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/obsoletes-yum/copper-1.0-1.fc29.spec
@@ -1,0 +1,16 @@
+Name: copper
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Obsoletes: wood < 2.0
+
+%description
+copper description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/obsoletes-yum/iron-1.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/obsoletes-yum/iron-1.0-1.fc29.spec
@@ -1,0 +1,16 @@
+Name: iron
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Obsoletes: wood < 2.0
+
+%description
+iron description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/obsoletes-yum/wood-1.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/obsoletes-yum/wood-1.0-1.fc29.spec
@@ -1,0 +1,14 @@
+Name: wood
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+wood description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/obsoletes-yum/wood-2.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/obsoletes-yum/wood-2.0-1.fc29.spec
@@ -1,0 +1,16 @@
+Name: wood
+Version: 2.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Obsoletes: wood < 2.0
+
+%description
+wood description
+
+%files
+
+%changelog


### PR DESCRIPTION
In https://issues.redhat.com/browse/RHEL-61475 I have noticed `dnf-3` installed the obsoleters as `Dependency`, it seems `dnf5` handles this better.

I am not sure if it is worth it to try to fix it in `dnf-3` since I believe the situation should be quite rare.