### PR TITLE
DNF5: Ansible: Move from Fedora 38 to 39

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -2,7 +2,7 @@
 # $ podman build --build-arg TYPE=distro -t ansible -f Dockerfile.ansible
 # $ podman run --net none -it ansible ./ansible
 
-FROM fedora:38
+FROM fedora:39
 ARG TYPE=nightly
 
 # enable nightlies if requested


### PR DESCRIPTION
Fedora 38 reached end of life and Copr is going to disable a build root for. There won't be dnf-nightly repositories for it.

This patch moves the Ansicble docker file to Fedora 39 because the same version is used for testing DNF4.