### PR TITLE
Use dockerfile from the up-to-date dnf-4-stack branch

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -28,6 +28,7 @@ prepare:
       script: |
         $TMT_PLANS_DATA/ci-dnf-stack/container-test \
         -c container-test-${PACKIT_SOURCE_BRANCH,,?}-${PACKIT_TARGET_BRANCH,,?} build \
+        --file $TMT_PLANS_DATA/ci-dnf-stack/Dockerfile \
         --base $( echo "$@distro" | tr '-' ':') \
         --container-arg="--env=COPR=$PACKIT_COPR_PROJECT" \
         --container-arg="--env=COPR_RPMS=$PACKIT_COPR_RPMS"


### PR DESCRIPTION
Otherwise it uses dockerfile from the current work directory which is the outdated dockerfile from this branch (`enable-tmt-dnf-4-stack`).

This ensures changes from https://github.com/rpm-software-management/ci-dnf-stack/commit/8532ca86767ed83b08d400e45432faff8d17a9cd take effect.