### PR TITLE
Update `Dockerfile.ansible` to fc40 to match CI tests

### DIFF
--- a/Dockerfile.ansible
+++ b/Dockerfile.ansible
@@ -2,7 +2,7 @@
 # $ podman build --build-arg TYPE=distro -t ansible -f Dockerfile.ansible
 # $ podman run --net none -it ansible ./ansible
 
-FROM fedora:39
+FROM fedora:40
 ARG TYPE=nightly
 
 # enable nightlies if requested


### PR DESCRIPTION
The same builds are used for both CI and ansible tests, their fedora versions have to match to be able to install tested packages.