### PR TITLE
Remove double definition of not.with_os because it doesn't work

### DIFF
--- a/dnf-behave-tests/createrepo_c/delta-rpms.feature
+++ b/dnf-behave-tests/createrepo_c/delta-rpms.feature
@@ -1,5 +1,4 @@
 @not.with_os=rhel__ge__9
-@not.with_os=fedora__ge__39
 Feature: Tests createrepo_c generating delta rpms
 
 


### PR DESCRIPTION
The definition of not.with_os doesn't work when it's defined twice. Let's remove the @not.with_os=fedora__ge__39 because it doesn't matter for rhel-10.0 branch anyway