### PR TITLE
Disable new dnf-automatic test on Fedora >= 41

### DIFF
--- a/dnf-behave-tests/dnf/dnf-automatic/error-report.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/error-report.feature
@@ -31,6 +31,9 @@ Scenario: dnf-automatic reports an error when package installation failed
     Error: Transaction failed
     """
 
+
+# dnf-automatic disabled by https://github.com/rpm-software-management/dnf/pull/2129
+@not.with_os=fedora__ge__41
 # https://github.com/rpm-software-management/dnf/issues/1918
 # https://issues.redhat.com/browse/RHEL-61882
 Scenario: emitters can report errors if configured by send_error_messages = yes


### PR DESCRIPTION
The old dnf-automatic builds are disabled on Fedora >= 41.