### PR TITLE
Fix disable dnf-automatic test on Fedora >= 41

### DIFF
--- a/dnf-behave-tests/dnf/dnf-automatic/config.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/config.feature
@@ -1,4 +1,7 @@
+# dnf-automatic disabled by https://github.com/rpm-software-management/dnf/pull/2129
+@not.with_os=fedora__ge__41
 Feature: dnf-automatic configuration files testing
+
 
 # https://issues.redhat.com/browse/RHEL-46030
 Scenario: dnf-automatic fails if non-existing config file is specified

--- a/dnf-behave-tests/dnf/dnf-automatic/error-report.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/error-report.feature
@@ -32,8 +32,6 @@ Scenario: dnf-automatic reports an error when package installation failed
     """
 
 
-# dnf-automatic disabled by https://github.com/rpm-software-management/dnf/pull/2129
-@not.with_os=fedora__ge__41
 # https://github.com/rpm-software-management/dnf/issues/1918
 # https://issues.redhat.com/browse/RHEL-61882
 Scenario: emitters can report errors if configured by send_error_messages = yes


### PR DESCRIPTION
In 7c48bc7076054417c6b9293c3a3ea5f9a1e04f04 I disabled already disabled tests :facepalm: , fix it by disabling the correct one.

There are also some failing rawhide copr tests but that would need separate investigation. I have created a new issue for that: https://github.com/rpm-software-management/ci-dnf-stack/issues/1606