### PR TITLE
Use "OpenPGP" instead of "PGP" in distro-sync, gpg

### DIFF
--- a/dnf-behave-tests/dnf/distro-sync.feature
+++ b/dnf-behave-tests/dnf/distro-sync.feature
@@ -67,8 +67,8 @@ Given I use repository "dnf-ci-gpg"
  Then the exit code is 1
   And stderr contains lines matching
     """
-    Transaction failed: Signature verification failed.
-    PGP check for package "wget-2\.0\.0-1\.fc29\.x86_64" \(.*/wget-2.0.0-1.fc29.x86_64.rpm\) from repo "dnf-ci-gpg-updates" has failed: Problem occurred when opening the package.
+    Transaction failed: Signature verification failed\.
+    OpenPGP check for package "wget-2\.0\.0-1\.fc29\.x86_64" \(.*/wget-2.0.0-1.fc29.x86_64.rpm\) from repo "dnf-ci-gpg-updates" has failed: Problem occurred when opening the package\.
     """
 
 
@@ -86,8 +86,8 @@ Given I use repository "dnf-ci-gpg"
  Then the exit code is 1
   And stderr contains lines matching
     """
-    Transaction failed: Signature verification failed.
-    PGP check for package "wget-2\.0\.0-1\.fc29\.x86_64" \(.*/wget-2.0.0-1.fc29.x86_64.rpm\) from repo "dnf-ci-gpg-updates" has failed: Problem occurred when opening the package.
+    Transaction failed: Signature verification failed\.
+    OpenPGP check for package "wget-2\.0\.0-1\.fc29\.x86_64" \(.*/wget-2.0.0-1.fc29.x86_64.rpm\) from repo "dnf-ci-gpg-updates" has failed: Problem occurred when opening the package\.
     """
 
 

--- a/dnf-behave-tests/dnf/gpg.feature
+++ b/dnf-behave-tests/dnf/gpg.feature
@@ -83,8 +83,8 @@ Scenario Outline: Fail to <offline> install signed package with incorrectly sign
     And RPMDB Transaction is empty
     And stderr contains lines matching
     """
-    Transaction failed: Signature verification failed
-    PGP check for package "basesystem-11-6\.fc29\.noarch" \(.*/basesystem-11-6\.fc29\.noarch\.rpm\) from repo "dnf-ci-gpg" has failed: Public key is not installed\.
+    Transaction failed: Signature verification failed\.
+    OpenPGP check for package "basesystem-11-6\.fc29\.noarch" \(.*/basesystem-11-6\.fc29\.noarch\.rpm\) from repo "dnf-ci-gpg" has failed: Public key is not installed\.
     """
 
 Examples:
@@ -103,8 +103,8 @@ Scenario Outline: Fail to <offline> install signed package with incorrect checks
     And RPMDB Transaction is empty
     And stderr contains lines matching
     """
-    Transaction failed: Signature verification failed
-    PGP check for package "broken-package-0\.2\.4-1\.fc29\.noarch" \(.*/broken-package-0\.2\.4-1\.fc29\.noarch\.rpm\) from repo "dnf-ci-gpg" has failed: Problem occurred when opening the package\.
+    Transaction failed: Signature verification failed\.
+    OpenPGP check for package "broken-package-0\.2\.4-1\.fc29\.noarch" \(.*/broken-package-0\.2\.4-1\.fc29\.noarch\.rpm\) from repo "dnf-ci-gpg" has failed: Problem occurred when opening the package\.
     """
 
 Examples:
@@ -141,8 +141,8 @@ Scenario Outline: Attempt to <offline> install unsigned package from repo with g
    Then the exit code is 1
     And stderr contains lines matching
     """
-    Transaction failed: Signature verification failed
-    PGP check for package "flac-1\.3\.2-8\.fc29\.x86_64" \(.*/flac-1\.3\.2-8\.fc29\.x86_64\.rpm\) from repo "dnf-ci-gpg" has failed: The package is not signed\.
+    Transaction failed: Signature verification failed\.
+    OpenPGP check for package "flac-1\.3\.2-8\.fc29\.x86_64" \(.*/flac-1\.3\.2-8\.fc29\.x86_64\.rpm\) from repo "dnf-ci-gpg" has failed: The package is not signed\.
     """
 
 Examples:

--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -257,7 +257,7 @@ def then_stdout_contains_lines_matching(context):
     test_lines = context.text.split('\n')
     for line in test_lines:
         for outline in out_lines:
-            if re.search(line.strip(), outline.strip()):
+            if re.search("^" + line.strip() + "$", outline.strip()):
                 break
         else:
             raise AssertionError("Stderr doesn't contain line matching: %s" % line)
@@ -321,7 +321,7 @@ def then_stderr_contains_lines_matching(context):
     test_lines = context.text.split('\n')
     for line in test_lines:
         for outline in out_lines:
-            if re.search(line.strip(), outline.strip()):
+            if re.search("^" + line.strip() + "$", outline.strip()):
                 break
         else:
             raise AssertionError("Stderr doesn't contain line matching: %s" % line)


### PR DESCRIPTION
Following up from this comment: https://github.com/rpm-software-management/ci-dnf-stack/pull/1601#pullrequestreview-2483708419.

These lines do use `.*` in some places, so instead of converting them to `stderr contains lines`, I added `^` and `$` to further constrain the regex.