### PR TITLE
Add extended test for installonly packages

### DIFF
--- a/dnf-behave-tests/dnf/installonly.feature
+++ b/dnf-behave-tests/dnf/installonly.feature
@@ -273,6 +273,55 @@ Scenario: Do not remove or change reason after remove of one of installonly pack
         | action  | package                               | reason | repository |
         | Remove  | kernel-core-0:4.19.15-300.fc29.x86_64 | User   | @System    |
 
+# https://issues.redhat.com/browse/RHEL-15902
+# The test expects that installed packages in pool are in order in which they were installed. This is required for fail
+# without patch but it is not guaranteed by RPM
+Scenario: Do not remove or change reason after remove of one of installonly packages - more complex
+   When I execute dnf with args "install abcde"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | install       | abcde-0:2.9.2-1.fc29.noarch           |
+        | install-dep   | wget-0:1.19.5-5.fc29.x86_64           |
+        | install-weak  | flac-0:1.3.2-8.fc29.x86_64            |
+   # We need to have a different packages then kernel installed and with a different reasons then user to ensure that
+   # the "kernel" package reason is unexpectedly inherited from "abcde" package. The package abcd or its dependencies
+   # must  be installed first to ensure that they will be in the first position in query and not the kernel package.
+   When I execute dnf with args "mark remove abcde"
+   Then the exit code is 0
+    And package reasons are
+        | Package                                | Reason          |
+        | abcde-2.9.2-1.fc29.noarch              | dependency      |
+        | flac-1.3.2-8.fc29.x86_64               | weak-dependency |
+        | wget-1.19.5-5.fc29.x86_64              | dependency      |
+  Given I use repository "dnf-ci-fedora-updates"
+   When I execute dnf with args "install kernel-core-0:4.18.16-300.fc29.x86_64 kernel-core-0:4.19.15-300.fc29.x86_64"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | install       | kernel-core-0:4.18.16-300.fc29.x86_64 |
+        | install       | kernel-core-0:4.19.15-300.fc29.x86_64 |
+   When I execute dnf with args "upgrade kernel-core"
+   Then the exit code is 0
+    And package reasons are
+        | Package                                | Reason          |
+        | abcde-2.9.2-1.fc29.noarch              | dependency      |
+        | flac-1.3.2-8.fc29.x86_64               | weak-dependency |
+        | kernel-core-4.18.16-300.fc29.x86_64    | user            |
+        | kernel-core-4.19.15-300.fc29.x86_64    | user            |
+        | wget-1.19.5-5.fc29.x86_64              | dependency      |
+   When I execute dnf with args "remove kernel-core-0:4.19.15-300.fc29.x86_64"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | remove        | kernel-core-0:4.19.15-300.fc29.x86_64 |
+        | unchanged     | kernel-core-0:4.18.16-300.fc29.x86_64 |
+    And package reasons are
+        | Package                                 | Reason          |
+        |  abcde-2.9.2-1.fc29.noarch              | dependency      |
+        |  flac-1.3.2-8.fc29.x86_64               | weak-dependency |
+        |  kernel-core-4.18.16-300.fc29.x86_64    | user            |
+        |  wget-1.19.5-5.fc29.x86_64              | dependency      |
 
 # TODO(jkolarik): autoremove not yet available in dnf5
 # @dnf5


### PR DESCRIPTION
Upstream commit: b2a97d200cce0deaeb437f50eced056636d5b415

The original test is ok, but this test is for a random behavior of the code, therefore it uses more additional packages in test to triger random behavior.

Backport notes: "dnf5 transaction items for transaction" steps removed bacause its specific to dnf5.

Required for: https://issues.redhat.com/browse/RHEL-15902