### PR TITLE
Disable new dnf-automatic test on Fedora >= 41

### DIFF
--- a/dnf-behave-tests/dnf/dnf-automatic/reboot.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/reboot.feature
@@ -1,3 +1,5 @@
+@not.with_os=fedora__ge__41
+# dnf-automatic disabled by https://github.com/rpm-software-management/dnf/pull/2129
 @no_installroot
 Feature: dnf-automatic reboots
 


### PR DESCRIPTION
While merging https://github.com/rpm-software-management/ci-dnf-stack/pull/1610 I **again** forgot that the dnf-automatic tests can't run on fedora >= 41.