### PR TITLE
Fix microdnf/reinstall-not-installed.feature

### DIFF
--- a/dnf-behave-tests/dnf/microdnf/reinstall-not-installed.feature
+++ b/dnf-behave-tests/dnf/microdnf/reinstall-not-installed.feature
@@ -13,5 +13,5 @@ Scenario: Reinstall an RPM that is available, but not installed
     And RPMDB Transaction is empty
     And stdout is
         """
-        Package for argument CQRlib available, but not installed.
+        No match for argument: CQRlib
         """


### PR DESCRIPTION
Currently it tests the stdout for dnf output, but the test is for microdnf. The output of microdnf is different.