### PR TITLE
automatic: Tests for error reporting and no updates functionality

### DIFF
--- a/dnf-behave-tests/dnf/dnf-automatic/emit-no-updates.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/emit-no-updates.feature
@@ -1,0 +1,21 @@
+@dnf5
+Feature: dnf-automatic does not emit when no updates are available
+
+
+Scenario: dnf-automatic does not emit when no updates are available
+   When I execute dnf with args "automatic --installupdates"
+   Then the exit code is 0
+    And Transaction is empty
+    And stdout is empty
+
+
+Scenario: dnf-automatic emits message when no updates are available when emit_no_updates is on
+  Given I create file "/etc/dnf/automatic.conf" with
+    """
+    [emitters]
+    emit_no_updates = yes
+    """
+   When I execute dnf with args "automatic --installupdates"
+   Then the exit code is 0
+    And Transaction is empty
+    And stdout contains "No new upgrades available."

--- a/dnf-behave-tests/dnf/dnf-automatic/error-report.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/error-report.feature
@@ -1,0 +1,45 @@
+@dnf5
+Feature: dnf-automatic reports an error when transaction failed
+
+
+Background:
+Given I use repository "dnf-ci-automatic-update"
+
+
+# First, install the "test-1.0" package, which should proceed successfully.
+# Then, attempt to update to "test-1.1", which contains a broken scriptlet.
+# An error should be reported during the installation of the update.
+@bz2170093
+Scenario: dnf-automatic reports an error when package installation failed
+  Given I successfully execute dnf with args "install test-1.0"
+   When I execute dnf with args "automatic --installupdates"
+   Then the exit code is 1
+    And RPMDB Transaction is empty
+    And stdout contains "Failed to install upgrades."
+    And stdout contains "Error in pre-install scriptlet"
+    And stdout contains "Transaction failed: Rpm transaction failed."
+
+# https://github.com/rpm-software-management/dnf/issues/1918
+# https://issues.redhat.com/browse/RHEL-61882
+Scenario: emitters report errors by default
+  Given I create and substitute file "/etc/dnf/automatic.conf" with
+    """
+    [commands]
+    download_updates = yes
+    apply_updates = yes
+
+    [emitters]
+    emit_via = command_email
+
+    [command_email]
+    command_format = "echo {{body}} > {context.dnf.tempdir}/dnf_error"
+    """
+    And I successfully execute dnf with args "install test-1.0"
+    And file "/{context.dnf.tempdir}/dnf_error" does not exist
+   When I execute dnf with args "automatic --installupdates"
+   Then the exit code is 1
+    And RPMDB Transaction is empty
+    And file "/{context.dnf.tempdir}/dnf_error" contains lines
+    """
+    Transaction failed: Rpm transaction failed.
+    """

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-automatic-update/test-1.0-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-automatic-update/test-1.0-1.spec
@@ -1,0 +1,16 @@
+Name:           test
+Epoch:          0
+Version:        1.0
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for dnf-automatic updates testing.
+
+%description
+Installs correctly.
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-automatic-update/test-1.1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-automatic-update/test-1.1-1.spec
@@ -1,0 +1,19 @@
+Name:           test
+Epoch:          0
+Version:        1.1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        The made up package for dnf-automatic updates testing.
+
+%description
+Fails on pre scriptlet.
+
+%pre -p <lua>
+error("failing on pre scriptlet", 1)
+
+%files
+
+%changelog


### PR DESCRIPTION
- Porting https://github.com/rpm-software-management/ci-dnf-stack/pull/1603 to dnf5.
- Porting https://github.com/rpm-software-management/ci-dnf-stack/pull/1251 to dnf5.
- Covering CI tests for the no updates functionality which requires: https://github.com/rpm-software-management/dnf5/pull/1884.