### PR TITLE
Install systemd package early

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ COPY ./repos.d/ /etc/yum.repos.d/
 # enable dnf5
 RUN set -x && \
     dnf -y --refresh upgrade; \
+    # Since Fedora 42, `systemd-standalone-sysuser` comes pre-installed.  This package 
+    # conflicts with `systemd`, preventing `dnf5daemon-server` from being installed.
+    dnf -y install systemd --allowerasing; \
     dnf -y install dnf5 dnf5-plugins; \
     dnf5 -y copr enable rpmsoftwaremanagement/test-utils; \
     dnf5 -y copr enable rpmsoftwaremanagement/dnf-nightly; \


### PR DESCRIPTION
Since version 42 Fedora comes with pre-installed
systemd-standalone-sysusers package which conflicts with systemd
package which prevents dnf5daemon-server from being installed.

See errors during the container build here: https://artifacts.dev.testing-farm.io/8d2a79aa-95f5-41b4-b09c-42e6f65a5ede/