### PR TITLE
Command clean: Must not remove files outside cache

### DIFF
--- a/dnf-behave-tests/dnf/clean-cachefiles.feature
+++ b/dnf-behave-tests/dnf/clean-cachefiles.feature
@@ -35,6 +35,27 @@ Scenario: Cleanup of the whole cache (dnf clean all)
    """
 
 
+Scenario: Cleanup of the whole cache, cache contains link pointing outside, content outside the cache must not be cleaned!
+  # Creating a directory and files outside the cache
+  Given I create directory "/tmp/user_dir"
+    And I create file "/tmp/user_dir/user_file1" with
+    """
+    User data 1
+    """
+    And I create file "/tmp/user_file2" with
+    """
+    User data 2
+    """
+    # Poison the cache, add symbolic links pointing to the directory and file outside the cache
+    And I execute "ln -s {context.dnf.installroot}/tmp/user_dir `ls -d simple-base-*`/packages/link_outside1" in "{context.dnf.installroot}/var/cache/dnf"
+    And I execute "ln -s {context.dnf.installroot}/tmp/user_file2 `ls -d simple-base-*`/packages/link_outside2" in "{context.dnf.installroot}/var/cache/dnf"
+   When I execute dnf with args "clean all"
+   Then the exit code is 0
+    And directory "/var/cache/dnf" is empty
+    And file "/tmp/user_dir/user_file1" exists
+    And file "/tmp/user_file2" exists
+
+
 Scenario: Cached metadata cleanup (dnf clean metadata)
    When I execute dnf with args "clean metadata"
    Then the exit code is 0


### PR DESCRIPTION
The cache contains symbolic links outside the cache. The `clean all` command must clean the entire cache, including symbolic links. However, it must not remove content (files, directories) outside the cache to which the links point.

Requires: https://github.com/rpm-software-management/dnf5/pull/2074