### PR TITLE
Tests for correct from_repo after offline transactions

### DIFF
--- a/dnf-behave-tests/dnf/offline.feature
+++ b/dnf-behave-tests/dnf/offline.feature
@@ -257,3 +257,16 @@ Given I use repository "simple-base"
   And Transaction is following
       | Action        | Package                       |
       | install       | labirinto-0:1.0-1.fc29.x86_64 |
+
+
+# https://github.com/rpm-software-management/dnf5/issues/1851
+Scenario: After an offline transaction, installed packages have correct from_repo
+Given I successfully execute dnf with args "install --offline flac"
+  And I successfully execute dnf with args "offline reboot"
+  And I successfully execute dnf with args "offline _execute"
+ When I execute dnf with args "repoquery --installed --queryformat="%{{full_nevra}} %{{from_repo}}\n" flac"
+ Then the exit code is 0
+  And stdout is
+      """
+      flac-0:1.3.2-8.fc29.x86_64 dnf-ci-fedora
+      """

--- a/dnf-behave-tests/dnf/system-upgrade.feature
+++ b/dnf-behave-tests/dnf/system-upgrade.feature
@@ -220,3 +220,20 @@ Examples:
       | option            |
       | --setopt=cachedir |
       | --setopt=system_cachedir |
+
+
+# https://github.com/rpm-software-management/dnf5/issues/1851
+Scenario: After the system-upgrade, packages from_repo contains correct repo_id
+Given I successfully execute dnf with args "system-upgrade download"
+  And I successfully execute dnf with args "system-upgrade reboot"
+  And I stop http server for repository "system-upgrade-f$releasever"
+  And I stop http server for repository "system-upgrade-2-f$releasever"
+  And I successfully execute dnf with args "offline _execute"
+ When I execute dnf with args "repoquery --installed --queryformat="%{{full_nevra}} %{{from_repo}}\n" pkg-a pkg-both pkg-b"
+ Then the exit code is 0
+  And stdout is
+  """
+  pkg-a-0:2.0-1.noarch system-upgrade-f30
+  pkg-b-0:1.0-1.noarch system-upgrade-f30
+  pkg-both-0:2.0-1.noarch system-upgrade-f30
+  """


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf5/pull/2093