### PR TITLE
Backport dnf5 tests for upgrading packages when removed from groups

### DIFF
--- a/dnf-behave-tests/dnf/comps-upgrade.feature
+++ b/dnf-behave-tests/dnf/comps-upgrade.feature
@@ -327,3 +327,37 @@ Scenario: Upgrade nonexistent and existent group
     And Transaction is following
         | Action        | Package                            |
         | group-upgrade | empty-group                        |
+
+
+Scenario: Upgrade group and a package that was removed from the group at the same time
+  Given I successfully execute dnf with args "group install AB-group"
+    And I drop repository "comps-upgrade-1"
+    And I use repository "comps-upgrade-2"
+   When I execute dnf with args "upgrade @AB-group A-mandatory"
+   Then the exit code is 0
+    And DNF Transaction is following
+        | Action        | Package                            |
+        | upgrade       | A-mandatory-0:2.0-1.x86_64         |
+        | install-group | B-mandatory-0:1.0-1.x86_64         |
+        | install-group | B-default-0:1.0-1.x86_64           |
+        | install-group | B-conditional-true-0:1.0-1.x86_64  |
+        | group-upgrade | AB-group                           |
+
+
+Scenario: Upgrade environment and a group that was removed from the environment at the same time
+  Given I successfully execute dnf with args "group install AB-environment"
+    And I drop repository "comps-upgrade-1"
+    And I use repository "comps-upgrade-2"
+   When I execute dnf with args "group upgrade AB-environment a-group"
+   Then the exit code is 0
+    And DNF Transaction is following
+        | Action        | Package                           |
+        | upgrade       | A-mandatory-0:2.0-1.x86_64        |
+        | upgrade       | A-default-0:2.0-1.x86_64          |
+        | upgrade       | A-conditional-true-0:2.0-1.x86_64 |
+        | install-group | B-mandatory-0:1.0-1.x86_64        |
+        | install-group | B-default-0:1.0-1.x86_64          |
+        | install-group | B-conditional-true-0:1.0-1.x86_64 |
+        | group-upgrade | A-group - repo#2                  |
+        | group-install | B-group                           |
+        | env-upgrade   | AB-environment                    |

--- a/dnf-behave-tests/dnf/comps-upgrade.feature
+++ b/dnf-behave-tests/dnf/comps-upgrade.feature
@@ -361,3 +361,24 @@ Scenario: Upgrade environment and a group that was removed from the environment 
         | group-upgrade | A-group - repo#2                  |
         | group-install | B-group                           |
         | env-upgrade   | AB-environment                    |
+
+
+Scenario: Packages removed from a group are still upgraded during an upgrade
+  Given I successfully execute dnf with args "group install AB-group"
+    And I drop repository "comps-upgrade-1"
+    And I use repository "comps-upgrade-2"
+   When I execute dnf with args "upgrade @AB-group"
+   Then the exit code is 0
+    And DNF Transaction is following
+        | Action        | Package                            |
+        | install-group | B-mandatory-0:1.0-1.x86_64         |
+        | install-group | B-default-0:1.0-1.x86_64           |
+        | install-group | B-conditional-true-0:1.0-1.x86_64  |
+        | group-upgrade | AB-group                           |
+   When I execute dnf with args "upgrade"
+   Then the exit code is 0
+    And DNF Transaction is following
+        | Action        | Package                            |
+        | upgrade       | A-mandatory-0:2.0-1.x86_64         |
+        | upgrade       | A-default-0:2.0-1.x86_64          |
+        | upgrade       | A-conditional-true-0:2.0-1.x86_64 |


### PR DESCRIPTION
Package/group is upgraded and at the same time removed from group/env
Test that packages removed from group get upgraded