### PR TITLE
Add releasever_{major,minor} tests

### DIFF
--- a/dnf-behave-tests/dnf/vars-releasever.feature
+++ b/dnf-behave-tests/dnf/vars-releasever.feature
@@ -103,13 +103,36 @@ Scenario: Releasever is substituted in baseurl via vars in custom location
         | install       | setup-0:2.12.1-1.fc29.noarch  |
 
 
-@dnf5
 Scenario: Releasever gets split into releasever_major and releasever_minor
   Given I copy directory "{context.scenario.repos_location}/dnf-ci-fedora" to "/temp-repos/base-epel-12-34"
     And I use repository "dnf-ci-fedora" with configuration
         | key         | value |
         | baseurl     | file://{context.dnf.installroot}/temp-repos/base-epel-$releasever_major-$releasever_minor |
     And I execute dnf with args "install setup --releasever=12.34"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                       |
+        | install       | setup-0:2.12.1-1.fc29.noarch  |
+
+
+Scenario: releasever_major, releasever_minor can be overridden by command-line options
+  Given I copy directory "{context.scenario.repos_location}/dnf-ci-fedora" to "/temp-repos/base-epel-9.9-12-34"
+    And I use repository "dnf-ci-fedora" with configuration
+        | key         | value |
+        | baseurl     | file://{context.dnf.installroot}/temp-repos/base-epel-$releasever-$releasever_major-$releasever_minor |
+    And I execute dnf with args "install setup --releasever=9.9 --releasever-major=12 --releasever-minor=34"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                       |
+        | install       | setup-0:2.12.1-1.fc29.noarch  |
+
+
+Scenario: Overriden only releasever_major
+  Given I copy directory "{context.scenario.repos_location}/dnf-ci-fedora" to "/temp-repos/base-epel-12-9"
+    And I use repository "dnf-ci-fedora" with configuration
+        | key         | value |
+        | baseurl     | file://{context.dnf.installroot}/temp-repos/base-epel-$releasever_major-$releasever_minor |
+    And I execute dnf with args "install setup --releasever=9.9 --releasever-major=12"
    Then the exit code is 0
     And Transaction is following
         | Action        | Package                       |

--- a/dnf-behave-tests/dnf/vars-releasever.feature
+++ b/dnf-behave-tests/dnf/vars-releasever.feature
@@ -101,3 +101,16 @@ Scenario: Releasever is substituted in baseurl via vars in custom location
     And Transaction is following
         | Action        | Package                       |
         | install       | setup-0:2.12.1-1.fc29.noarch  |
+
+
+@dnf5
+Scenario: Releasever gets split into releasever_major and releasever_minor
+  Given I copy directory "{context.scenario.repos_location}/dnf-ci-fedora" to "/temp-repos/base-epel-12-34"
+    And I use repository "dnf-ci-fedora" with configuration
+        | key         | value |
+        | baseurl     | file://{context.dnf.installroot}/temp-repos/base-epel-$releasever_major-$releasever_minor |
+    And I execute dnf with args "install setup --releasever=12.34"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                       |
+        | install       | setup-0:2.12.1-1.fc29.noarch  |

--- a/dnf-behave-tests/dnf/vars-releasever.feature
+++ b/dnf-behave-tests/dnf/vars-releasever.feature
@@ -53,6 +53,20 @@ Scenario: Releasever is substituted in baseurl via a value detected from 'system
         | Action        | Package                       |
         | install       | setup-0:2.12.1-1.fc29.noarch  |
 
+
+Scenario: releasever_{major,minor} are substituted via values detected from 'system-release(releasever_{major,minor})' provides
+  Given I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/dnf-ci-fedora-release/noarch/fedora-release-29-1.noarch.rpm"
+    And I use repository "dnf-ci-fedora" with configuration
+        | key     | value                                                                                             |
+        | baseurl | file://{context.dnf.installroot}/temp-repos/base-f$releasever-$releasever_major-$releasever_minor |
+    And I copy directory "{context.scenario.repos_location}/dnf-ci-fedora" to "/temp-repos/base-f123-45-67"
+    And I execute dnf with args "install setup"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                       |
+        | install       | setup-0:2.12.1-1.fc29.noarch  |
+
+
 # @dnf5
 # TODO(nsella) different exit code
 @destructive

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-release/fedora-release-29-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-release/fedora-release-29-1.spec
@@ -17,6 +17,9 @@ Provides:       config(fedora-release) = 29-1
 
 # detected $releasever should be '123'
 Provides:       system-release(releasever) = 123
+# $releasever_major, $releasever_minor should be overridden to 45, 67
+Provides:       system-release(releasever_major) = 45
+Provides:       system-release(releasever_minor) = 67
 
 
 %description


### PR DESCRIPTION
Backports https://github.com/rpm-software-management/ci-dnf-stack/pull/1359 to rhel-10.0.

Adds a test for the new --releasever-major and --releasever-minor options.

Requires https://github.com/rpm-software-management/dnf/pull/2198 and https://github.com/rpm-software-management/libdnf/pull/1689.

For https://issues.redhat.com/browse/RHEL-68034.