### PR TITLE
Enable test for length of history list output outside of terminal

### DIFF
--- a/dnf-behave-tests/dnf/history-list.feature
+++ b/dnf-behave-tests/dnf/history-list.feature
@@ -207,19 +207,17 @@ Scenario: history lame (no transaction with such package)
   And stdout is empty
 
 
-@xfail
 # Reported as https://github.com/rpm-software-management/dnf5/issues/2025
 @bz1786335
 @bz1786316
 @bz1852577
 @bz1906970
-# TODO change this to actually verify stdout
-Scenario: history longer than 80 charactersi gets cut when there is no terminal
- When I execute dnf with args "history | head -1 | wc -c"
+Scenario: history table width doesn't exceed 80 characters when there is no terminal
+ When I execute dnf with args "history list | head -1"
  Then the exit code is 0
-  And stdout is
+  And stdout matches line by line
   """
-  80
+  ID Command line {1,28}Date and time       Action\(s\) Altered
   """
 
 

--- a/dnf-behave-tests/dnf/history-list.feature
+++ b/dnf-behave-tests/dnf/history-list.feature
@@ -223,19 +223,6 @@ Scenario: history longer than 80 charactersi gets cut when there is no terminal
   """
 
 
-@xfail
-# Reported as https://github.com/rpm-software-management/dnf5/issues/2025
-@bz1786335
-@bz1786316
-Scenario: history length is 80 chars when missing rows are queried
- When I execute dnf with args "history 10 | head -1 | wc -c"
- Then the exit code is 0
-  And stdout is
-  """
-  80
-  """
-
-
 @bz1846692
 Scenario: history list --reverse
  When I execute dnf with args "history list --reverse"


### PR DESCRIPTION
Test for https://github.com/rpm-software-management/dnf5/pull/2162