### PR TITLE
Configure installed group/environment manually

### DIFF
--- a/dnf-behave-tests/dnf/comps-environment-list.feature
+++ b/dnf-behave-tests/dnf/comps-environment-list.feature
@@ -4,8 +4,13 @@ Feature: Tests for environment list and info commands
 
 Background: Enable repo and mark an environment as installed
  Given I use repository "comps-group-list"
-   And I successfully execute dnf with args "group install test-environment"
+   And I create file "/usr/lib/sysimage/libdnf5/environments.toml" with
+       """
+       version = "1.0"
+       [environments]
 
+       test-environment = {groups = [], userinstalled = true}
+       """
 
 # https://github.com/rpm-software-management/dnf5/issues/1502
 @xfail

--- a/dnf-behave-tests/dnf/comps-environment-list.feature
+++ b/dnf-behave-tests/dnf/comps-environment-list.feature
@@ -1,4 +1,3 @@
-@dnf5daemon
 Feature: Tests for environment list and info commands
 
 

--- a/dnf-behave-tests/dnf/comps-environment-list.feature
+++ b/dnf-behave-tests/dnf/comps-environment-list.feature
@@ -3,6 +3,9 @@ Feature: Tests for environment list and info commands
 
 Background: Enable repo and mark an environment as installed
  Given I use repository "comps-group-list"
+   # Create the installed environment manually so the test can be
+   # used by dnf5daemon because it doesn't implement the environment
+   # install command yet.
    And I create file "/usr/lib/sysimage/libdnf5/environments.toml" with
        """
        version = "1.0"

--- a/dnf-behave-tests/dnf/comps-group-list.feature
+++ b/dnf-behave-tests/dnf/comps-group-list.feature
@@ -3,6 +3,9 @@ Feature: Tests for group list and info commands
 
 Background: Enable repo and mark a group as installed
  Given I use repository "comps-group-list"
+ # Create the installed group manually so the test can be
+ # used by dnf5daemon because it doesn't implement the group
+ # install command yet.
  Given I create file "/usr/lib/sysimage/libdnf5/groups.toml" with
     """
     version = "1.0"

--- a/dnf-behave-tests/dnf/comps-group-list.feature
+++ b/dnf-behave-tests/dnf/comps-group-list.feature
@@ -3,7 +3,15 @@ Feature: Tests for group list and info commands
 
 Background: Enable repo and mark a group as installed
  Given I use repository "comps-group-list"
-   And I successfully execute dnf with args "group install test-group"
+ Given I create file "/usr/lib/sysimage/libdnf5/groups.toml" with
+    """
+    version = "1.0"
+
+    [groups]
+
+    [groups.test-group]
+    userinstalled = true
+    """
 
 Scenario: All user visible groups are listed by default (installed group is not duplicated)
   When I execute dnf with args "group list"


### PR DESCRIPTION
This is needed because daemon doesn't implement install for comps.

For https://github.com/rpm-software-management/dnf5/issues/2176