### PR TITLE
Change expected output of the clean command to also work for dnf5daemon

### DIFF
--- a/dnf-behave-tests/dnf/clean-cachefiles.feature
+++ b/dnf-behave-tests/dnf/clean-cachefiles.feature
@@ -30,7 +30,7 @@ Scenario: Cleanup of the whole cache (dnf clean all)
    Then the exit code is 0
     And stdout matches line by line
         """
-        Removed 4 files, 4 directories \(total of [0-9]* KiB\). 0 errors occurred.
+        (Removed 4 files, 4 directories \(total of [0-9]* KiB\). 0 errors occurred.|Cache successfully cleaned.)
         """
    When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
@@ -57,7 +57,7 @@ Scenario: Cleanup of the whole cache, cache contains link pointing outside, cont
    Then the exit code is 0
     And stdout matches line by line
         """
-        Removed 6 files, 4 directories \(total of [0-9]* KiB\). 0 errors occurred.
+        (Removed 6 files, 4 directories \(total of [0-9]* KiB\). 0 errors occurred.|Cache successfully cleaned.)
         """
     And directory "/var/cache/dnf" is empty
     And file "/tmp/user_dir/user_file1" exists
@@ -69,7 +69,7 @@ Scenario: Cached metadata cleanup (dnf clean metadata)
    Then the exit code is 0
     And stdout matches line by line
         """
-        Removed 3 files, 2 directories \(total of [0-9]* KiB\). 0 errors occurred.
+        (Removed 3 files, 2 directories \(total of [0-9]* KiB\). 0 errors occurred.|Cache successfully cleaned.)
         """
    When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
@@ -86,7 +86,7 @@ Scenario: Cached packages cleanup (dnf clean packages)
    Then the exit code is 0
     And stdout matches line by line
         """
-        Removed 1 files, 1 directories \(total of [0-9]* KiB\). 0 errors occurred.
+        (Removed 1 files, 1 directories \(total of [0-9]* KiB\). 0 errors occurred.|Cache successfully cleaned.)
         """
    When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
@@ -106,7 +106,7 @@ Scenario: Database cached cleanup (dnf clean dbcache)
    Then the exit code is 0
     And stdout matches line by line
         """
-        Removed 1 files, 1 directories \(total of [0-9]* KiB\). 0 errors occurred.
+        (Removed 1 files, 1 directories \(total of [0-9]* KiB\). 0 errors occurred.|Cache successfully cleaned.)
         """
    When I execute "find | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line


### PR DESCRIPTION
The output for the daemon is different from dnf5. I think that duplicating the tests to customize them for each command is not necessary when the only difference is this output.