### PR TITLE
search: Separate a package from a summary with a tabulation character

### DIFF
--- a/dnf-behave-tests/dnf/search-sort.feature
+++ b/dnf-behave-tests/dnf/search-sort.feature
@@ -16,33 +16,33 @@ Scenario: sort alphanumerically
    And stdout is
        """
        Matched fields: name (exact)
-        name.src: Summary
-        name.x86_64: Summary
+        name.src	Summary
+        name.x86_64	Summary
        Matched fields: name, summary
-        name-summary.src: Summary of name
-        name-summary.x86_64: Summary of name
-        name-summary-description.src: Summary of name
-        name-summary-description.x86_64: Summary of name
-        name-summary-description-url.src: Summary of name
-        name-summary-description-url.x86_64: Summary of name
-        name-summary-url.src: Summary of name
-        name-summary-url.x86_64: Summary of name
+        name-summary.src	Summary of name
+        name-summary.x86_64	Summary of name
+        name-summary-description.src	Summary of name
+        name-summary-description.x86_64	Summary of name
+        name-summary-description-url.src	Summary of name
+        name-summary-description-url.x86_64	Summary of name
+        name-summary-url.src	Summary of name
+        name-summary-url.x86_64	Summary of name
        Matched fields: name
-        name-description.src: Summary
-        name-description.x86_64: Summary
-        name-description-url.src: Summary
-        name-description-url.x86_64: Summary
-        name-url.src: Summary
-        name-url.x86_64: Summary
+        name-description.src	Summary
+        name-description.x86_64	Summary
+        name-description-url.src	Summary
+        name-description-url.x86_64	Summary
+        name-url.src	Summary
+        name-url.x86_64	Summary
        Matched fields: summary
-        summary.src: Summary of name
-        summary.x86_64: Summary of name
-        summary-description.src: Summary of name
-        summary-description.x86_64: Summary of name
-        summary-description-url.src: Summary of name
-        summary-description-url.x86_64: Summary of name
-        summary-url.src: Summary of name
-        summary-url.x86_64: Summary of name
+        summary.src	Summary of name
+        summary.x86_64	Summary of name
+        summary-description.src	Summary of name
+        summary-description.x86_64	Summary of name
+        summary-description-url.src	Summary of name
+        summary-description-url.x86_64	Summary of name
+        summary-url.src	Summary of name
+        summary-url.x86_64	Summary of name
        """
 
 
@@ -57,45 +57,45 @@ Scenario: sort --all alphanumerically
    And stdout is
        """
        Matched fields: name (exact)
-        name.src: Summary
-        name.x86_64: Summary
+        name.src	Summary
+        name.x86_64	Summary
        Matched fields: name, summary, description, url
-        name-summary-description-url.src: Summary of name
-        name-summary-description-url.x86_64: Summary of name
+        name-summary-description-url.src	Summary of name
+        name-summary-description-url.x86_64	Summary of name
        Matched fields: name, summary, description
-        name-summary-description.src: Summary of name
-        name-summary-description.x86_64: Summary of name
+        name-summary-description.src	Summary of name
+        name-summary-description.x86_64	Summary of name
        Matched fields: name, summary, url
-        name-summary-url.src: Summary of name
-        name-summary-url.x86_64: Summary of name
+        name-summary-url.src	Summary of name
+        name-summary-url.x86_64	Summary of name
        Matched fields: name, summary
-        name-summary.src: Summary of name
-        name-summary.x86_64: Summary of name
+        name-summary.src	Summary of name
+        name-summary.x86_64	Summary of name
        Matched fields: name, description, url
-        name-description-url.src: Summary
-        name-description-url.x86_64: Summary
+        name-description-url.src	Summary
+        name-description-url.x86_64	Summary
        Matched fields: name, description
-        name-description.src: Summary
-        name-description.x86_64: Summary
+        name-description.src	Summary
+        name-description.x86_64	Summary
        Matched fields: name, url
-        name-url.src: Summary
-        name-url.x86_64: Summary
+        name-url.src	Summary
+        name-url.x86_64	Summary
        Matched fields: summary, description, url
-        summary-description-url.src: Summary of name
-        summary-description-url.x86_64: Summary of name
+        summary-description-url.src	Summary of name
+        summary-description-url.x86_64	Summary of name
        Matched fields: summary, description
-        summary-description.src: Summary of name
-        summary-description.x86_64: Summary of name
+        summary-description.src	Summary of name
+        summary-description.x86_64	Summary of name
        Matched fields: summary, url
-        summary-url.src: Summary of name
-        summary-url.x86_64: Summary of name
+        summary-url.src	Summary of name
+        summary-url.x86_64	Summary of name
        Matched fields: summary
-        summary.src: Summary of name
-        summary.x86_64: Summary of name
+        summary.src	Summary of name
+        summary.x86_64	Summary of name
        Matched fields: description
-        description.src: Summary
-        description.x86_64: Summary
+        description.src	Summary
+        description.x86_64	Summary
        Matched fields: url
-        url.src: Summary
-        url.x86_64: Summary
+        url.src	Summary
+        url.x86_64	Summary
        """

--- a/dnf-behave-tests/dnf/search.feature
+++ b/dnf-behave-tests/dnf/search.feature
@@ -18,8 +18,8 @@ Scenario: with keyword
    """
    <REPOSYNC>
    Matched fields: name (exact), summary
-    setup.noarch: A set of system configuration and setup files
-    setup.src: A set of system configuration and setup files
+    setup.noarch	A set of system configuration and setup files
+    setup.src	A set of system configuration and setup files
    """
 
 
@@ -39,8 +39,8 @@ Scenario: with installed and available newest package doesn't duplicate results
     And stdout is
         """
         Matched fields: name (exact), summary
-         setup.noarch: A set of system configuration and setup files
-         setup.src: A set of system configuration and setup files
+         setup.noarch	A set of system configuration and setup files
+         setup.src	A set of system configuration and setup files
         """
 
 
@@ -55,10 +55,10 @@ Scenario: Only one occurence of a package is in the output when more versions ar
     And stdout is
         """
         Matched fields: name (exact)
-         flac.src: An encoder/decoder for the Free Lossless Audio Codec
-         flac.x86_64: An encoder/decoder for the Free Lossless Audio Codec
+         flac.src	An encoder/decoder for the Free Lossless Audio Codec
+         flac.x86_64	An encoder/decoder for the Free Lossless Audio Codec
         Matched fields: name
-         flac-libs.x86_64: Libraries for the Free Lossless Audio Codec
+         flac-libs.x86_64	Libraries for the Free Lossless Audio Codec
         """
 
 
@@ -73,17 +73,17 @@ Scenario: All versions of a package are in the output when using the --showdupli
     And stdout is
         """
         Matched fields: name (exact)
-         flac-0:1.3.2-8.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
-         flac-0:1.3.2-8.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
-         flac-0:1.3.3-1.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
-         flac-0:1.3.3-1.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
-         flac-0:1.3.3-2.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
-         flac-0:1.3.3-2.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
-         flac-0:1.3.3-3.fc29.src: An encoder/decoder for the Free Lossless Audio Codec
-         flac-0:1.3.3-3.fc29.x86_64: An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.2-8.fc29.src	An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.2-8.fc29.x86_64	An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-1.fc29.src	An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-1.fc29.x86_64	An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-2.fc29.src	An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-2.fc29.x86_64	An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-3.fc29.src	An encoder/decoder for the Free Lossless Audio Codec
+         flac-0:1.3.3-3.fc29.x86_64	An encoder/decoder for the Free Lossless Audio Codec
         Matched fields: name
-         flac-libs-0:1.3.2-8.fc29.x86_64: Libraries for the Free Lossless Audio Codec
-         flac-libs-0:1.3.3-1.fc29.x86_64: Libraries for the Free Lossless Audio Codec
-         flac-libs-0:1.3.3-2.fc29.x86_64: Libraries for the Free Lossless Audio Codec
-         flac-libs-0:1.3.3-3.fc29.x86_64: Libraries for the Free Lossless Audio Codec
+         flac-libs-0:1.3.2-8.fc29.x86_64	Libraries for the Free Lossless Audio Codec
+         flac-libs-0:1.3.3-1.fc29.x86_64	Libraries for the Free Lossless Audio Codec
+         flac-libs-0:1.3.3-2.fc29.x86_64	Libraries for the Free Lossless Audio Codec
+         flac-libs-0:1.3.3-3.fc29.x86_64	Libraries for the Free Lossless Audio Codec
         """


### PR DESCRIPTION
For: https://github.com/rpm-software-management/dnf5/pull/2190
Resolves: https://github.com/rpm-software-management/dnf5/issues/2166

I did tested it yet. I will need to build RPMs and install them into a container and that will take some time. I cannot reuse builds from builds from code PR because somebody restarted the  PR tests and that deleted the old builds.