### PR TITLE
tmt: Don't use $TMT_PLANS_DATA

### DIFF
--- a/plans/integration/behave-createrepo_c.fmf
+++ b/plans/integration/behave-createrepo_c.fmf
@@ -3,6 +3,6 @@ tag: createrepo_c
 execute:
     how: tmt
     script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test \
+        /var/tmp/ci-dnf-stack/container-test \
         --suite createrepo_c \
         run

--- a/plans/integration/behave-dnf.fmf
+++ b/plans/integration/behave-dnf.fmf
@@ -3,5 +3,5 @@ tag: dnf
 execute:
     how: tmt
     script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test run
+        /var/tmp/ci-dnf-stack/container-test run
 

--- a/plans/integration/behave-dnf5.fmf
+++ b/plans/integration/behave-dnf5.fmf
@@ -3,6 +3,6 @@ tag: dnf5
 execute:
     how: tmt
     script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test run \
+        /var/tmp/ci-dnf-stack/container-test run \
         --tags dnf5 \
         --command dnf5

--- a/plans/integration/behave-dnf5daemon.fmf
+++ b/plans/integration/behave-dnf5daemon.fmf
@@ -3,6 +3,6 @@ tag: dnf5daemon
 execute:
     how: tmt
     script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test run \
+        /var/tmp/ci-dnf-stack/container-test run \
         --tags dnf5daemon \
         --command dnf5daemon-client

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -10,22 +10,22 @@ prepare:
     - name: Download latest ci-dnf-stack from PR
       how: shell
       script:
-        - git clone https://github.com/rpm-software-management/ci-dnf-stack $TMT_PLANS_DATA/ci-dnf-stack
+        - git clone https://github.com/rpm-software-management/ci-dnf-stack /var/tmp/ci-dnf-stack
 
     - name: Checkout PR branch if packit call is from ci-dnf-stack
       how: shell
       script: |
         if [ "$PACKIT_UPSTREAM_NAME" == "ci-dnf-stack" ]; then
-          git -C $TMT_PLANS_DATA/ci-dnf-stack remote add pull-request $PACKIT_SOURCE_URL
-          git -C $TMT_PLANS_DATA/ci-dnf-stack fetch pull-request
-          git -C $TMT_PLANS_DATA/ci-dnf-stack checkout --track pull-request/$PACKIT_SOURCE_BRANCH
-          git -C $TMT_PLANS_DATA/ci-dnf-stack rebase $PACKIT_TARGET_BRANCH
+          git -C /var/tmp/ci-dnf-stack remote add pull-request $PACKIT_SOURCE_URL
+          git -C /var/tmp/ci-dnf-stack fetch pull-request
+          git -C /var/tmp/ci-dnf-stack checkout --track pull-request/$PACKIT_SOURCE_BRANCH
+          git -C /var/tmp/ci-dnf-stack rebase $PACKIT_TARGET_BRANCH
         fi
 
     - name: Build testing container
       how: shell
       script: |
-        $TMT_PLANS_DATA/ci-dnf-stack/container-test build \
+        /var/tmp/ci-dnf-stack/container-test build \
         --base $( echo "$@distro" | tr '-' ':') \
         --container-arg="--env=COPR=$PACKIT_COPR_PROJECT" \
         --container-arg="--env=COPR_RPMS=$PACKIT_COPR_RPMS"


### PR DESCRIPTION
Use `/var/tmp/ci-dnf-stack` instead of `$TMT_PLANS_DATA/ci-dnf-stack`, which was expanding to `/ci-dnf-stack`.

The correct variable is `TMT_PLAN_DATA` anyway, and it's not appropriate for this use case.

Resolves https://github.com/rpm-software-management/ci-dnf-stack/issues/1487.