### PR TITLE
Fix `dnf_tag_matcher`, previously it was hardcoded to dnf5

### DIFF
--- a/dnf-behave-tests/dnf/dnf5daemon/no-dnfdaemon-server.feature
+++ b/dnf-behave-tests/dnf/dnf5daemon/no-dnfdaemon-server.feature
@@ -1,6 +1,6 @@
 @dnf5daemon
 @destructive
-@not.with_dnf=5
+@not.with_mode=dnf5
 Feature: Test dnf5daemon-client initialization
 
 

--- a/dnf-behave-tests/dnf/dnf5daemon/repo-enable-disable.feature
+++ b/dnf-behave-tests/dnf/dnf5daemon/repo-enable-disable.feature
@@ -1,5 +1,5 @@
 @dnf5daemon
-@not.with_dnf=5
+@not.with_mode=dnf5
 Feature: Enable/disable repo functionality for dnf5daemon
 
 

--- a/dnf-behave-tests/dnf/environment.py
+++ b/dnf-behave-tests/dnf/environment.py
@@ -240,7 +240,7 @@ def before_all(context):
             break
 
     context.os_tag_matcher = VersionedActiveTagMatcher({"os": context.config.userdata.get("os", detect_os_version())})
-    context.dnf_tag_matcher = ActiveTagMatcher({"dnf": "5"})
+    context.dnf_tag_matcher = ActiveTagMatcher({"mode": "dnf5daemon" if context.dnf5daemon_mode else "dnf5"})
     context.repos = {}
     context.invalid_utf8_char = consts.INVALID_UTF8_CHAR
 


### PR DESCRIPTION
In 1ecc5166aa91850e1dfefca7390fc671853e35a0 I hardcoded it to dnf5 because I didn't realize the dnf5daemon tests use it. This meant the dnf/dnf5daemon tests were never run, not even in dnf5daemon mode.