### PR TITLE
dnf-automatic: email_command: Pass recipients as separate arguments to a command

### DIFF
--- a/dnf-behave-tests/dnf/dnf-automatic/command_email.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/command_email.feature
@@ -1,0 +1,29 @@
+Feature: dnf-automatic command_email emitter
+
+Background:
+Given I use repository "simple-base"
+  And I successfully execute dnf with args "install labirinto"
+  And I use repository "simple-updates"
+
+
+@gh-dnf5-2273
+Scenario: dnf-automatic pass multiple recipients as separate arguments
+  Given I create file "/etc/dnf/automatic.conf" with
+    """
+    [commands]
+    apply_updates = no
+    reboot = never
+    [emitters]
+    emit_via = command_email
+    [command_email]
+    email_to = recipient1,recipient2
+    command_format = "printf '%s\\n' {email_to}"
+    """
+   When I execute dnf with args "automatic"
+   Then the exit code is 0
+    And stdout contains lines:
+    """
+    recipient1
+    recipient2
+    """
+


### PR DESCRIPTION
If multiple recipients are configured for email_command, "{email_to}" should expand to multiple white-space separated arguments. If multiple arguments are passed to "printf '%s\n'" command, each argument will be printed on a separate line. And that is tested. (Otherwise, printf would spit all the recipients on a single line.)

For: https://github.com/rpm-software-management/dnf5/issues/2273