### PR TITLE
bootc: test usr_drift_protected_paths

### DIFF
--- a/dnf-behave-tests/common/cmd.py
+++ b/dnf-behave-tests/common/cmd.py
@@ -60,6 +60,10 @@ def file_has_mode(context, filepath, octal_mode_str):
     assert oct(octal_mode) == oct(octal_file_mode), \
         "File \"{}\" has mode \"{}\"".format(matched_files[0], oct(octal_file_mode))
 
-@behave.step("path \"{path}\" is not writeable")
-def path_is_not_writeable(context, path):
-    assert not os.access(path, os.W_OK), f"Path '{path}' is unexpectedly writeable"
+@behave.step("path \"{path}\" is writable")
+def path_is_writable(context, path):
+    assert os.access(path, os.W_OK), f"Path '{path}' is not writable"
+
+@behave.step("path \"{path}\" is not writable")
+def path_is_not_writable(context, path):
+    assert not os.access(path, os.W_OK), f"Path '{path}' is unexpectedly writable"

--- a/dnf-behave-tests/dnf-bootc/transient.feature
+++ b/dnf-behave-tests/dnf-bootc/transient.feature
@@ -93,6 +93,7 @@ Scenario: Paths in usr_drift_protected_paths are protected
        """
        /etc/configurable-2/*
        /etc/configurable-3/configurable.conf
+       /var/lib/configurable/*
        """
   When I execute dnf with args "install configurable --transient"
   Then the exit code is 1
@@ -102,6 +103,7 @@ Scenario: Paths in usr_drift_protected_paths are protected
      configurable-1.0-1.fc29.x86_64
        /etc/configurable-2/configurable.conf
        /etc/configurable-3/configurable.conf
+       /var/lib/configurable/configurable.db
      """
 
 @reboot_count_1

--- a/dnf-behave-tests/dnf-bootc/transient.feature
+++ b/dnf-behave-tests/dnf-bootc/transient.feature
@@ -7,7 +7,8 @@ Background: Enable repositories
 Scenario: System should boot without any overlay (it is locked)
   When I successfully execute "ostree admin status"
   Then stdout does not contain "Unlocked:"
-   And path "/usr/bin" is not writeable
+   And path "/usr/bin" is not writable
+   And path "/etc" is writable
 
 @reboot_count_1
 Scenario: Installing a package without overlay fails
@@ -25,7 +26,7 @@ Scenario: Installing a package without overlay fails
    And file "/usr/bin/hello" does not exist
 
 @reboot_count_1
-Scenario: Install a package using --transient without any overlay procudes a warning
+Scenario: Install a package using --transient without any overlay produces a warning
  Given file "/usr/bin/hello" does not exist
   When I execute dnf with args "install hello --transient"
   Then the exit code is 0
@@ -50,7 +51,7 @@ Scenario: After using DNF --transient, transient overlay should exist
      """
      Unlocked: transient
      """
-   And path "/usr/bin" is not writeable
+   And path "/usr/bin" is not writable
 
 @reboot_count_1
 Scenario: Remove and install a package using --transient with transient overlay doesn't produce warning
@@ -86,6 +87,39 @@ Scenario: Removing a package without --transient and with transient overlay fail
      """
    And file "/usr/bin/hello" exists
 
+@reboot_count_1
+Scenario: Paths in usr_drift_protected_paths are protected
+ Given I create file "/etc/dnf/usr-drift-protected-paths.d/configurable.conf" with
+       """
+       /etc/configurable-2/*
+       /etc/configurable-3/configurable.conf
+       """
+  When I execute dnf with args "install configurable --transient"
+  Then the exit code is 1
+   And stdout contains lines
+     """
+     This operation would modify the following paths, possibly introducing inconsistencies when the transient overlay on /usr is discarded. See the usr_drift_protected_paths configuration option for more information.
+     configurable-1.0-1.fc29.x86_64
+       /etc/configurable-2/configurable.conf
+       /etc/configurable-3/configurable.conf
+     """
+
+@reboot_count_1
+Scenario: usr_drift_protected_paths can be bypassed on the command line
+ Given I create file "/etc/dnf/usr-drift-protected-paths.d/configurable.conf" with
+       """
+       /etc/configurable-2/*
+       /etc/configurable-3/configurable.conf
+       """
+  When I execute dnf with args "install configurable --transient --setopt=usr_drift_protected_paths="
+  Then the exit code is 0
+   And Transaction is following
+     | Action        | Package                          |
+     | install       | configurable-0:1.0-1.fc29.x86_64 |
+   And stderr is empty
+   And file "/etc/configurable-2/configurable.conf" exists
+   And file "/etc/configurable-3/configurable.conf" exists
+
 @reboot_count_2
 Scenario: After reboot, the transient overlay should disappear
   When I successfully execute "ostree admin status"
@@ -93,8 +127,11 @@ Scenario: After reboot, the transient overlay should disappear
      """
      Unlocked: transient
      """
-   And path "/usr/bin" is not writeable
+   And path "/usr/bin" is not writable
    And file "/usr/bin/hello" does not exist
+   And file "/etc/configurable-1/configurable.conf" exists
+   And file "/etc/configurable-2/configurable.conf" exists
+   And file "/etc/configurable-3/configurable.conf" exists
 
 @reboot_count_2
 Scenario: Create writable overlay (unlock the system)
@@ -144,7 +181,7 @@ Scenario: After reboot, the writable overlay should disappear
      """
      Unlocked: development
      """
-   And path "/usr/bin" is not writeable
+   And path "/usr/bin" is not writable
    And file "/usr/bin/hello" does not exist
 
 @reboot_count_3

--- a/dnf-behave-tests/fixtures/specs/bootc/configurable-1.0.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/bootc/configurable-1.0.0-1.fc29.spec
@@ -1,0 +1,28 @@
+Name: configurable
+Version: 1.0
+Release: 1.fc29
+Summary: A package with config file
+
+License: GPLv3+
+Url: None
+
+%description
+Description of a pkg that provides a file in /usr/bin and /etc
+
+%install
+mkdir -p %{buildroot}/usr/bin
+mkdir -p %{buildroot}/etc/configurable-1
+mkdir -p %{buildroot}/etc/configurable-2
+mkdir -p %{buildroot}/etc/configurable-3
+touch %{buildroot}/usr/bin/configurable
+touch %{buildroot}/etc/configurable-1/configurable.conf
+touch %{buildroot}/etc/configurable-2/configurable.conf
+touch %{buildroot}/etc/configurable-3/configurable.conf
+
+%files
+/usr/bin/configurable
+/etc/configurable-1/configurable.conf
+/etc/configurable-2/configurable.conf
+/etc/configurable-3/configurable.conf
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/bootc/configurable-1.0.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/bootc/configurable-1.0.0-1.fc29.spec
@@ -14,15 +14,19 @@ mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/etc/configurable-1
 mkdir -p %{buildroot}/etc/configurable-2
 mkdir -p %{buildroot}/etc/configurable-3
+mkdir -p %{buildroot}/var/lib/configurable
 touch %{buildroot}/usr/bin/configurable
 touch %{buildroot}/etc/configurable-1/configurable.conf
 touch %{buildroot}/etc/configurable-2/configurable.conf
 touch %{buildroot}/etc/configurable-3/configurable.conf
+# Include a path that is not usually listed in primary.xml
+touch %{buildroot}/var/lib/configurable/configurable.db
 
 %files
 /usr/bin/configurable
 /etc/configurable-1/configurable.conf
 /etc/configurable-2/configurable.conf
 /etc/configurable-3/configurable.conf
+/var/lib/configurable/configurable.db
 
 %changelog

--- a/dnf-behave-tests/fixtures/specs/bootc/hello-1.0.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/bootc/hello-1.0.0-1.fc29.spec
@@ -10,13 +10,16 @@ Conflicts: hello
 Provides: hello
 
 %description
-Description of a pkg that provides a file in /usr/bin
+Description of a pkg that provides a file in /usr/bin and /etc
 
 %install
 mkdir -p %{buildroot}/usr/bin
 touch %{buildroot}/usr/bin/hello
+mkdir -p %{buildroot}/etc
+touch %{buildroot}/etc/hello.conf
 
 %files
 /usr/bin/hello
+/etc/hello.conf
 
 %changelog


### PR DESCRIPTION
For https://github.com/rpm-software-management/dnf/issues/2199.

Requires https://github.com/rpm-software-management/libdnf/pull/1711 and https://github.com/rpm-software-management/dnf/pull/2244.