### PR TITLE
Require libdnf5-plugin-expired-pgp-keys for expired-pgp-keys.feature

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -55,6 +55,7 @@ BuildRequires:  dnf5-plugin-automatic
 BuildRequires:  dnf5daemon-server
 BuildRequires:  dnf5daemon-client
 BuildRequires:  libdnf5-plugin-actions
+BuildRequires:  libdnf5-plugin-expired-pgp-keys
 # dnf5 python api tests need libdnf5 python bindings
 BuildRequires:  python3-libdnf5
 


### PR DESCRIPTION
This is causing CI failures such as: https://artifacts.dev.testing-farm.io/46b65578-3809-46a7-b894-a948b48c5b98/work-behave-dnf5n7o7buv1/plans/integration/behave-dnf5/execute/data/guest/default-0/script-00-1/output.txt