### PR TITLE
rhel-9.7: test $releasever_{major,minor}, shell-style variable expansion

### DIFF
--- a/dnf-behave-tests/dnf/vars-releasever.feature
+++ b/dnf-behave-tests/dnf/vars-releasever.feature
@@ -53,6 +53,20 @@ Scenario: Releasever is substituted in baseurl via a value detected from 'system
         | Action        | Package                       |
         | install       | setup-0:2.12.1-1.fc29.noarch  |
 
+
+Scenario: releasever_{major,minor} are substituted via values detected from 'system-release(releasever_{major,minor})' provides
+  Given I execute rpm with args "-i --nodeps {context.dnf.fixturesdir}/repos/dnf-ci-fedora-release/noarch/fedora-release-29-1.noarch.rpm"
+    And I use repository "dnf-ci-fedora" with configuration
+        | key     | value                                                                                             |
+        | baseurl | file://{context.dnf.installroot}/temp-repos/base-f$releasever-$releasever_major-$releasever_minor |
+    And I copy directory "{context.scenario.repos_location}/dnf-ci-fedora" to "/temp-repos/base-f123-45-67"
+    And I execute dnf with args "install setup"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                       |
+        | install       | setup-0:2.12.1-1.fc29.noarch  |
+
+
 # @dnf5
 # TODO(nsella) different exit code
 @destructive

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-release/fedora-release-29-1.spec
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-release/fedora-release-29-1.spec
@@ -17,6 +17,9 @@ Provides:       config(fedora-release) = 29-1
 
 # detected $releasever should be '123'
 Provides:       system-release(releasever) = 123
+# $releasever_major, $releasever_minor should be overridden to 45, 67
+Provides:       system-release(releasever_major) = 45
+Provides:       system-release(releasever_minor) = 67
 
 
 %description


### PR DESCRIPTION
For [RHEL-95006](https://issues.redhat.com/browse/RHEL-95006) and [RHEL-65817](https://issues.redhat.com/browse/RHEL-65817).

Requires https://github.com/rpm-software-management/libdnf/pull/1715 and https://github.com/rpm-software-management/dnf/pull/2253.

Backports https://github.com/rpm-software-management/ci-dnf-stack/pull/1621 to rhel-9.7.0.