### PR TITLE
groups: specify display_order to match the expected order in tests

### DIFF
--- a/dnf-behave-tests/fixtures/specs/advisories-and-groups/comps.xml
+++ b/dnf-behave-tests/fixtures/specs/advisories-and-groups/comps.xml
@@ -4,6 +4,7 @@
   <group>
     <id>test-group-1</id>
     <name>Test Group 1</name>
+    <display_order>1</display_order>
     <description>Test Group 1 description.</description>
       <packagelist>
         <packagereq type="mandatory">test</packagereq>
@@ -12,6 +13,7 @@
 
   <group>
     <id>test-group-2</id>
+    <display_order>2</display_order>
     <name>Test Group 2</name>
     <description>Test Group 2 description.</description>
   </group>

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty/comps.xml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-thirdparty/comps.xml
@@ -21,7 +21,7 @@
    <id>cqrlib-non-devel</id>
    <default>false</default>
    <uservisible>true</uservisible>
-   <display_order>1024</display_order>
+   <display_order>1021</display_order>
    <name>CQRlib-non-devel</name>
    <description>Testgroup for DNF CI swap testing</description>
     <packagelist>
@@ -34,7 +34,7 @@
    <id>superripper-and-deps</id>
    <default>false</default>
    <uservisible>true</uservisible>
-   <display_order>1024</display_order>
+   <display_order>1029</display_order>
    <name>SuperRipper-and-deps</name>
    <description>Testgroup for DNF CI swap testing</description>
     <packagelist>


### PR DESCRIPTION
Otherwise the order is implementation dependent and can cause test fails.