### PR TITLE
groups: specify display_order to match the expected order in tests

### DIFF
--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -426,7 +426,7 @@ Scenario: Merge groups when one has empty packagelist
         Name                 : Test Group
         Description          : Test Group description updated.
         Installed            : yes
-        Order                : 
+        Order                : 2
         Langonly             : 
         Uservisible          : yes
         Repositories         : @System
@@ -449,7 +449,7 @@ Scenario: Merge environment with missing names containg a group with missing nam
         Id                   : no-name-env
         Name                 : 
         Description          : 
-        Order                : 
+        Order                : 2
         Installed            : False
         Repositories         : comps-group, comps-group-merging
         Required groups      : no-name-group
@@ -471,7 +471,7 @@ Scenario: Group info with a group that has missing name
         Name                 : 
         Description          : 
         Installed            : no
-        Order                : 
+        Order                : 1
         Langonly             : 
         Uservisible          : yes
         Repositories         : comps-group
@@ -626,7 +626,7 @@ Scenario: dnf can list installed groups even without their xml definitions prese
         Name                 : Test Group
         Description          : Test Group description.
         Installed            : yes
-        Order                : 
+        Order                : 2
         Langonly             : 
         Uservisible          : yes
         Repositories         : @System

--- a/dnf-behave-tests/fixtures/specs/comps-group/comps.xml
+++ b/dnf-behave-tests/fixtures/specs/comps-group/comps.xml
@@ -4,6 +4,7 @@
   <group>
    <id>test-group</id>
    <name>Test Group</name>
+   <display_order>2</display_order>
    <description>Test Group description.</description>
     <packagelist>
       <packagereq type="mandatory">test-package</packagereq>
@@ -14,6 +15,7 @@
    <id>no-name-group</id>
    <name></name>
    <description></description>
+   <display_order>1</display_order>
     <packagelist>
       <packagereq type="mandatory">test-package</packagereq>
     </packagelist>
@@ -23,6 +25,7 @@
     <id>no-name-env</id>
     <name></name>
     <description></description>
+    <display_order>2</display_order>
     <grouplist>
       <groupid>test-group</groupid>
     </grouplist>
@@ -34,6 +37,7 @@
     <id>env-with-a-nonexistent-group</id>
     <name>Env with a nonexistent group</name>
     <description></description>
+    <display_order>1</display_order>
     <grouplist>
       <groupid>test-group</groupid>
       <groupid>nonexistent-group</groupid>


### PR DESCRIPTION
Without this the order is implementation dependent.

This is a follow up to: https://github.com/rpm-software-management/ci-dnf-stack/pull/1696
It is required for: https://github.com/rpm-software-management/dnf5/pull/2345