### PR TITLE
rhel-10.1: stderr for module commands now contains deprecation warning

### DIFF
--- a/dnf-behave-tests/dnf/module/enable-errors.feature
+++ b/dnf-behave-tests/dnf/module/enable-errors.feature
@@ -22,6 +22,7 @@ Scenario: Fail to enable a different stream of an already enabled module (dnf)
         | nodejs    | enabled   | 8         |           |
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         The operation would result in switching of module 'nodejs' stream '8' to stream '10'
         Error: It is not possible to switch enabled streams of a module unless explicitly enabled via configuration option module_stream_switch.
         It is recommended to rather remove all installed content from the module, and reset the module using 'dnf module reset <module_name>' command. After you reset the module, you can install the other stream.
@@ -44,6 +45,7 @@ Scenario: Fail to enable a different stream of an already enabled module (yum)
         | nodejs    | enabled   | 8         |           |
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         The operation would result in switching of module 'nodejs' stream '8' to stream '10'
         Error: It is not possible to switch enabled streams of a module unless explicitly enabled via configuration option module_stream_switch.
         It is recommended to rather remove all installed content from the module, and reset the module using 'yum module reset <module_name>' command. After you reset the module, you can install the other stream.
@@ -66,6 +68,7 @@ Scenario: Fail to install a different stream of an already enabled module
         | nodejs    | enabled   | 8         |           |
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         The operation would result in switching of module 'nodejs' stream '8' to stream '10'
         Error: It is not possible to switch enabled streams of a module unless explicitly enabled via configuration option module_stream_switch.
         It is recommended to rather remove all installed content from the module, and reset the module using 'dnf module reset <module_name>' command. After you reset the module, you can install the other stream.
@@ -104,6 +107,7 @@ Scenario: Fail to enable a module stream when specifying only module
         | Module    | State     | Stream    | Profiles  |
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         Argument 'nodejs' matches 4 streams ('8', '10', '11', '12') of module 'nodejs', but none of the streams are enabled or default
         Unable to resolve argument nodejs
         Error: Problems in request:
@@ -142,6 +146,7 @@ Scenario: Fail to enable a module stream when not specifying anything
         | Module    | State     | Stream    | Profiles  |
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         Error: dnf module enable: too few arguments
         """
 

--- a/dnf-behave-tests/dnf/module/info.feature
+++ b/dnf-behave-tests/dnf/module/info.feature
@@ -755,6 +755,7 @@ Examples:
    Then the exit code is 1
     And stderr is
     """
+    WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
     Error: dnf module info: too few arguments
     """
 

--- a/dnf-behave-tests/dnf/module/install-default.feature
+++ b/dnf-behave-tests/dnf/module/install-default.feature
@@ -15,6 +15,7 @@ Scenario: Install module, no default profile defined, expecting no profile selec
         | DnfCiModuleNoDefaults |           |           |           |
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         No default profiles for module DnfCiModuleNoDefaults:stable. Available profiles: default
         Error: Problems in request:
         broken groups or modules: DnfCiModuleNoDefaults:stable
@@ -31,6 +32,7 @@ Scenario: Install module, no default stream or profile defined, expecting no pro
     And Transaction is empty
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         Argument 'DnfCiModuleNoDefaults' matches 2 streams ('development', 'stable') of module 'DnfCiModuleNoDefaults', but none of the streams are enabled or default
         Unable to resolve argument DnfCiModuleNoDefaults
         Error: Problems in request:

--- a/dnf-behave-tests/dnf/module/install-errors.feature
+++ b/dnf-behave-tests/dnf/module/install-errors.feature
@@ -69,6 +69,7 @@ Scenario: Install module without any profiles
         | DnfCiModuleNoProfiles   |           |           |           |
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         No profiles for module DnfCiModuleNoProfiles:master
         Error: Problems in request:
         broken groups or modules: DnfCiModuleNoProfiles:master
@@ -111,6 +112,7 @@ Scenario: Profile is not installed after its artifact failed to get installed
    Then the exit code is 1
     And stderr is
     """
+    WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
     Error: Transaction test error:
       file /usr/lib/FileConflict/a_dir from install of FileConflict-0:2.0.streamB-1.x86_64 conflicts with file from package FileConflict-0:1.0-1.x86_64
     """

--- a/dnf-behave-tests/dnf/module/list.feature
+++ b/dnf-behave-tests/dnf/module/list.feature
@@ -83,7 +83,10 @@ Scenario: I can list installed modules
 Scenario: I can list disabled modules (when there are no disabled modules)
    When I execute dnf with args "module list --disabled"
    Then the exit code is 0
-    And stderr is empty
+    And stderr is
+      """
+      WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
+      """
     And module list is empty
 
 @bz1647382

--- a/dnf-behave-tests/dnf/module/platform.feature
+++ b/dnf-behave-tests/dnf/module/platform.feature
@@ -46,6 +46,7 @@ Scenario: I can't list info for the pseudo-module
    """
   And stderr is
    """
+   WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
    Error: No matching Modules to list
    """
 
@@ -86,7 +87,8 @@ Scenario: I can't update pseudo-module
  Then the exit code is 1
   And stderr is
   """
-   Error: No such module: pseudoplatform:6.0
+  WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
+  Error: No such module: pseudoplatform:6.0
   """
 
 

--- a/dnf-behave-tests/dnf/module/provides.feature
+++ b/dnf-behave-tests/dnf/module/provides.feature
@@ -162,6 +162,7 @@ Given I set dnf command to "dnf"
  Then the exit code is 1
   And stderr is
       """
+      WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
       Error: dnf module provides: too few arguments
       """
 
@@ -171,5 +172,6 @@ Given I set dnf command to "yum"
  Then the exit code is 1
   And stderr is
       """
+      WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
       Error: yum module provides: too few arguments
       """

--- a/dnf-behave-tests/dnf/module/remove.feature
+++ b/dnf-behave-tests/dnf/module/remove.feature
@@ -216,6 +216,7 @@ Scenario: module removed with --all and not existing module argument - no traceb
     And Transaction is empty
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         Problems in request:
         missing groups or modules: noexists
         """

--- a/dnf-behave-tests/dnf/module/switch.feature
+++ b/dnf-behave-tests/dnf/module/switch.feature
@@ -95,6 +95,7 @@ Scenario: Reject switch a module stream, when stream does not exist
         | nodejs    | enabled   | 8         |  minimal       |
     And stderr is
         """
+        WARNING: modularity is deprecated, and functionality will be removed in a future release of DNF5.
         Error: Problems in request:
         missing groups or modules: nodejs:notexists
         """


### PR DESCRIPTION
Backport of https://github.com/rpm-software-management/ci-dnf-stack/pull/1702 for rhel-10.1

For https://issues.redhat.com/browse/RHEL-89940.