### PR TITLE
Fix behave table syntax

### DIFF
--- a/dnf-behave-tests/dnf/removed-tmpdir.feature
+++ b/dnf-behave-tests/dnf/removed-tmpdir.feature
@@ -6,7 +6,7 @@ Given I use repository "dnf-ci-fedora" with configuration
       | key             | value                                       |
       | baseurl         |                                             |
       | mirrorlist      | {context.dnf.installroot}/tmp/mirrorlist    |
-      | gpgcheck        | 0
+      | gpgcheck        | 0                                           |
   And I set environment variable "TMPDIR" to "/tmp/dummy.ABC123"
  When I execute dnf with args "repoquery empty --refresh"
  Then the exit code is 1


### PR DESCRIPTION
Behave 1.3.1 complains:

    Malformed table row at dnf/removed-tmpdir.feature: line 9

That's indeed a syntax error in our test suite.

Related: #1715