### PR TITLE
No relative imports

### DIFF
--- a/dnf-behave-tests/dnf/steps/lib/dnf.py
+++ b/dnf-behave-tests/dnf/steps/lib/dnf.py
@@ -6,8 +6,8 @@ from __future__ import print_function
 import re
 
 
-from .rpm import normalize_epoch
-from .rpm import RPM
+from lib.rpm import normalize_epoch
+from lib.rpm import RPM
 
 
 ACTION_RE = re.compile(r"^([^ ].+):$")

--- a/dnf-behave-tests/dnf/steps/lib/rpmdb.py
+++ b/dnf-behave-tests/dnf/steps/lib/rpmdb.py
@@ -5,8 +5,8 @@ from __future__ import print_function
 
 import rpm
 
-from .rpm import normalize_epoch
-from .rpm import RPM
+from lib.rpm import normalize_epoch
+from lib.rpm import RPM
 
 
 def _str(obj):


### PR DESCRIPTION
Behave >= 1.3.0 breaks relative imports:

    # behave dnf
    USING RUNNER: behave.runner:Runner
    Exception KeyError: "'__name__' not in globals"
    Traceback (most recent call last):
      File "/usr/local/bin/behave", line 8, in <module>
	sys.exit(main())
		 ~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/__main__.py", line 291, in main
	return run_behave(config)
      File "/usr/local/lib/python3.14/site-packages/behave/__main__.py", line 113, in run_behave
	failed = runner.run()
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1138, in run
	return self.run_with_paths()
	       ~~~~~~~~~~~~~~~~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1143, in run_with_paths
	self.load_step_definitions()
	~~~~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1130, in load_step_definitions
	load_step_modules(step_paths)
	~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner_util.py", line 596, in load_step_modules
	exec_file(os.path.join(path, name), step_module_globals)
	~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner_util.py", line 567, in exec_file
	exec(code, globals_, locals_)
	~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
      File "dnf/steps/lib/dnf.py", line 9, in <module>
	from .rpm import normalize_epoch
    KeyError: "'__name__' not in globals"

We did "from .rpm import normalize_epoch" because "rpm" is also a system-wide installed Pyhon binding for librpm.

According to Behave upstream
<https://github.com/behave/behave/issues/742>, Behave adds current steps directory to Python search path and thus one can use non-relative imports.

This fix uses that approach. It works with both 1.2.6 and 1.3.1 Behave versions.

Note that more fixes will be needed for Behave 1.3.1.

Related: #1715