### PR TITLE
Add gnupg2 to requirements.spec

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -22,6 +22,7 @@ BuildRequires:  fakeuname
 BuildRequires:  findutils
 BuildRequires:  glibc-langpack-en
 BuildRequires:  glibc-langpack-de
+BuildRequires:  gnupg2
 BuildRequires:  libfaketime
 BuildRequires:  openssl
 BuildRequires:  python3


### PR DESCRIPTION
ubi10 images do not have gpgconf binary pre-installed.