### PR TITLE
rhel-8.6.0: Pin behave to 1.2.6

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -30,7 +30,7 @@ BuildRequires:  rpm-build
 BuildRequires:  rpm-sign
 BuildRequires:  sqlite
 %if 0%{?fedora}
-BuildRequires:  python3-behave
+BuildRequires:  python3-behave < 1.2.7
 BuildRequires:  python3-pexpect
 BuildRequires:  zchunk
 %endif

--- a/dnf-behave-tests/requirements.txt
+++ b/dnf-behave-tests/requirements.txt
@@ -1,3 +1,3 @@
-behave >= 1.2.6
+behave == 1.2.6
 pexpect
 pyftpdlib


### PR DESCRIPTION
Upstream commit: 354b1bc528e0b15aff7bb7e5d80a41f01f2130b0

Upstream releases new 1.3.0 version after 7 years. It contains few incompatibilities:

Relative Python imports do not work:

    # behave dnf
    USING RUNNER: behave.runner:Runner
    Exception KeyError: "'__name__' not in globals"
    Traceback (most recent call last):
      File "/usr/local/bin/behave", line 8, in <module>
	sys.exit(main())
		 ~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/__main__.py", line 291, in main
	return run_behave(config)
      File "/usr/local/lib/python3.14/site-packages/behave/__main__.py", line 113, in run_behave
	failed = runner.run()
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1138, in run
	return self.run_with_paths()
	       ~~~~~~~~~~~~~~~~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1143, in run_with_paths
	self.load_step_definitions()
	~~~~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1130, in load_step_definitions
	load_step_modules(step_paths)
	~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner_util.py", line 596, in load_step_modules
	exec_file(os.path.join(path, name), step_module_globals)
	~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner_util.py", line 567, in exec_file
	exec(code, globals_, locals_)
	~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
      File "dnf/steps/lib/dnf.py", line 9, in <module>
	from .rpm import normalize_epoch
    KeyError: "'__name__' not in globals"

context.config.tags is not behave.tag_expression.TagExpression anymore:

    HOOK-ERROR in before_all: AttributeError: 'str' object has no attribute 'ands'
    ABORTED: HOOK-ERROR in hook=before_all

Fixing the first issue is possible, but the second issue looks like a bug in behave. Until proper fixes are developed in ci-dnf-stack and/or behave, require behave = 1.2.6.

Fedora delivers that version, that version is still available from PyPI.

Related: #1715
@janblazek, please.