### PR TITLE
rhel-8.4.0: Pin behave to 1.2.6

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -68,7 +68,7 @@ RUN set -x && \
     yum -y install \
         # behave and test requirements
         libfaketime \
-        # python2-behave - version >= 1.2.6 is not available as an RPM; install it from pip instead
+        # python2-behave - version == 1.2.6 is not available as an RPM; install it from pip instead
         python2-pip \
         pexpect \
         sqlite \
@@ -97,7 +97,7 @@ RUN set -x && \
         # dnf-utils \
         libdnf \
         microdnf && \
-    pip install 'behave >= 1.2.6'
+    pip install 'behave == 1.2.6'
 
 
 # if TYPE == local, install local RPMs

--- a/Dockerfile.f32
+++ b/Dockerfile.f32
@@ -61,7 +61,7 @@ RUN set -x && \
         findutils \
         glibc-langpack-en \
         libfaketime \
-        python3-behave \
+        'python3-behave < 1.2.7' \
         python3-pexpect \
         python3-pip \
         rpm-build \

--- a/Dockerfile.f33
+++ b/Dockerfile.f33
@@ -62,7 +62,7 @@ RUN set -x && \
         glibc-langpack-en \
         libfaketime \
         openssl \
-        python3-behave \
+        'python3-behave < 1.2.7' \
         python3-pexpect \
         python3-pip \
         rpm-build \


### PR DESCRIPTION
Upstream commit: 354b1bc528e0b15aff7bb7e5d80a41f01f2130b0

Upstream releases new 1.3.0 version after 7 years. It contains few incompatibilities:

Relative Python imports do not work:

    # behave dnf
    USING RUNNER: behave.runner:Runner
    Exception KeyError: "'__name__' not in globals"
    Traceback (most recent call last):
      File "/usr/local/bin/behave", line 8, in <module>
	sys.exit(main())
		 ~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/__main__.py", line 291, in main
	return run_behave(config)
      File "/usr/local/lib/python3.14/site-packages/behave/__main__.py", line 113, in run_behave
	failed = runner.run()
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1138, in run
	return self.run_with_paths()
	       ~~~~~~~~~~~~~~~~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1143, in run_with_paths
	self.load_step_definitions()
	~~~~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner.py", line 1130, in load_step_definitions
	load_step_modules(step_paths)
	~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner_util.py", line 596, in load_step_modules
	exec_file(os.path.join(path, name), step_module_globals)
	~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.14/site-packages/behave/runner_util.py", line 567, in exec_file
	exec(code, globals_, locals_)
	~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
      File "dnf/steps/lib/dnf.py", line 9, in <module>
	from .rpm import normalize_epoch
    KeyError: "'__name__' not in globals"

context.config.tags is not behave.tag_expression.TagExpression anymore:

    HOOK-ERROR in before_all: AttributeError: 'str' object has no attribute 'ands'
    ABORTED: HOOK-ERROR in hook=before_all

Fixing the first issue is possible, but the second issue looks like a bug in behave. Until proper fixes are developed in ci-dnf-stack and/or behave, require behave = 1.2.6.

Fedora delivers that version, that version is still available from PyPI.

Related: #1715
@janblazek, please.