### PR TITLE
rhel-8.8.0: `upgrade --security` doesn't upgrade packages with resolved advisories

### DIFF
--- a/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-1-1.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-1-1.i686.spec
@@ -1,0 +1,16 @@
+Name:           libnsl
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-1-1.spec
@@ -1,0 +1,16 @@
+Name:           libnsl
+Epoch:          0
+Version:        1
+Release:        1
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-2-2.i686.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-2-2.i686.spec
@@ -1,0 +1,16 @@
+Name:           libnsl
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-2-2.spec
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/libnsl-2-2.spec
@@ -1,0 +1,16 @@
+Name:           libnsl
+Epoch:          0
+Version:        2
+Release:        2
+
+License:        Public Domain
+URL:            None
+
+Summary:        Testing advisory upgrade options
+
+%description
+This package is part of testing security options
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/security-upgrade/updateinfo.xml
@@ -163,4 +163,24 @@
             </collection>
         </pkglist>
     </update>
+
+    <update from="dnf-testing@redhat.com" status="stable" type="security" version="1">
+        <id>DNF-2019-99</id>
+        <title>upgrade all packages in all archs</title>
+        <release>Fedora 29</release>
+        <issue date="2019-02-22 15:30:01" />
+        <references />
+        <description>When WIP</description>
+        <pkglist>
+            <collection short="F29">
+                <name>Fedora 29</name>
+                <package name="libnsl" version="1" release="1" epoch="0" arch="i686" src="https://the.url/the.package.rpm">
+                    <filename>libnsl-1-1.i686.rpm</filename>
+                </package>
+                <package name="libnsl" version="1" release="1" epoch="0" arch="x86_64" src="https://the.url/the.package.rpm">
+                    <filename>libnsl-1-1.x86_64.rpm</filename>
+                </package>
+            </collection>
+        </pkglist>
+    </update>
 </updates>


### PR DESCRIPTION
This is a cherry-pick of ebc01c65174cca31704caa0f66e440dfc6c1a830 to rhel-8.8.0.

Related: RHEL-107042