### PR TITLE
rhel-10.1: protected-packages: Isolate protected-yum test by an installroot

### DIFF
--- a/dnf-behave-tests/dnf/protected-packages.feature
+++ b/dnf-behave-tests/dnf/protected-packages.feature
@@ -47,16 +47,20 @@ Scenario: Package with protected dependency via setopt cannot be removed
 
 
 # TODO: Removal of DNF itself
-# - doesn't makes sense to test in installroot
-# - a potentially destructive test
-
-
+# - It is performed in an installroot not to modify the host in case of
+#   a failure.
+# - It intentionally uses host's protected_packages to test how DNF is
+#   packaged on the host.
+# - It disables clean_requirements_on_remove to prevent protected dependecies
+#   appearing in the error message.
 @use.with_os=rhel__ge__8
-@no_installroot
 Scenario: Dnf when installed protects yum package, because of dnf yum alias
   Given I use repository "dnf-ci-fedora"
    When I execute dnf with args "install yum"
    Then the exit code is 0
-   When I execute dnf with args "remove yum"
+    And Transaction is following
+        | Action        | Package              |
+        | install       | yum-0:3.4.3-0.x86_64 |
+   When I execute dnf with args "--setopt protected_packages='glob:/etc/dnf/protected.d/*' --setopt=clean_requirements_on_remove=false remove yum"
    Then the exit code is 1
     And stderr contains "operation would result in removing the following protected packages: yum"


### PR DESCRIPTION
Upstream commit: 4e3ec20922e65b2e697028f0ccdbd7467e7d12f2

Previously the "Dnf when installed protects yum package, because of dnf yum alias" failed in some environments, e.g. Testing farm, like this:

    Feature: Protected packages # dnf/protected-packages.feature:1

      @use.with_os=rhel__ge__8 @no_installroot
      Scenario: Dnf when installed protects yum package, because of dnf yum alias                      # dnf/protected-packages.feature:56
        Given I use repository "dnf-ci-fedora"                                                         # dnf/steps/repo.py:182
        When I execute dnf with args "install yum"                                                     # dnf/steps/cmd.py:106
        Then the exit code is 0                                                                        # common/output.py:57
        When I execute dnf with args "remove yum"                                                      # dnf/steps/cmd.py:106
        Then the exit code is 1                                                                        # common/output.py:57
        And stderr contains "operation would result in removing the following protected packages: yum" # dnf/steps/cmd.py:288
          Assertion Failed: Stderr doesn't contain: operation would result in removing the following protected packages: yum
          Captured stdout:
          Last Command: dnf -y --releasever=29 --setopt=module_platform_id=platform:f29 --disableplugin='*' remove yum
          Last Command stdout:
          (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
          Last Command stderr:
          Error:
           Problem: The operation would result in removing the following protected packages: dnf, yum

The cause was that it tested yum in the host system and the host system installed dnf as a yum dependency. Together with default clean_requirements_on_remove=true, "dnf remove yum" attempted to uninstall both yum and dnf and reported both of them protected (yum because of an explicit listing in /etc/dnf/protected.d, dnf because of a hard-coded self protection).

This patch fixes the failure by adding
--setopt=clean_requirements_on_remove=false option to the "dnf remove" command.

This patch also removes the @no_installroot tag to make this possibly destructive test safe for the host. Then it points protected_packages to host's configuration to test how that configuration is packaged. It is intention of this test to check how DNF is packaged.

This patch only targets DNF4 because "yum" package does not exist in DNF5. DNF5 emits completely different error on removing by an RPM Provide symbol.

Resolve: #1746