### PR TITLE
dnf-nightly: overlay: remove workaround branch name extension

### DIFF
--- a/overlays/dnf-nightly/overlay.yml
+++ b/overlays/dnf-nightly/overlay.yml
@@ -54,7 +54,7 @@ components:
   - name: libdnf
     git:
       src: github:rpm-software-management/libdnf.git
-      branch: origin/dnf-4-master
+      branch: dnf-4-master
     requires:
       - libsolv
       - libmodulemd


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/rpm-gitoverlay/pull/40

This was required because `rpm-gitoverlay` clone used the default branch and it was using `git cat-file -p branch:spec_path` to get the contents of the spec file. However if there are patches and it later tries to copy them it doesn't work because it assumes the patches are available (even though they might be on a different branch).

With: https://github.com/rpm-software-management/rpm-gitoverlay/pull/40 we no longer need this because after cloning we are checkedout in the requested branch.

These two patches (and `rpm-gitoverlay` build) should fix the nightly builds.

I think that a change of default branch of https://gitlab.com/CentOS/archives/git.centos.org/rpms/libsolv/ caused this problem to surface.

----

I wonder if it makes sense to maintain `rpm-gitoverlay` going forward. I think we now use it only for the nighly builds and we should be able to move those to `packit` as well.