### PR TITLE
Disable coloring in Python interpreter

### DIFF
--- a/dnf-behave-tests/dnf/steps/shell.py
+++ b/dnf-behave-tests/dnf/steps/shell.py
@@ -36,7 +36,7 @@ def when_I_open_dnf_shell(context):
     context.cmd = cmd
     context.dnf["rpmdb_pre"] = get_rpmdb_rpms(context.dnf.installroot)
 
-    context.shell_session = pexpect.spawn(cmd, env = {"COLORTERM": "FALSE"})
+    context.shell_session = pexpect.spawn(cmd, env = {"COLORTERM": "FALSE", "NO_COLOR": "TRUE"})
     # pexpect adds a short delay before sending data, so that SSH has time
     # to turn off TTY echo; the echo is still there though, so removing the delay
     context.shell_session.delaybeforesend = None


### PR DESCRIPTION
"Using dnf shell, list available commands" (dnf/shell-help.feature:6) test failed with Python 3.14.0~rc2:

~~~~
  Scenario: Using dnf shell, list available commands (dnf)                              # dnf/shell-help.feature:6
    Given I set dnf command to "dnf"                                                    # dnf/steps/cmd.py:192
    When I open dnf shell session                                                       # dnf/steps/shell.py:33
    And I execute in dnf shell "help"                                                   # dnf/steps/shell.py:48
    [...]
    And stdout contains "-q, --quiet\s+quiet operation"                                 # dnf/steps/cmd.py:237
      Assertion Failed: Stdout doesn't contain: -q, --quiet\s+quiet operation
      Captured stdout:
      [...]
         [1;32m-q [0m,  [1;36m--quiet [0m           quiet operation
~~~~

The cause is that Python 3.14 enabled coloring in argparse help output <https://github.com/python/cpython/issues/130645>.

This patch fixes the test by disabling Python coloring for all executions of the DNF shell.