### PR TITLE
Ignore RPM transaction order

### DIFF
--- a/dnf-behave-tests/dnf/transaction-output.feature
+++ b/dnf-behave-tests/dnf/transaction-output.feature
@@ -57,12 +57,12 @@ Scenario: Packages in transaction are sorted by NEVRA
       Transaction test succeeded.
       Running transaction
         Preparing        :                                                        1/1
-        Installing       : setup-2.12.1-1.fc29.noarch                            1/11
-        Installing       : filesystem-3.9-2.fc29.x86_64                          2/11
-        Installing       : basesystem-11-6.fc29.noarch                           3/11
-        Installing       : glibc-all-langpacks-2.28-9.fc29.x86_64                4/11
-        Installing       : glibc-common-2.28-9.fc29.x86_64                       5/11
-        Installing       : glibc-2.28-9.fc29.x86_64                              6/11
+        Installing       : *
+        Installing       : *
+        Installing       : *
+        Installing       : *
+        Installing       : *
+        Installing       : *
         Installing       : *
         Installing       : *
         Installing       : *


### PR DESCRIPTION
After upgrading rpm from 4.20.1-1.fc42 to 5.99.91-5.fc43, "Packages in transaction are sorted by NEVRA" (dnf/transaction-output.feature:20) failed like this:

~~~~
  @bz1773436
  Scenario: Packages in transaction are sorted by NEVRA                # dnf/transaction-output.feature:20
    Given I use repository "dnf-ci-fedora"                             # dnf/steps/repo.py:183
    And I use repository "dnf-ci-thirdparty"                           # dnf/steps/repo.py:183
    When I execute dnf with args "install wget glibc flac SuperRipper" # dnf/steps/cmd.py:106
    Then the exit code is 0                                            # common/output.py:57
    And stdout matches line by line                                    # common/output.py:119
      Running transaction
        Preparing        :                                                        1/1
        Installing       : setup-2.12.1-1.fc29.noarch                            1/11
        Installing       : filesystem-3.9-2.fc29.x86_64                          2/11
        Installing       : basesystem-11-6.fc29.noarch                           3/11
        Installing       : glibc-all-langpacks-2.28-9.fc29.x86_64                4/11
        Installing       : glibc-common-2.28-9.fc29.x86_64                       5/11
        Installing       : glibc-2.28-9.fc29.x86_64                              6/11
        Installing       : *
  [...]
      Assertion Failed: 'Installing       : glibc-all-langpacks-2.28-9.fc29.x86_64                4/11' regexp does not match line: '  Installing       : glibc-2.28-9.fc29.x86_64                              4/11 '
      Captured stdout:
      Running transaction
        Preparing        :                                                        1/1
        Installing       : setup-2.12.1-1.fc29.noarch                            1/11
        Installing       : filesystem-3.9-2.fc29.x86_64                          2/11
        Installing       : basesystem-11-6.fc29.noarch                           3/11
        Installing       : glibc-2.28-9.fc29.x86_64                              4/11
        Installing       : glibc-common-2.28-9.fc29.x86_64                       5/11
        Installing       : glibc-all-langpacks-2.28-9.fc29.x86_64                6/11
  [...]
~~~~

The cause was RPM library which changed how it orders installation items in a transaction.

Because the transaction order is fully under control of RPM and it is not a DNF business, it does not make sense to test it. A purpose of the affected test is to check an alphabetical order in a proposal of the transaction, i.e. in a table printed before a user confirms it.

This fix completely ignores order of all installation items in the RPM transaction output.

This test was already partially fixed this way in commit 25e98f358850a14788c715feab046b424d3f84a6 (Update transaction-output test not to rely on rpm processing order). But that fix was for an unknown reason incomplete.