### PR TITLE
Actions plugin: Check for "0" instead of "false" in response

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/actions-json_mode.feature
+++ b/dnf-behave-tests/dnf/plugins-core/actions-json_mode.feature
@@ -236,7 +236,7 @@ check_reply(
      "return": {
          "keys_val": [{"key": "repo_id", "value": "test-repo"},
                       {"key": "name", "value": "Test repository"},
-                      {"key": "enabled", "value": "false"},
+                      {"key": "enabled", "value": "0"},
                       {"key": "baseurl", "value": "https://xyz.com/rpm"}]}})
 
 send_request({"op": "get", "domain": "conf", "args": {"key": "*.enabled"}})


### PR DESCRIPTION
Actions plugin responds with actual values. Boolean values in response are always represented as "0" and "1", even if the request was "false" or "true".

Requires: https://github.com/rpm-software-management/dnf5/pull/2444