### PR TITLE
Replace deprecated python3-toml with tomllib

### DIFF
--- a/dnf-behave-tests/dnf/steps/module.py
+++ b/dnf-behave-tests/dnf/steps/module.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import behave
 import os
-import toml
+import tomllib
 
 from common.lib.behave_ext import check_context_table
 from lib.dnf import parse_module_list
@@ -41,8 +41,8 @@ def get_modules_state(installroot):
     states_filepath = os.path.join(installroot, "usr/lib/sysimage/libdnf5/modules.toml")
     if not os.path.exists(states_filepath):
         return found_modules
-    with open(states_filepath) as f:
-        for section_name, section_dict in toml.load(f)["modules"].items():
+    with open(states_filepath, "rb") as f:
+        for section_name, section_dict in tomllib.load(f)["modules"].items():
             module_dict = dict()
             if section_dict.get("state"):
                 module_dict["state"] = section_dict["state"].lower()

--- a/dnf-behave-tests/dnf/steps/system_state.py
+++ b/dnf-behave-tests/dnf/steps/system_state.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import behave
 import os
-import toml
+import tomllib
 
 from common.lib.behave_ext import check_context_table
 from common.lib.diff import print_lines_diff
@@ -29,14 +29,14 @@ def package_state_is(context):
     check_context_table(context, ["package", "reason", "from_repo"])
 
     found_pkgs = []
-    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/libdnf5/packages.toml")) as f:
-        for k, v in toml.load(f)["packages"].items():
+    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/libdnf5/packages.toml"), "rb") as f:
+        for k, v in tomllib.load(f)["packages"].items():
             found_pkgs.append((k, v["reason"]))
     found_pkgs.sort()
 
     found_nevras = []
-    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/libdnf5/nevras.toml")) as f:
-        for k, v in toml.load(f)["nevras"].items():
+    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/libdnf5/nevras.toml"), "rb") as f:
+        for k, v in tomllib.load(f)["nevras"].items():
             found_nevras.append((k, v["from_repo"]))
     found_nevras.sort()
 
@@ -78,8 +78,8 @@ def group_state_is(context):
     check_context_table(context, ["id", "package_types", "packages", "userinstalled"])
 
     found_groups = []
-    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/libdnf5/groups.toml")) as f:
-        for k, v in toml.load(f)["groups"].items():
+    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/libdnf5/groups.toml"), "rb") as f:
+        for k, v in tomllib.load(f)["groups"].items():
             pkg_types = v["package_types"]
             pkg_types.sort()
             pkgs = v["packages"]
@@ -118,8 +118,8 @@ def environment_state_is(context):
     check_context_table(context, ["id", "groups"])
 
     found_environments = []
-    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/libdnf5/environments.toml")) as f:
-        for k, v in toml.load(f)["environments"].items():
+    with open(os.path.join(context.dnf.installroot, "usr/lib/sysimage/libdnf5/environments.toml"), "rb") as f:
+        for k, v in tomllib.load(f)["environments"].items():
             groups = v["groups"]
             groups.sort()
             found_environments.append((k, ', '.join(groups)))

--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -24,13 +24,12 @@ BuildRequires:  glibc-langpack-en
 BuildRequires:  glibc-langpack-de
 BuildRequires:  libfaketime
 BuildRequires:  openssl
-BuildRequires:  python3
+BuildRequires:  python3 >= 3.11
 BuildRequires:  python3-distro
 BuildRequires:  python3-pip
 BuildRequires:  python3-rpm
 # a missing dep of python3-pip on f35 beta, remove when unneeded
 BuildRequires:  python3-setuptools
-BuildRequires:  python3-toml
 BuildRequires:  rpm-build
 BuildRequires:  rpm-sign
 BuildRequires:  sqlite


### PR DESCRIPTION
tomllib is the build-in TOML parser avaliable since Python 3.11 and is
the recommended replacement for the deprecated toml package.

I saw some CI stack failures due to python3-toml not being available - https://artifacts.dev.testing-farm.io/551205f8-e08e-44d6-b429-1951fe15f0d1/work-behave-createrepo_c3h4oepea/tmt-run.log