### PR TITLE
dnf-4-stack: Add libpkgmanifest to overlays

### DIFF
--- a/overlays/dnf-ci/overlay.yml
+++ b/overlays/dnf-ci/overlay.yml
@@ -4,6 +4,11 @@ aliases:
     url: https://github.com/
 
 components:
+  - name: libpkgmanifest
+    version-from: git
+    git:
+      src: github:rpm-software-management/libpkgmanifest.git
+
   - name: librepo
     git:
       src: github:rpm-software-management/librepo.git
@@ -32,6 +37,7 @@ components:
     requires:
       - libdnf
       - dnf
+      - libpkgmanifest
 
   - name: dnf-plugins-extras
     git:

--- a/overlays/dnf-nightly/overlay.yml
+++ b/overlays/dnf-nightly/overlay.yml
@@ -33,6 +33,11 @@ components:
     git:
       src: github:rpm-software-management/drpm.git
 
+  - name: libpkgmanifest
+    version-from: git
+    git:
+      src: github:rpm-software-management/libpkgmanifest.git
+
   - name: librepo
     git:
       src: github:rpm-software-management/librepo.git
@@ -74,6 +79,7 @@ components:
     requires:
       - libdnf
       - dnf
+      - libpkgmanifest
 
   - name: dnf-plugins-extras
     git:

--- a/overlays/dnf5-ci/overlay.yml
+++ b/overlays/dnf5-ci/overlay.yml
@@ -4,6 +4,11 @@ aliases:
     url: https://github.com/
 
 components:
+  - name: libpkgmanifest
+    version-from: git
+    git:
+      src: github:rpm-software-management/libpkgmanifest.git
+
   - name: librepo
     git:
       src: github:rpm-software-management/librepo.git
@@ -13,3 +18,4 @@ components:
       src: github:rpm-software-management/dnf5.git
     requires:
       - librepo
+      - libpkgmanifest


### PR DESCRIPTION
dnf-pluings-core links to libpkgmanifest. dnf5 is going to use libpkgmanifest too. We need to start building libpkgmanifest regularly from git to ensure that API and ABI matche. Otherwise, ci-dnf-stack could die when building the container like this one for DNF4:

        + dnf -y builddep /opt/ci/dnf-behave-tests/requirements.spec
        Traceback (most recent call last):
          File "/usr/bin/dnf", line 57, in <module>
            main.user_main(sys.argv[1:], exit_code=True)
            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/usr/lib/python3.14/site-packages/dnf/cli/main.py", line 208, in user_main
            errcode = main(args)
          File "/usr/lib/python3.14/site-packages/dnf/cli/main.py", line 67, in main
            return _main(base, args, cli_class, option_parser_class)
          File "/usr/lib/python3.14/site-packages/dnf/cli/main.py", line 102, in _main
            cli.configure(list(map(ucd, args)), option_parser())
            ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/usr/lib/python3.14/site-packages/dnf/cli/cli.py", line 901, in configure
            self.base.init_plugins(opts.disableplugin, opts.enableplugin, self)
            ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/usr/lib/python3.14/site-packages/dnf/base.py", line 315, in init_plugins
            self._plugins._load(self.conf, disabled_glob, enable_plugins)
            ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/usr/lib/python3.14/site-packages/dnf/plugin.py", line 142, in _load
            self._check_enabled(conf, enable_plugins)
            ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
          File "/usr/lib/python3.14/site-packages/dnf/plugin.py", line 123, in _check_enabled
            parser = plug_cls.read_config(conf)
          File "/usr/lib/python3.14/site-packages/dnf/plugin.py", line 58, in read_config
            files = ['%s/%s.conf' % (path, name) for path in conf.pluginconfpath]
                                                             ^^^^^^^^^^^^^^^^^^^
          File "/usr/lib64/python3.14/site-packages/libpkgmanifest/manifest.py", line 200, in __iter__
            return self.iterator()
                   ~~~~~~~~~~~~~^^
          File "/usr/lib64/python3.14/site-packages/libpkgmanifest/manifest.py", line 198, in iterator
            return _manifest.VectorString_iterator(self)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
        TypeError: in method 'VectorString_iterator', argument 1 of type 'std::vector< std::string > *'
        Error: building at STEP "RUN set -x &&     dnf -y builddep /opt/ci/dnf-behave-tests/requirements.spec &&     pip3 install -r /opt/ci/dnf-behave-tests/requirements.txt": while running runtime: exit status 1
        Error: Failed to build the container.

This patch adds libpkgmanifest to all overlays where dnf-plugins-core or dnf5 is present. Except of dnf5-unstable which intentinoally relies on dependencies from the distributions.