### PR TITLE
Do not build libpkgmanifest on RHEL 9

### DIFF
--- a/overlays/dnf-ci/overlay.yml
+++ b/overlays/dnf-ci/overlay.yml
@@ -8,6 +8,14 @@ components:
     version-from: git
     git:
       src: github:rpm-software-management/libpkgmanifest.git
+    distgit-overrides:
+      - chroots:
+          - epel-10-x86_64
+          - fedora-eln-x86_64
+          - fedora-rawhide-x86_64
+          - fedora-41-x86_64
+          - fedora-42-x86_64
+          - fedora-43-x86_64
 
   - name: librepo
     git:

--- a/overlays/dnf-nightly/overlay.yml
+++ b/overlays/dnf-nightly/overlay.yml
@@ -37,6 +37,14 @@ components:
     version-from: git
     git:
       src: github:rpm-software-management/libpkgmanifest.git
+    distgit-overrides:
+      - chroots:
+          - epel-10-x86_64
+          - fedora-eln-x86_64
+          - fedora-rawhide-x86_64
+          - fedora-41-x86_64
+          - fedora-42-x86_64
+          - fedora-43-x86_64
 
   - name: librepo
     git:

--- a/overlays/dnf5-ci/overlay.yml
+++ b/overlays/dnf5-ci/overlay.yml
@@ -8,6 +8,14 @@ components:
     version-from: git
     git:
       src: github:rpm-software-management/libpkgmanifest.git
+    distgit-overrides:
+      - chroots:
+          - epel-10-x86_64
+          - fedora-eln-x86_64
+          - fedora-rawhide-x86_64
+          - fedora-41-x86_64
+          - fedora-42-x86_64
+          - fedora-43-x86_64
 
   - name: librepo
     git:

--- a/overlays/dnf5-testing-nightly/overlay.yml
+++ b/overlays/dnf5-testing-nightly/overlay.yml
@@ -17,6 +17,14 @@ components:
     version-from: git
     git:
       src: github:rpm-software-management/libpkgmanifest.git
+    distgit-overrides:
+      - chroots:
+          - epel-10-x86_64
+          - fedora-eln-x86_64
+          - fedora-rawhide-x86_64
+          - fedora-41-x86_64
+          - fedora-42-x86_64
+          - fedora-43-x86_64
 
   - name: dnf
     git:


### PR DESCRIPTION
It requires yaml-cpp ≥ 0.7.0 and swig ≥ 4.2.0 which do not exist in RHEL 9. The team decided on 2025-10-06 meeting that libpkgmanifs won't be supported there.