### PR TITLE
Do not install behave from RPM on Fedora >= 44

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -36,7 +36,9 @@ BuildRequires:  sqlite
 BuildRequires:  yq
 BuildRequires:  zstd
 %if 0%{?fedora}
+%if 0%{?fedora} < 44
 BuildRequires:  python3-behave < 1.2.7
+%endif
 BuildRequires:  python3-pexpect
 BuildRequires:  zchunk
 %endif


### PR DESCRIPTION
Fedora 44 rebased behave to 1.3.3 which is incompatible with current ci-dnf-stack. The rebase was correctly caught by a version constraint in requirements.spec, but prevented from building the testing container:

~~~
    + dnf5 -y builddep /opt/ci/dnf-behave-tests/requirements.spec -x 'libfaketime-0.9.12-1.*'
    Updating and loading repositories:
    Repositories loaded.
    Failed to resolve the transaction:
    [...]
    No match for argument: python3-behave < 1.2.7
~~~

This patch removes the RPM dependency on Fedora ≥ 44 and relies on an installation from PyPi.

Related: #1715