### PR TITLE
dnf-4-stack: Do not install behave from RPM on Fedora >= 44

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -35,7 +35,9 @@ BuildRequires:  sqlite
 BuildRequires:  yq
 BuildRequires:  zstd
 %if 0%{?fedora}
+%if 0%{?fedora} < 44
 BuildRequires:  python3-behave < 1.2.7
+%endif
 BuildRequires:  python3-pexpect
 BuildRequires:  zchunk
 %endif


### PR DESCRIPTION
Fedora 44 rebased behave to 1.3.3 which is incompatible with current ci-dnf-stack. The rebase was correctly caught by a version constraint in requirements.spec, but prevented from building the testing container:

~~~~
    + dnf -y builddep /opt/ci/dnf-behave-tests/requirements.spec
    [...]
    No matching package to install: 'python3-behave < 1.2.7'
    [...]
    Not all dependencies satisfied
    Error: Some packages could not be found.
~~~~
This patch removes the RPM dependency on Fedora ≥ 44 and relies on an installation from PyPi.

Related: #1715