### PR TITLE
Adapt to curl-8.17.0-rc1

### DIFF
--- a/dnf-behave-tests/dnf/ssl.feature
+++ b/dnf-behave-tests/dnf/ssl.feature
@@ -92,7 +92,7 @@ Scenario: Installation with untrusted repository should fail
     And stderr matches line by line
     """
     Errors during downloading metadata for repository 'simple-base':
-      - Curl error \(60\): .* for https://localhost:[0-9]+/repodata/repomd\.xml \[SSL certificate problem:.*\]
+      - Curl error \(60\): .* for https://localhost:[0-9]+/repodata/repomd\.xml \[SSL certificate (OpenSSL verify result|problem):.*\]
     Error: Failed to download metadata for repo 'simple-base': Cannot download repomd\.xml: Cannot download repodata/repomd\.xml: All mirrors were tried
     """
 


### PR DESCRIPTION
With curl-8.17.0-rc1 "Installation with untrusted repository should fail" scenario failed:

      Assertion Failed: '- Curl error \(60\): .* for https://localhost:[0-9]+/repodata/repomd\.xml \[SSL certificate problem:.*\]' regexp does not match line: '  - Curl error (60): SSL peer certificate or SSH remote key was not OK for https://localhost:41333/repodata/repomd.xml [SSL certificate OpenSSL verify result: self-signed certificate in certificate chain (19)]'

The cause was a change in the error message curl returns when a certificate cannot be verified. The message changed in curl-8.17.0-rc1.

This patch fixes it by accepting both old new new messages.