### PR TITLE
Rotating logger preserves file mode and ACL

### DIFF
--- a/dnf-behave-tests/dnf/log-rotate.feature
+++ b/dnf-behave-tests/dnf/log-rotate.feature
@@ -26,3 +26,34 @@ Scenario: Size and number of log files respects log_size and log_rotate options
    Then size of file "var/log/dnf5.log" is at most "1024"
    Then size of file "var/log/dnf5.log.1" is at most "1024"
    Then size of file "var/log/dnf5.log.2" is at most "1024"
+
+
+# Log rotation cannot work within installroot
+@no_installroot
+# https://github.com/rpm-software-management/dnf5/issues/1820
+@bz1910084
+Scenario: Log rotation keeps file permissions
+Given I use repository "dnf-ci-fedora-updates"
+  And I successfully execute dnf with args "install flac"
+    # Set permissions to 600
+  And I successfully execute "chmod 600 /var/log/dnf5.log"
+    # Run dnf again, so that files are rotated
+ When I execute dnf with args "--setopt=log_size=1 --setopt=log_rotate=2 remove flac"
+ Then the exit code is 0
+  And file "/var/log/dnf5.log" has mode "600"
+  And file "/var/log/dnf5.log.1" has mode "600"
+
+
+# Log rotation cannot work within installroot
+@no_installroot
+# https://github.com/rpm-software-management/dnf5/issues/2487
+Scenario: Log rotation keeps ACL
+Given I use repository "dnf-ci-fedora-updates"
+  And I successfully execute dnf with args "install flac"
+    # Set non-default ACL
+  And I successfully execute "setfacl -m user:root:r /var/log/dnf5.log"
+    # Run dnf again, so that files are rotated
+ When I execute dnf with args "--setopt=log_size=1 --setopt=log_rotate=2 remove flac"
+ Then the exit code is 0
+  And file "/var/log/dnf5.log" has ACL entry "user:root:r--"
+  And file "/var/log/dnf5.log.1" has ACL entry "user:root:r--"

--- a/dnf-behave-tests/dnf/logs.feature
+++ b/dnf-behave-tests/dnf/logs.feature
@@ -46,18 +46,3 @@ Given I use repository "dnf-ci-fedora-updates"
  Then the exit code is 0
   And file "/var/log/dnf5.log" has mode "600"
 Given I set umask to "0022"
-
-
-@xfail
-# https://github.com/rpm-software-management/dnf5/issues/1820
-@bz1910084
-Scenario: Log rotation keeps file permissions
-Given I use repository "dnf-ci-fedora-updates"
-  And I successfully execute dnf with args "install flac"
-    # Set permissions to 600
-  And I successfully execute "chmod 600 {context.dnf.installroot}/var/log/dnf5.log"
-    # Run dnf again, so that files are rotated
- When I execute dnf with args "--setopt=log_size=100 --setopt=log_rotate=2 remove flac"
- Then the exit code is 0
-  And file "/var/log/dnf5.log" has mode "600"
-  And file "/var/log/dnf5.log.1" has mode "600"

--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -16,6 +16,7 @@ License:        GPLv3
 
 
 # test suite dependencies
+BuildRequires:  acl
 BuildRequires:  attr
 BuildRequires:  createrepo_c
 BuildRequires:  fakeuname


### PR DESCRIPTION
This checks that the rotating logger preserves file mode and file access control list which a user set on the log file before executing dnf.

It enables a test for the file mode and adds a new test for ACL.

Because log rotation only works outside of installroot, it adds no_installroot tag to the tests.

Because behave fails to execute multiple no_installroot scenarios from one feature file, it moves them into separate files.

For: https://github.com/rpm-software-management/dnf5/issues/1820
For: https://github.com/rpm-software-management/dnf5/issues/2487
Requires: https://github.com/rpm-software-management/dnf5/pull/2494