### PR TITLE
dnf4: distro-sync nightly packages with dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,7 @@ RUN set -x && \
 RUN set -x && \
     if [ "$TYPE" == "nightly" ]; then \
         dnf -y copr enable rpmsoftwaremanagement/dnf-nightly; \
-        # run upgrade before distro-sync in case there is a new version in dnf-nightly that has a new dependency
-        dnf -y upgrade; \
-        dnf -y distro-sync --repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly; \
+        dnf5 -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*' ; \
     fi
 
 RUN set -x && \


### PR DESCRIPTION
Building a container failed on "dnf -y distro-sync --repo copr..." command on Fedora 44 with this error:

    nothing provides libyaml-cpp.so.0.8()(64bit) needed by libpkgmanifest-0.5.9-1.20251120011136697201.main.7.g5ea5353.fc44.x86_64 from copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly

The cause is was that a new python3-dnf-plugins-core required libpkgmanifest which required yaml-cpp, but yaml-cpp was not installed and "dnf -y distro-sync --repo copr" effectively disabled distrbution repositories with yaml-cpp.

After a discussion in the team, I went with `dnf5 distro-sync --from-repo copr... '*'` fix instead of preinstalling the particular dependency.