### PR TITLE
dnf5: distro-sync nightly packages with dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ RUN set -x && \
     dnf -y install dnf5 dnf5-plugins; \
     dnf5 -y copr enable rpmsoftwaremanagement/test-utils; \
     dnf5 -y copr enable rpmsoftwaremanagement/dnf-nightly; \
-    # run upgrade before distro-sync in case there is a new version in dnf-nightly that has a new dependency
-    dnf5 -y upgrade; \
-    dnf5 -y distro-sync --repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly;
+    dnf5 -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*'
 
 RUN set -x && \
     if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then \


### PR DESCRIPTION
This is a fore-port of this DNF4 issue (see PR #1785):

    Building a container failed on "dnf -y distro-sync --repo copr..."
    command on Fedora 44 with this error:

        nothing provides libyaml-cpp.so.0.8()(64bit) needed by libpkgmanifest-0.5.9-1.20251120011136697201.main.7.g5ea5353.fc44.x86_64 from copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly

    The cause was that a new python3-dnf-plugins-core required
    libpkgmanifest which required yaml-cpp, but yaml-cpp was not installed
    and "dnf -y distro-sync --repo copr" effectively disabled distribution
    repositories with yaml-cpp.

We could run into the same issue in ci-dnf-stack for DNF5 too.

This patch fixes it with "dnf5 distro-sync --from-repo copr...", making the unreliable update redundant.