### PR TITLE
Fix new repoquery srpm test package

### DIFF
--- a/dnf-behave-tests/dnf/repoquery/main.feature
+++ b/dnf-behave-tests/dnf/repoquery/main.feature
@@ -32,6 +32,7 @@ Scenario: repoquery (no arguments, i.e. list all packages)
       mid-a2-1:1.0-1.x86_64
       multipackage-1:1.0-1.src
       multipackage-1:1.0-1.x86_64
+      multipackage-docs-1:1.0-1.x86_64
       top-a-1:1.0-1.src
       top-a-1:1.0-1.x86_64
       top-a-1:2.0-1.src

--- a/dnf-behave-tests/fixtures/specs/repoquery-main/multipackage.spec
+++ b/dnf-behave-tests/fixtures/specs/repoquery-main/multipackage.spec
@@ -19,4 +19,6 @@ Dummy docs as a subpackage.
 
 %files
 
+%files docs
+
 %changelog


### PR DESCRIPTION
It seems the %files section is mandatory, otherwise the subpackage is not generated.