### PR TITLE
rhel-10.2: versionlock: Local packages are not affected

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/versionlock-exclude.feature
+++ b/dnf-behave-tests/dnf/plugins-core/versionlock-exclude.feature
@@ -48,3 +48,13 @@ Scenario: The excluded version of the package is not installed as a dependency
         | install       | abcde-0:2.9.3-1.fc29.noarch           |
         | install-dep   | wget-0:1.19.5-5.fc29.x86_64           |
         | install-weak  | flac-0:1.3.3-3.fc29.x86_64            |
+
+
+Scenario: The excluded newest version of the package is installed when passed as a local file
+   When I execute dnf with args "install {context.dnf.fixturesdir}/repos/dnf-ci-fedora-updates/x86_64/wget-1.19.6-5.fc29.x86_64.rpm"
+   Then the exit code is 0
+    And Transaction is following
+        | Action        | Package                               |
+        | install       | wget-0:1.19.6-5.fc29.x86_64           |
+
+


### PR DESCRIPTION
Upstream commit: da5a564ad4b8a95b606140a00a18600a3c006f4f

This is not a feature, this a deficiency difficult to fix because of DNF4 plugin architecture.

For: https://github.com/rpm-software-management/dnf-plugins-core/issue/585