### PR TITLE
Disable testing DNF local plugin on RHEL >= 10

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/local.feature
+++ b/dnf-behave-tests/dnf/plugins-core/local.feature
@@ -1,3 +1,5 @@
+# Local plugin is not built on RHEL >= 10.
+@not.with_os=rhel__ge__10
 Feature: Tests for local plugin
 
 


### PR DESCRIPTION
The plugin is disabled there.

Requires: https://github.com/rpm-software-management/dnf5/pull/2548