### PR TITLE
Update quay.io target container fedora versions

### DIFF
--- a/.github/workflows/container-build-quay-io.yml
+++ b/.github/workflows/container-build-quay-io.yml
@@ -18,10 +18,8 @@ jobs:
           - dnf5-nightly
           - dnf5-testing
         tag:
-          - 38
-          - 39
-          - 40
-          - 41
+          - 42
+          - 43
           - latest
           - rawhide
 


### PR DESCRIPTION
This is a kind of follow up to https://github.com/rpm-software-management/ci-dnf-stack/pull/1801