### PR TITLE
Use `--skip-file-locks` when unprivileged

### DIFF
--- a/dnf-behave-tests/dnf/comps-group.feature
+++ b/dnf-behave-tests/dnf/comps-group.feature
@@ -558,7 +558,7 @@ Scenario: 'dnf group list -C' works for unprivileged user even when decompressed
    And I create directory "/{context.dnf.installroot}/var/tmp"
    And I successfully execute "chmod 777 {context.dnf.installroot}/var/tmp"
    And I successfully execute dnf with args "makecache"
-  When I execute dnf with args "group list -C" as an unprivileged user
+  When I execute dnf with args "group list -C --skip-file-locks" as an unprivileged user
   Then the exit code is 0
   Then stderr does not contain "Permission denied: '{context.dnf.installroot}/var/cache/dnf/dnf-ci-thirdparty-[a-z0-9]{{16}}/repodata/gen'"
    And stderr is


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/2519.

When performing a read-only operation, such as `group list`, DNF5 will try to obtain a read lock on the system repository inside the installroot. If the lock file does not exist (for example the installroot is empty), and the user doesn't have permission to create the lock file, an error is thrown. In these situations, we can use `--skip-file-locks` to skip trying to create and/or acquire the lock.