### PR TITLE
rhel-10.2: dnf-automatic: email_command: Pass recipients as separate arguments to a command

### DIFF
--- a/dnf-behave-tests/dnf/dnf-automatic/command_email.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/command_email.feature
@@ -1,0 +1,31 @@
+# dnf-automatic disabled by https://github.com/rpm-software-management/dnf/pull/2129
+@not.with_os=fedora__ge__41
+Feature: dnf-automatic command_email emitter
+
+Background:
+Given I use repository "simple-base"
+  And I successfully execute dnf with args "install labirinto"
+  And I use repository "simple-updates"
+
+
+@gh-dnf-2241
+Scenario: dnf-automatic pass multiple recipients as separate arguments
+  Given I create file "/etc/dnf/automatic.conf" with
+    """
+    [commands]
+    apply_updates = no
+    reboot = never
+    [emitters]
+    emit_via = command_email
+    [command_email]
+    email_to = recipient1,recipient2
+    command_format = "printf '%s\n' {email_to}"
+    """
+   When I execute dnf-automatic with args "{context.dnf.installroot}/etc/dnf/automatic.conf"
+   Then the exit code is 0
+    And stdout contains lines:
+    """
+    recipient1
+    recipient2
+    """
+


### PR DESCRIPTION
Upstream commit: e942bcf8c045098243fc192faa211669f1d85299

If multiple recipients are configured for email_command, "{email_to}" should expand to multiple white-space separated arguments. If multiple arguments are passed to "printf '%s\n'" command, each argument will be printed on a separate line. And that is tested. (Otherwise, printf would spit all the recipients on a single line.)

Implementation detail: Because dnf-automatic does not search its configuration file in installroot and I do not want to polute host system, I explicitly pass the file as an alternative configuration file to the dnf-automatic tool.

Implementation detail: A backslash in the command_format does not need an extra escaping as in DNF5 test. That's probably an unrelated bug in DNF5 implementation.

For: https://github.com/rpm-software-management/dnf/issues/2241
For: https://github.com/rpm-software-management/dnf/pull/2288