### PR TITLE
rhel-9.8.0: Do not use installroot in dnf-automatic/command_email.feature

### DIFF
--- a/dnf-behave-tests/dnf/dnf-automatic/command_email.feature
+++ b/dnf-behave-tests/dnf/dnf-automatic/command_email.feature
@@ -1,5 +1,7 @@
 # dnf-automatic disabled by https://github.com/rpm-software-management/dnf/pull/2129
 @not.with_os=fedora__ge__41
+# dnf-automatic does not have --installroot option.
+@no_installroot
 Feature: dnf-automatic command_email emitter
 
 Background:
@@ -21,7 +23,7 @@ Scenario: dnf-automatic pass multiple recipients as separate arguments
     email_to = recipient1,recipient2
     command_format = "printf '%s\n' {email_to}"
     """
-   When I execute dnf-automatic with args "{context.dnf.installroot}/etc/dnf/automatic.conf"
+   When I execute dnf-automatic with args "/etc/dnf/automatic.conf"
    Then the exit code is 0
     And stdout contains lines:
     """


### PR DESCRIPTION
Upstream commit: dfb62f47e131b4c3af25c475d1774a44a049eb86

The test sometimes failed because dnf-automatic sometimes did not print any output.

The cause was that the test added in commit
e942bcf8c045098243fc192faa211669f1d85299 ("dnf-automatic: email_command: Pass recipients as separate arguments to a command") used an installroot to avoid clobbering host system. But dnf-automatic does not have --installroot option, causing dnf-automatic to always operate on the host system, disregarding what happened in the installroot:

If the host system had a pending update, dnf-automatic emitted an notification and thus the test passed.  On the other hand, if the host had no pending update, there was no notification and the test failed.

This patch fixes it by disabling installroot.

For: https://issues.redhat.com/browse/RHEL-94321