### PR TITLE
Packit: checkout release-5.2.x.x branch

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -12,7 +12,7 @@ prepare:
       script:
         - git clone https://github.com/rpm-software-management/ci-dnf-stack /var/tmp/ci-dnf-stack
 
-    - name: Checkout PR branch if packit call is from ci-dnf-stack
+    - name: Checkout correct branch, or PR branch if packit call is from ci-dnf-stack
       how: shell
       script: |
         if [ "$PACKIT_UPSTREAM_NAME" == "ci-dnf-stack" ]; then
@@ -20,6 +20,8 @@ prepare:
           git -C /var/tmp/ci-dnf-stack fetch pull-request
           git -C /var/tmp/ci-dnf-stack checkout --track pull-request/$PACKIT_SOURCE_BRANCH
           git -C /var/tmp/ci-dnf-stack rebase $PACKIT_TARGET_BRANCH
+        else
+          git -C /var/tmp/ci-dnf-stack checkout release-5.2.x.x
         fi
 
     - name: Build testing container


### PR DESCRIPTION
Packit always checks out the main branch here, even when run from the DNF5 repository with `fmf_ref: release-5.2.x.x`. So I suppose we need to amend the `main.fmf` here. Though maybe there is a better way to get the correct branch name other than hardcoding it here?

See also https://github.com/rpm-software-management/dnf5/pull/2577/files.