### PR TITLE
9.8: backport: protected-packages: test protected dependencies and autoremove

### DIFF
--- a/dnf-behave-tests/dnf/protected-packages.feature
+++ b/dnf-behave-tests/dnf/protected-packages.feature
@@ -18,20 +18,119 @@ Scenario: Package protected via setopt cannot be removed
     And stderr contains "Problem: The operation would result in removing the following protected packages: filesystem"
 
 
-# @dnf5
-# TODO(nsella) different stderr
-Scenario: Package with protected dependency via setopt cannot be removed
-  Given I use repository "dnf-ci-fedora"
-    And I execute dnf with args "install filesystem"
+Scenario: Package with protected dependency via setopt can be removed
+  Given I use repository "dependency-chain"
+    And I execute dnf with args "install top"
    Then the exit code is 0
     And Transaction is following
-        | Action        | Package                               |
-        | install       | filesystem-0:3.9-2.fc29.x86_64        |
-        | install-dep   | setup-0:2.12.1-1.fc29.noarch          |
-   When I execute dnf with args "remove filesystem --setopt=protected_packages=setup"
+        | Action      | Package               |
+        | install     | top-0:1-1.fc29.x86_64 |
+        | install-dep | mid-0:2-1.fc29.x86_64 |
+        | install-dep | bot-0:1-1.fc29.x86_64 |
+   When I execute dnf with args "remove top --setopt=protected_packages=mid"
+   Then the exit code is 0
+    And Transaction is following
+        | Action | Package               |
+        | remove | top-0:1-1.fc29.x86_64 |
+
+
+Scenario: Protected dependency via setopt cannot be removed, transaction fails
+  Given I use repository "dependency-chain"
+    And I execute dnf with args "install top"
+   Then the exit code is 0
+    And Transaction is following
+        | Action      | Package               |
+        | install     | top-0:1-1.fc29.x86_64 |
+        | install-dep | mid-0:2-1.fc29.x86_64 |
+        | install-dep | bot-0:1-1.fc29.x86_64 |
+   When I execute dnf with args "remove mid --setopt=protected_packages=mid"
    Then the exit code is 1
     And Transaction is empty
-    And stderr contains "Problem: The operation would result in removing the following protected packages: setup"
+    And stderr contains "Problem: The operation would result in removing the following protected packages: mid"
+
+
+Scenario: Dependency of a protected package cannot be removed
+  Given I use repository "dependency-chain"
+    And I execute dnf with args "install top"
+   Then the exit code is 0
+    And Transaction is following
+        | Action      | Package               |
+        | install     | top-0:1-1.fc29.x86_64 |
+        | install-dep | mid-0:2-1.fc29.x86_64 |
+        | install-dep | bot-0:1-1.fc29.x86_64 |
+   When I execute dnf with args "remove bot --setopt=protected_packages=mid"
+   Then the exit code is 1
+    And Transaction is empty
+    And stderr is
+        """
+        Error: 
+         Problem: The operation would result in removing the following protected packages: mid
+        """
+
+
+@wip
+Scenario: Left over protected package installed as a dependency is not autoremoved and keeps reason
+  Given I use repository "dependency-chain"
+    And I successfully execute dnf with args "install top"
+    And I successfully execute dnf with args "remove top --setopt=protected_packages=mid"
+   When I execute dnf with args "autoremove --setopt=protected_packages=mid --debugsolver"
+   Then the exit code is 0
+    And stderr is
+        """
+        Unneeded protected package: mid-2-1.fc29.x86_64 (and its dependencies) cannot be removed, either mark it as user-installed or change protected_packages configuration option.
+        """
+    And stdout is
+        """
+        <REPOSYNC>
+        Dependencies resolved.
+        Nothing to do.
+        Complete!
+        """
+    And Transaction is empty
+   When I execute dnf with args "rq mid --queryformat='%{{name}}-%{{evr}} - %{{reason}}' --installed"
+   Then stdout is
+        """
+        <REPOSYNC>
+        mid-2-1.fc29 - dependency
+        """
+
+
+Scenario: Left over chain of dependencies with protected package is not autoremoved and keeps reason
+  Given I use repository "dependency-chain"
+    And I successfully execute dnf with args "install top"
+    And I successfully execute dnf with args "mark remove top"
+   When I execute dnf with args "autoremove --setopt=protected_packages=mid"
+   Then the exit code is 0
+    And stderr is
+        """
+        Unneeded protected package: mid-2-1.fc29.x86_64 (and its dependencies) cannot be removed, either mark it as user-installed or change protected_packages configuration option.
+        """
+    And Transaction is following
+        | Action | Package               |
+        | remove | top-0:1-1.fc29.x86_64 |
+   When I execute dnf with args "rq mid --queryformat='%{{name}}-%{{evr}} - %{{reason}}' --installed"
+   Then stdout is
+        """
+        <REPOSYNC>
+        mid-2-1.fc29 - dependency
+        """
+
+
+Scenario: Left over protected package installed as a dependency keeps reason after upgrade
+  Given I use repository "dependency-chain"
+    And I successfully execute dnf with args "install top --exclude mid-2"
+    And I successfully execute dnf with args "remove top --setopt=protected_packages=mid"
+   When I execute dnf with args "upgrade"
+   Then the exit code is 0
+    And Transaction is following
+        | Action      | Package               |
+        | upgrade     | mid-0:2-1.fc29.x86_64 |
+   When I execute dnf with args "rq mid --queryformat='%{{name}}-%{{evr}} - %{{reason}}' --installed"
+   Then stdout is
+        """
+        <REPOSYNC>
+        mid-2-1.fc29 - dependency
+        """
 
 
 # TODO: make protected packages work in installroots first

--- a/dnf-behave-tests/fixtures/specs/dependency-chain/bot-1-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/dependency-chain/bot-1-1.fc29.spec
@@ -1,0 +1,14 @@
+Name: bot
+Version: 1
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+bot description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dependency-chain/mid-1-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/dependency-chain/mid-1-1.fc29.spec
@@ -1,0 +1,16 @@
+Name: mid
+Version: 1
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Requires: bot
+
+%description
+mid description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dependency-chain/mid-2-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/dependency-chain/mid-2-1.fc29.spec
@@ -1,0 +1,16 @@
+Name: mid
+Version: 2
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Requires: bot
+
+%description
+mid description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/dependency-chain/top-1-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/dependency-chain/top-1-1.fc29.spec
@@ -1,0 +1,16 @@
+Name: top
+Version: 1
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Requires: mid
+
+%description
+top description
+
+%files
+
+%changelog


### PR DESCRIPTION
For: https://issues.redhat.com/browse/RHEL-76112

Associated:
- dnf - https://github.com/rpm-software-management/dnf/pull/2293
- libdnf - https://github.com/rpm-software-management/libdnf/pull/1747