### PR TITLE
fix: add missing specs for RHEL-81779

### DIFF
--- a/dnf-behave-tests/fixtures/specs/history-info/rsyslog-8.2102.0-1.el9.spec
+++ b/dnf-behave-tests/fixtures/specs/history-info/rsyslog-8.2102.0-1.el9.spec
@@ -1,0 +1,14 @@
+Name: rsyslog
+Version: 8.2102.0
+Release: 1.el9
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+rsyslog description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/history-info/rsyslog-8.2102.0-2.el9.spec
+++ b/dnf-behave-tests/fixtures/specs/history-info/rsyslog-8.2102.0-2.el9.spec
@@ -1,0 +1,14 @@
+Name: rsyslog
+Version: 8.2102.0
+Release: 2.el9
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+rsyslog description
+
+%files
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/history-info/rsyslog-8.2102.0-3.el9.spec
+++ b/dnf-behave-tests/fixtures/specs/history-info/rsyslog-8.2102.0-3.el9.spec
@@ -1,0 +1,14 @@
+Name: rsyslog
+Version: 8.2102.0
+Release: 3.el9
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+%description
+rsyslog description
+
+%files
+
+%changelog


### PR DESCRIPTION
Cherry-pick of enabling and fixing the test did backport whole test, but it did not backport the specs that are needed to run the test.

(cherry picked from commit 790bc47870d2de261449ace3a415a32b27791fc7)