### PR TITLE
Fix libsolv nightly builds by downloading all current patches

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,10 @@ jobs:
             specfile_path: libsolv.spec
             actions:
               post-upstream-clone:
+                # Download spec
                 - "wget https://src.fedoraproject.org/rpms/libsolv/raw/main/f/libsolv.spec -O libsolv.spec"
+                # Download patches used in the spec
+                - bash -c "spectool -P libsolv.spec | awk '{print $2}' | xargs -I {} curl --retry 3 -O https://src.fedoraproject.org/rpms/libsolv/raw/rawhide/f/{}"
           EOL
             COMMAND_STRING+=" -c ./packit_libsolv.yaml"
           fi


### PR DESCRIPTION
Since we take libsolv specfile from fedora we have to somehow deal with its patches otherwise the build fails.
(It currently fails due to a patch that is not found: https://github.com/rpm-software-management/ci-dnf-stack/actions/runs/22333046695/job/64619445104)

We could either drop them or use them.

Since the specfile could be changed in a way that requires the patches to successfully create an rpm I think it will be more robust to download and use them.