### PR TITLE
Escape awk $2 var otherwise it gets substituted by outer `bash -c`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
                 # Download spec
                 - "wget https://src.fedoraproject.org/rpms/libsolv/raw/main/f/libsolv.spec -O libsolv.spec"
                 # Download patches used in the spec
-                - bash -c "spectool -P libsolv.spec | awk '{print $2}' | xargs -I {} curl --retry 3 -O https://src.fedoraproject.org/rpms/libsolv/raw/rawhide/f/{}"
+                - bash -c "spectool -P libsolv.spec | awk '{print \$2}' | xargs -I {} curl --retry 3 -O https://src.fedoraproject.org/rpms/libsolv/raw/rawhide/f/{}"
           EOL
             COMMAND_STRING+=" -c ./packit_libsolv.yaml"
           fi


### PR DESCRIPTION
Follow up to https://github.com/rpm-software-management/ci-dnf-stack/pull/1835.

The libsolv builds are still failing: https://github.com/rpm-software-management/ci-dnf-stack/actions/runs/22378483037/job/64773869670

I have wrapped the command in `bash -c` only after I created and tested it and I didn't realize it will cause variable substitution problems.