### PR TITLE
Test that offline and stored transactions use cached packages

### DIFF
--- a/dnf-behave-tests/dnf/offline.feature
+++ b/dnf-behave-tests/dnf/offline.feature
@@ -270,3 +270,85 @@ Given I successfully execute dnf with args "install --offline flac"
       """
       flac-0:1.3.2-8.fc29.x86_64 dnf-ci-fedora
       """
+
+
+Scenario: Offline upgrade reuses cached packages whith --cacheonly
+Given I use repository "dnf-ci-fedora-updates" as http
+  And I successfully execute dnf with args "upgrade --downloadonly"
+ When I execute dnf with args "upgrade --offline --cacheonly"
+ Then the exit code is 0
+  And DNF Transaction is following
+      | Action        | Package                                   |
+      | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+      | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+      | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+  And stderr contains lines
+      """
+      Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
+      """
+Given I successfully execute dnf with args "offline reboot"
+ When I execute dnf with args "offline _execute"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                                   |
+      | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+      | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+      | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+
+
+Scenario: Offline upgrade reuses cached packages automatically
+Given I use repository "dnf-ci-fedora-updates" as http
+  And I successfully execute dnf with args "upgrade --downloadonly"
+  And I start capturing outbound HTTP requests
+ When I execute dnf with args "upgrade --offline"
+ Then the exit code is 0
+  And DNF Transaction is following
+      | Action        | Package                                   |
+      | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+      | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+      | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+  And stderr contains lines
+      """
+      Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
+      """
+Given I successfully execute dnf with args "offline reboot"
+ When I execute dnf with args "offline _execute"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                                   |
+      | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+      | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+      | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+  # Both needed metadata and packages are already cached, nothing should be redownloaded
+  And HTTP log is empty
+
+
+Scenario: cached packages are used and preserved with keepcache=true
+Given I use repository "dnf-ci-fedora-updates" as http
+  And I configure dnf with
+      | key       | value |
+      | keepcache | True  |
+  And I successfully execute dnf with args "upgrade --downloadonly"
+  And I start capturing outbound HTTP requests
+ When I execute dnf with args "upgrade --offline"
+ Then the exit code is 0
+  And DNF Transaction is following
+      | Action        | Package                                   |
+      | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+      | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+      | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+  And stderr contains lines
+      """
+      Transaction stored to be performed offline. Run `dnf5 offline reboot` to reboot and run the transaction. To cancel the transaction and delete the downloaded files, use `dnf5 offline clean`.
+      """
+Given I successfully execute dnf with args "offline reboot"
+ When I execute dnf with args "offline _execute"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                                   |
+      | upgrade       | glibc-0:2.28-26.fc29.x86_64               |
+      | upgrade       | glibc-common-0:2.28-26.fc29.x86_64        |
+      | upgrade       | glibc-all-langpacks-0:2.28-26.fc29.x86_64 |
+  And file "/var/cache/dnf/dnf-ci-fedora-updates-*/packages/glibc-2.28-26.fc29.x86_64.rpm" exists
+  # Both needed metadata and packages are already cached, nothing should be redownloaded
+  And HTTP log is empty

--- a/dnf-behave-tests/dnf/steps/server.py
+++ b/dnf-behave-tests/dnf/steps/server.py
@@ -139,3 +139,19 @@ def step_http_log_is(context):
     print_lines_diff(expected, found)
 
     raise AssertionError("HTTP log is not: %s" % context.text)
+
+
+@behave.step("HTTP log is empty")
+def step_http_log_is(context):
+    found = []
+    server_ids = list(context.dnf.ports.keys())
+    server_ports = list(context.dnf.ports.values())
+    for r in context.scenario.httpd.log:
+        port = r.headers['Host'].split(':')[1]
+        server_id = server_ids[server_ports.index(int(port))]
+        found.append("%s %s %s" % (r.command, server_id, r.path))
+
+    if len(found) == 0:
+        return
+
+    raise AssertionError("HTTP log is not empty: %s" % found)

--- a/dnf-behave-tests/dnf/transaction-sr/store-option.feature
+++ b/dnf-behave-tests/dnf/transaction-sr/store-option.feature
@@ -311,3 +311,13 @@ Scenario: stored packages with keepcache=false are not removed by following tran
         | Action        | Package              |
         | install       | top-a-1:1.0-1.x86_64 |
     And file "/{context.dnf.tempdir}/transaction/packages/top-a-1.0-1.x86_64.rpm" exists
+
+
+Scenario: storing transaction uses already cached packages
+  Given I use repository "transaction-sr" as http
+    And I execute dnf with args "install top-a-1.0 --downloadonly"
+    And I start capturing outbound HTTP requests
+   When I execute dnf with args "install top-a-1.0 --store ./transaction"
+   Then file "/{context.dnf.tempdir}/transaction/packages/top-a-1.0-1.x86_64.rpm" exists
+    # Both needed metadata and packages are already cached, nothing should be redownloaded
+    And HTTP log is empty


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf5/pull/2634