### PR TITLE
createrepo_c: Skip modularity tests since RHEL 11

### DIFF
--- a/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
+++ b/dnf-behave-tests/createrepo_c/mergerepo_c-modular.feature
@@ -1,3 +1,5 @@
+# Modularity support disabled from RHEL 11.
+@not.with_os=rhel__ge__11
 Feature: Tests mergerepo_c with modular repositories
 
 

--- a/dnf-behave-tests/createrepo_c/modular.feature
+++ b/dnf-behave-tests/createrepo_c/modular.feature
@@ -1,3 +1,5 @@
+# Modularity support disabled from RHEL 11.
+@not.with_os=rhel__ge__11
 Feature: Tests createrepo_c with modular metedata
 
 


### PR DESCRIPTION
Modularity was disabled in RHEL 11.

Because: https://github.com/rpm-software-management/createrepo_c/pull/474