### PR TITLE
rhel-9.9.0: Rotating logger preserves ACL

### DIFF
--- a/dnf-behave-tests/common/cmd.py
+++ b/dnf-behave-tests/common/cmd.py
@@ -7,7 +7,7 @@ import behave
 import glob
 import os
 
-from common.lib.cmd import assert_exitcode, run_in_context
+from common.lib.cmd import assert_exitcode, run, run_in_context
 from common.lib.file import prepend_installroot
 
 
@@ -59,6 +59,19 @@ def file_has_mode(context, filepath, octal_mode_str):
     octal_file_mode = os.stat(matched_files[0]).st_mode & 0o777
     assert oct(octal_mode) == oct(octal_file_mode), \
         "File \"{}\" has mode \"{}\"".format(matched_files[0], oct(octal_file_mode))
+
+@behave.step("file \"{filepath}\" has ACL entry \"{entry}\"")
+def file_has_acl_entry(context, filepath, entry):
+    filepath = prepend_installroot(context, filepath)
+    command = ["/usr/bin/getfacl", "-c", filepath]
+    ret, out, err = run(command, shell=False)
+    if ret != 0:
+        raise AssertionError("Could not retrieve ACL: Command \"{}\" failed: "
+            "{}".format(command.join(" "), err))
+    for line in out.split("\n"):
+        if line == entry:
+            return
+    raise AssertionError("File \"{}\" has ACL:\n{}".format(filepath, out))
 
 @behave.step("path \"{path}\" is writable")
 def path_is_writable(context, path):

--- a/dnf-behave-tests/dnf/log-rotate.feature
+++ b/dnf-behave-tests/dnf/log-rotate.feature
@@ -48,3 +48,35 @@ Scenario: Size and number of log files respects log_size and log_rotate options
    Then size of file "var/log/dnf.librepo.log" is at most "1024"
    Then size of file "var/log/dnf.librepo.log.1" is at most "1024"
    Then size of file "var/log/dnf.librepo.log.2" is at most "1024"
+
+
+@bz1910084
+Scenario: Log rotation keeps file permissions
+Given I use repository "dnf-ci-fedora-updates"
+  And I successfully execute dnf with args "install flac"
+    # Set permissions to 600
+  And I successfully execute "chmod 600 {context.dnf.installroot}/var/log/dnf.log"
+  And I successfully execute "chmod 600 {context.dnf.installroot}/var/log/dnf.librepo.log"
+  And I successfully execute "chmod 600 {context.dnf.installroot}/var/log/dnf.rpm.log"
+    # Run dnf again, so that files are rotated
+ When I execute dnf with args "--setopt=log_size=100 --setopt=log_rotate=2 remove flac"
+ Then the exit code is 0
+  And file "/var/log/dnf.log" has mode "600"
+  And file "/var/log/dnf.log.1" has mode "600"
+  And file "/var/log/dnf.librepo.log" has mode "600"
+  And file "/var/log/dnf.librepo.log.1" has mode "600"
+  And file "/var/log/dnf.rpm.log" has mode "600"
+  And file "/var/log/dnf.rpm.log.1" has mode "600"
+
+
+# https://github.com/rpm-software-management/dnf/issues/2279
+Scenario: Log rotation keeps ACL
+Given I use repository "dnf-ci-fedora-updates"
+  And I successfully execute dnf with args "install flac"
+    # Set non-default ACL
+  And I successfully execute "setfacl -m user:root:r {context.dnf.installroot}/var/log/dnf.log"
+    # Run dnf again, so that files are rotated
+ When I execute dnf with args "--setopt=log_size=1 --setopt=log_rotate=2 remove flac"
+ Then the exit code is 0
+  And file "/var/log/dnf.log" has ACL entry "user:root:r--"
+  And file "/var/log/dnf.log.1" has ACL entry "user:root:r--"

--- a/dnf-behave-tests/dnf/logs.feature
+++ b/dnf-behave-tests/dnf/logs.feature
@@ -110,22 +110,3 @@ Given I use repository "dnf-ci-fedora-updates"
   And file "/var/log/dnf.rpm.log" has mode "600"
   And file "/var/log/hawkey.log" has mode "600"
 Given I set umask to "0022"
-
-
-@bz1910084
-Scenario: Log rotation keeps file permissions
-Given I use repository "dnf-ci-fedora-updates"
-  And I successfully execute dnf with args "install flac"
-    # Set permissions to 600
-  And I successfully execute "chmod 600 {context.dnf.installroot}/var/log/dnf.log"
-  And I successfully execute "chmod 600 {context.dnf.installroot}/var/log/dnf.librepo.log"
-  And I successfully execute "chmod 600 {context.dnf.installroot}/var/log/dnf.rpm.log"
-    # Run dnf again, so that files are rotated
- When I execute dnf with args "--setopt=log_size=100 --setopt=log_rotate=2 remove flac"
- Then the exit code is 0
-  And file "/var/log/dnf.log" has mode "600"
-  And file "/var/log/dnf.log.1" has mode "600"
-  And file "/var/log/dnf.librepo.log" has mode "600"
-  And file "/var/log/dnf.librepo.log.1" has mode "600"
-  And file "/var/log/dnf.rpm.log" has mode "600"
-  And file "/var/log/dnf.rpm.log.1" has mode "600"

--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -16,6 +16,7 @@ License:        GPLv3
 
 
 # test suite dependencies
+BuildRequires:  acl
 BuildRequires:  attr
 BuildRequires:  createrepo_c
 BuildRequires:  fakeuname


### PR DESCRIPTION
rhel-9.9.0 backport of #1787.
Upstream commit: 73f1d36896fae7aea522c69284523ac75eb9c5a4

This checks that the rotating logger preserves file access control list which a user set on the log file before executing dnf.

It also moves a test for the file mode to better place.

For: https://github.com/rpm-software-management/dnf/pull/2313