### PR TITLE
Copr documentation moved to docs.copr.fedorainfracloud.org

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/copr-chroot.feature
+++ b/dnf-behave-tests/dnf/plugins-core/copr-chroot.feature
@@ -79,7 +79,7 @@ Scenario: Test enabling a repo with manually specified chroot (different to curr
 
       The Fedora Project does not exercise any power over the contents of
       this repository beyond the rules outlined in the Copr FAQ at
-      <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+      <https://docs.copr.fedorainfracloud.org/user_documentation.html#what-i-can-build-in-copr>,
       and packages are not held to any quality or security level.
 
       Please do not file bug reports about these packages in Fedora

--- a/dnf-behave-tests/dnf/plugins-core/copr.feature
+++ b/dnf-behave-tests/dnf/plugins-core/copr.feature
@@ -50,7 +50,7 @@ Scenario: Test enabling and disabling a project
 
       The Fedora Project does not exercise any power over the contents of
       this repository beyond the rules outlined in the Copr FAQ at
-      <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+      <https://docs.copr.fedorainfracloud.org/user_documentation.html#what-i-can-build-in-copr>,
       and packages are not held to any quality or security level.
 
       Please do not file bug reports about these packages in Fedora
@@ -201,7 +201,7 @@ Given I create and substitute file "/{context.dnf.tempdir}/copr/api_3/rpmrepo/te
 
       The Fedora Project does not exercise any power over the contents of
       this repository beyond the rules outlined in the Copr FAQ at
-      <https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+      <https://docs.copr.fedorainfracloud.org/user_documentation.html#what-i-can-build-in-copr>,
       and packages are not held to any quality or security level.
 
       Please do not file bug reports about these packages in Fedora


### PR DESCRIPTION
See https://github.com/fedora-copr/copr/pull/4198
See https://github.com/rpm-software-management/dnf5/pull/2663