### PR TITLE
[rhel-10.3] history-info: Check Persistence in interval query test

### DIFF
--- a/dnf-behave-tests/dnf/history-info.feature
+++ b/dnf-behave-tests/dnf/history-info.feature
@@ -63,5 +63,7 @@ Scenario: history info range - two upgrade actions should be reported as upgrade
    Then the exit code is 0
     And History info "last-1..last" should match
         | Key           | Value                              |
+        | Persistence   | Persist                            |
         | Upgraded      | rsyslog-8.2102.0-1.el9.x86_64      |
         | Upgrade       | rsyslog-8.2102.0-3.el9.x86_64      |
+    And stderr is empty


### PR DESCRIPTION
Backport of https://github.com/rpm-software-management/ci-dnf-stack/pull/1842 for rhel-10.3.

Tests passing locally with https://github.com/rpm-software-management/dnf/pull/2320 and https://github.com/rpm-software-management/libdnf/pull/1767.