### PR TITLE
dnf-nightly: build just one libmodulemd package

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,6 +68,10 @@ jobs:
           if [[ "${{matrix.component}}" == "dnf5" ]]; then
             COMMAND_STRING+=" --package dnf5"
           fi
+          # libmodulemd upstream also defines two packit packages, build just one
+          if [[ "${{matrix.component}}" == "libmodulemd" ]]; then
+            COMMAND_STRING+=" --package libmodulemd"
+          fi
 
           echo "Executing: $COMMAND_STRING"
           $COMMAND_STRING


### PR DESCRIPTION
See: https://github.com/fedora-modularity/libmodulemd/pull/638

Since libmodulemd now also defines two packit packages specify we want to build just one (the one with snapshot caret notation).

We could add a more structured way to add the extra parameters but since its needed only for two packages so far it seems fine.