### PR TITLE
Normalize percent-encoding in "HTTP log contains"

### DIFF
--- a/dnf-behave-tests/dnf/steps/server.py
+++ b/dnf-behave-tests/dnf/steps/server.py
@@ -7,6 +7,7 @@ import behave
 from fnmatch import fnmatch
 import os
 import parse
+import re
 
 from fixtures import start_server_based_on_type
 from common.lib.diff import print_lines_diff
@@ -103,10 +104,11 @@ def step_check_http_log(context, quantifier, command):
 @behave.step("HTTP log contains")
 def step_http_log_contains(context):
     expected = context.text.format(context=context).rstrip().split('\n')
-    found = ["%s %s" % (r.command, r.path) for r in context.scenario.httpd.log]
-
+    # curl 8.20.0+ normalizes percent-encoding to uppercase
+    normalize = lambda s: re.sub(r'%[0-9a-fA-F]{2}', lambda m: m.group().upper(), s)
+    found = ["%s %s" % (r.command, normalize(r.path)) for r in context.scenario.httpd.log]
     for e in expected:
-        if e not in found:
+        if normalize(e) not in found:
             raise AssertionError('HTTP log does not contain "%s": %s' % (e, "\n" + "\n".join(found) + "\n"))
 
 


### PR DESCRIPTION
libcurl started to normalize percent-encoding hexadecimal digits to uppercase (following RFC 3986 section 2.1) (see
https://github.com/curl/curl/commit/0b4ebebb06b3148a234a5a7bc95f8253dd6cb8df).

This change makes HTTP log comparison case insensitive with regard to percent-encoded parts.

This change should fix CI stack failures on Fedora rawhide (e.g. https://github.com/rpm-software-management/dnf5/pull/2724/checks?check_run_id=74253503641)