### PR TITLE
bootc: Port framework and tests from dnf-4-stack

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -13,6 +13,14 @@ jobs:
 
   - job: tests
     trigger: pull_request
+    identifier: "dnf5-bootc-tests"
+    targets:
+      - fedora-all
+    skip_build: true
+    tmt_plan: "^/plans/integration/behave-dnf5-bootc/"
+
+  - job: tests
+    trigger: pull_request
     identifier: "createrepo_c-tests"
     targets:
       - fedora-all

--- a/bootc/Containerfile
+++ b/bootc/Containerfile
@@ -1,0 +1,76 @@
+# Example Usage:
+# $ podman build --build-arg TYPE=distro -t ci-dnf-stack -f Dockerfile
+# $ podman run --net none -it ci-dnf-stack behave dnf
+
+ARG BASE=quay.io/fedora/fedora-bootc:42
+FROM $BASE
+
+ENV LANG C.UTF-8
+ARG TYPE=nightly
+
+# disable deltas and weak deps
+RUN set -x && \
+    echo -e "deltarpm=0" >> /etc/dnf/dnf.conf && \
+    echo -e "install_weak_deps=0" >> /etc/dnf/dnf.conf
+
+# Import extra CA certificates
+COPY ./ca-trust/ /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+
+# Copy extra repo files
+COPY ./repos.d/ /etc/yum.repos.d/
+
+# enable dnf5
+RUN set -x && \
+    dnf -y upgrade bootc; \
+    dnf -y install dnf5 dnf5-plugins; \
+    dnf5 -y copr enable rpmsoftwaremanagement/test-utils; \
+    dnf5 -y copr enable rpmsoftwaremanagement/dnf-nightly; \
+    dnf5 -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*'
+
+RUN set -x && \
+    if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then \
+       dnf5 -y copr enable $COPR; \
+       dnf5 -y install $COPR_RPMS; \
+    fi
+
+# install local RPMs if available
+COPY ./rpms/ /opt/ci/rpms/
+RUN set -x && \
+    rm /opt/ci/rpms/*-{devel,debuginfo,debugsource}*.rpm; \
+    if [ -n "$(find /opt/ci/rpms/ -maxdepth 1 -name '*.rpm' -print -quit)" ]; then \
+        dnf5 -y install /opt/ci/rpms/*.rpm --disableplugin=local && \
+        dnf5 -y versionlock add $(rpm -qp --queryformat '%{NAME}\n' /opt/ci/rpms/*.rpm | sort | uniq); \
+    fi
+
+# Make /opt a symlink to /var/opt. /opt is read-only on bootc systems by default.
+RUN mv /opt /var/opt && ln -sfT /var/opt /opt
+
+# copy test suite
+COPY ./dnf-behave-tests/ /opt/ci/dnf-behave-tests
+
+# install test suite dependencies
+# Temporarily exclude new libfaketime because it doesn't work: https://bugzilla.redhat.com/show_bug.cgi?id=2381595
+RUN set -x && \
+    dnf5 -y builddep /opt/ci/dnf-behave-tests/requirements.spec -x libfaketime-0.9.12-1.* && \
+    pip3 install -r /opt/ci/dnf-behave-tests/requirements.txt
+
+# create directory for dbus daemon socket
+RUN set -x && \
+    mkdir -p /run/dbus
+
+RUN set -x && \
+    rm -rf "/opt/ci/dnf-behave-tests/fixtures/certificates/testcerts/" && \
+    rm -rf "/opt/ci/dnf-behave-tests/fixtures/gpgkeys/keys/" && \
+    rm -rf "/opt/ci/dnf-behave-tests/fixtures/repos/"
+
+# build test repos from sources
+RUN set -x && \
+    cd /opt/ci/dnf-behave-tests/fixtures/specs/ && \
+    ./build.sh --force-rebuild
+
+# Import the default GPG key into the RPM database at build time.
+# After bootc install, /usr is read-only and keys can't be imported at runtime.
+RUN rpm --import /opt/ci/dnf-behave-tests/fixtures/gpgkeys/keys/default-key/default-key-public
+
+WORKDIR /opt/ci/dnf-behave-tests

--- a/container-test
+++ b/container-test
@@ -30,7 +30,7 @@ def command_line_parser():
         help="Test suite to run (directory with *.feature files)")
     parser.add_argument(
         "-c", "--container", metavar="IMAGE",
-        default='dnf-bot/dnf-testing:latest',
+        default='localhost/dnf-bot/dnf-testing:latest',
         help="Specified Image ID or name if do not want to run the last built image")
     parser.add_argument(
         "-d", "--devel", action="store_true", default=False,
@@ -41,6 +41,9 @@ def command_line_parser():
     parser.add_argument(
         "-v", "--verbose", action="store_true", default=False,
         help="Increase verbosity")
+    parser.add_argument(
+        "-H", "--run-on-host", action="store_true", default=False,
+        help="Run command on the host instead of using the container")
 
     subparsers = parser.add_subparsers(
         dest="command", help="List of available commands:")
@@ -98,6 +101,9 @@ def command_line_parser():
     run_parser.add_argument(
         "featurefiles", metavar="<feature>", nargs="*",
         help="List of feature files to run")
+    run_parser.add_argument(
+        "--reboot", action="store_true", default=False,
+        help="Run only tests tagged with `reboot_count_$TMT_REBOOT_COUNT` and reboot if tests succeeded and there are tests tagged with `reboot_count_${TMT_REBOOT_COUNT+1}`")
 
     # list command
     list_parser = subparsers.add_parser(
@@ -204,7 +210,7 @@ class BehaveRunner(object):
                     os.path.join('/opt/ci/dnf-behave-tests', self.command_line_args.suite))])
             if hasattr(self.command_line_args, 'junit_directory') \
                 and self.command_line_args.junit_directory:
-                self._volumes.extend(['--volume', '{}:/junit:z'.format(
+                self._volumes.extend(['--volume', '{}:/var/junit:z'.format(
                     self.command_line_args.junit_directory)])
         return self._volumes
 
@@ -272,16 +278,21 @@ class BehaveRunner(object):
 
         return tests
 
-    def dry_run(self):
-        command = self.docker_bin + ['run', '--rm']
-        command += self.volumes
-        command += [self.command_line_args.container, 'behave', '--dry-run', '--no-skipped']
+    def dry_run(self, extra_tags=()):
+        command = []
+        if not self.command_line_args.run_on_host:
+            command = self.docker_bin + ['run', '--rm']
+            command += self.volumes
+            command += [self.command_line_args.container]
+        command += ['behave', '--dry-run', '--no-skipped']
         if getattr(self.command_line_args, 'featurefiles', []):
             command += [os.path.join(self.command_line_args.suite, a) for a in self.command_line_args.featurefiles]
         else:
             command += [self.command_line_args.suite]
-        for tag in self.tags:
+
+        for tag in (*self.tags, *extra_tags):
             command += ['--tags', tag]
+
         returncode, stdout, stderr = execute(command)
         if returncode > 0:
             msg = 'Command "{}" failed with {}'.format(' '.join(command), returncode)
@@ -357,23 +368,36 @@ class BehaveRunner(object):
                 yield (feature_name, None)
 
         def param_junit(feature_name, i):
-            return ['--junit-directory="/junit/{}_{}"'.format(feature_name, i)]
+            return ['--junit-directory="/var/junit/{}_{}"'.format(feature_name, i)]
 
 
-        command = self.docker_bin + ['run', '--rm'] + self.param_tty + self.volumes + self.capabilities
+        command = []
+        if not self.command_line_args.run_on_host:
+            command += self.docker_bin + ['run', '--rm'] + self.param_tty + self.volumes + self.capabilities
+            if self.command_line_args.container_args:
+                command += self.command_line_args.container_args
 
-        if self.command_line_args.container_args:
-            command += self.command_line_args.container_args
+            if not self.command_line_args.enable_network:
+                command += ['--net', 'none']
 
-        if not self.command_line_args.enable_network:
-            command += ['--net', 'none']
+            command += [self.command_line_args.container]
 
-        command += [self.command_line_args.container, './container-test-wrapper']
-        command += self.param_reserve
+        command += ['./container-test-wrapper'] + self.param_reserve
 
         command += ['--', '--no-skipped', '--junit']
 
-        for tag in self.tags:
+
+        if self.command_line_args.reboot:
+            tmt_reboot_count_env = os.getenv("TMT_REBOOT_COUNT")
+            try:
+                tmt_reboot_count = int(tmt_reboot_count_env)
+            except (ValueError, TypeError):
+                error(f"--reboot specified, but TMT_REBOOT_COUNT is {repr(tmt_reboot_count_env)}")
+            reboot_tags = (f"reboot_count_{tmt_reboot_count}",)
+        else:
+            reboot_tags = ()
+
+        for tag in (*self.tags, *reboot_tags):
             command += ['--tags', tag]
 
         if self.command_line_args.dnf_command:
@@ -383,7 +407,7 @@ class BehaveRunner(object):
             command.extend(['-D destructive=yes'])
 
         failed = set()
-        for feature, scenarios in self.dry_run():
+        for feature, scenarios in self.dry_run(reboot_tags):
             i = 1
             for feature_name, scenario_name in process_feature(feature, scenarios):
                 if scenario_name is not None:
@@ -411,6 +435,12 @@ class BehaveRunner(object):
 
         if failed:
             error('\n'.join(['Failed test(s):'] + sorted(failed)))
+
+        if self.command_line_args.reboot:
+            # If we are running under TMT and counting reboots, and there are
+            # tests to be done on the next reboot, then reboot.
+            if self.dry_run((f"reboot_count_{tmt_reboot_count+1}",)):
+                subprocess.call(["tmt-reboot"])
 
     def command_build(self):
         '''

--- a/dnf-behave-tests/README.md
+++ b/dnf-behave-tests/README.md
@@ -107,6 +107,35 @@ To preserve the directories of failing scenarios only, you can use:
 sudo behave -Ddnf_command=my-dnf -Dpreserve=f dnf
 ```
 
+dnf-bootc Test Suite
+-----------
+The `dnf-bootc` test suite contains tests for DNF functionality specific to
+[bootc](https://github.com/containers/bootc) systems. It shares `steps` with
+the `dnf` suite. The tests are destructive and must be run using
+[TMT](https://tmt.readthedocs.io/en/stable/) since they call `tmt-reboot` to
+reboot the test system. Starting from the top level of the ci-dnf-stack
+repository, you can run the `dnf-bootc` test suite with:
+
+```
+sudo dnf install -y tmt+all
+sudo tmt run plan --name behave-dnf5-bootc
+```
+
+Each of the features in the suite should be run on a clean bootc system, so TMT
+is configured (via `plans/behave-dnf5-bootc.fmf` and
+`tmt/tests/00-bootc-install.sh`) to reinstall the DNF testing container to the
+test runner via `bootc install to-existing-root` before running each feature.
+
+To test the effects of system reboots, scenarios in some features use the tags
+`@reboot_count_1`, `@reboot_count_2`, and so on. `container-test run --reboot`
+reads the environment variable `TMT_REBOOT_COUNT` and runs scenarios tagged
+with `@reboot_count_$TMT_REBOOT_COUNT`. After running these scenarios, if there
+are scenarios tagged `@reboot_count_${TMT_REBOOT_COUNT+1}`, `container-test`
+will call `tmt-reboot` to reboot the system and run the next phase of the test.
+Beware: because we need to split up scenarios with reboots, **Behave scenarios
+in this test suite are not independent**, which is a departure from best
+practices.
+
 
 Contributing
 ------------

--- a/dnf-behave-tests/common/cmd.py
+++ b/dnf-behave-tests/common/cmd.py
@@ -73,3 +73,11 @@ def file_has_acl_entry(context, filepath, entry):
         if line == entry:
             return
     raise AssertionError("File \"{}\" has ACL:\n{}".format(filepath, out))
+
+@behave.step("path \"{path}\" is writable")
+def path_is_writable(context, path):
+    assert os.access(path, os.W_OK), f"Path '{path}' is not writable"
+
+@behave.step("path \"{path}\" is not writable")
+def path_is_not_writable(context, path):
+    assert not os.access(path, os.W_OK), f"Path '{path}' is unexpectedly writable"

--- a/dnf-behave-tests/dnf-bootc/environment.py
+++ b/dnf-behave-tests/dnf-bootc/environment.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# add the behave tests root to python path so that the `common` module can be found
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+# make sure behave loads the common steps
+import consts
+import subprocess
+
+from behave import model
+from behave.formatter.ansi_escapes import escapes
+
+from steps.lib.config import write_config
+from common.lib.cmd import print_last_command, run_in_context
+from common.lib.file import ensure_directory_exists
+from common.lib.os_version import detect_os_version
+from common.lib.tag_matcher import VersionedActiveTagMatcher
+
+
+DEFAULT_DNF_COMMAND = "dnf"
+DEFAULT_REPOS_LOCATION = os.path.join(consts.FIXTURES_DIR, "repos")
+DEFAULT_RELEASEVER="29"
+DEFAULT_PLATFORM_ID="platform:f29"
+
+
+class DNFContext(object):
+    def __init__(self, userdata, force_installroot=False, no_installroot=False):
+        self._scenario_data = {}
+
+        self.repos = {}
+        self.ports = {}
+        self.config = {
+            "[main]": {
+                "gpgcheck": "1",
+                "installonly_limit": "3",
+                "clean_requirements_on_remove": "True",
+                "best": "True"
+            }
+        }
+
+        self.tempdir = tempfile.mkdtemp(prefix="dnf_ci_tempdir_")
+
+        # bootc tests need to be run without installroot
+        self.installroot = "/"
+
+        # remove dnf config files so that they don't interfere and the tests start with a clean state
+        config_file_path = "/etc/dnf/dnf.conf"
+        if os.path.exists(config_file_path):
+            os.remove(config_file_path)
+        for path in ("/etc/yum.repos.d", "/var/lib/dnf/modulefailsafe"):
+            if os.path.exists(path):
+                shutil.rmtree(path)
+
+        ensure_directory_exists(os.path.join(self.installroot, "etc/yum.repos.d"))
+
+        self.dnf_command = userdata.get("dnf_command", DEFAULT_DNF_COMMAND)
+        self.releasever = userdata.get("releasever", DEFAULT_RELEASEVER)
+        self.module_platform_id = userdata.get("module_platform_id", DEFAULT_PLATFORM_ID)
+        self.fixturesdir = consts.FIXTURES_DIR
+        self.disable_plugins = True
+        self.disable_repos_option = "--disablerepo='*'"
+        self.assumeyes_option = "-y"
+
+        self.preserve_temporary_dirs = "none"
+        preserve = userdata.get("preserve", "no")
+        if preserve in ("yes", "y", "1", "true"):
+            self.preserve_temporary_dirs = "all"
+        elif preserve in ("failed", "fail", "f"):
+            self.preserve_temporary_dirs = "failed"
+
+        self.scenario_failed = False
+
+    def __del__(self):
+        preserved_dirs = []
+        if os.path.realpath(self.tempdir) not in ["/", "/tmp"]:
+            if (self.preserve_temporary_dirs == "all"
+                    or (self.preserve_temporary_dirs == "failed" and self.scenario_failed)):
+                preserved_dirs.append(self.tempdir)
+            else:
+                shutil.rmtree(self.tempdir)
+
+        if preserved_dirs:
+            print(escapes["undefined"] + "Temporary directories have been preserved for your browsing pleasure:")
+            for d in preserved_dirs:
+                print("   " + d)
+            print(escapes["reset"])
+
+    def __getitem__(self, name):
+        return self._scenario_data[name]
+
+    def __setitem__(self, name, value):
+        self._scenario_data[name] = value
+
+    def __contains__(self, name):
+        return name in self._scenario_data
+
+    def _get(self, name):
+        if name in self:
+            return self[name]
+        return getattr(self, name, None)
+
+    def _set(self, name, value):
+        return setattr(self, name, value)
+
+    def get_cmd(self, context):
+        result = [self.dnf_command]
+        result.append(self.assumeyes_option)
+
+        releasever = self._get("releasever")
+        if releasever:
+            result.append("--releasever={0}".format(releasever))
+
+        module_platform_id = self._get("module_platform_id")
+        if module_platform_id:
+            result.append("--setopt=module_platform_id={0}".format(module_platform_id))
+
+        disable_plugins = self._get("disable_plugins")
+        if disable_plugins and self.dnf_command != "dnf5daemon-client":
+            result.append("--disable-plugin='*'")
+        plugins = self._get("plugins") or []
+        for plugin in plugins:
+            result.append("--enableplugin='{0}'".format(plugin))
+
+        setopts = self._get("setopts") or {}
+        for key,value in setopts.items():
+            result.append("--setopt={0}={1}".format(key, value))
+
+        result.append("--setopt=cachedir=%s" % self.installroot + "/var/cache/dnf")
+
+        return result
+
+def before_step(context, step):
+    pass
+
+
+def after_step(context, step):
+    if step.status == model.Status.failed:
+        print_last_command(context)
+
+
+def string_to_bool(value):
+    return value in ("yes", "y", "1", "true")
+
+def before_scenario(context, scenario):
+    if "xfail" in scenario.effective_tags:
+        skip = True
+        tags = context.config.tags
+        if not isinstance(tags, list):
+            # Support behave tags v1 (behave < 3.0.0)
+            tags = str(context.config.tags).split()
+        if "xfail" in tags:
+            skip = False
+
+        if skip:
+            scenario.skip(reason="Disabled by default by @xfail.")
+
+    if context.os_tag_matcher.should_exclude_with(scenario.effective_tags):
+        scenario.skip(reason="Disabled by OS version tag.")
+
+    # if we are skipping a scenario, don't create the environment
+    # in case of a destructive scenario, that could mean modifying the current (non-temporary) system!
+    if scenario.status == model.Status.skipped:
+        context.dnf = None
+        return
+
+
+    context.dnf = DNFContext(context.config.userdata)
+
+    write_config(context)
+
+    context.scenario.default_tmp_dir = context.dnf.installroot
+    context.scenario.repos_location = context.config.userdata.get("repos_location", DEFAULT_REPOS_LOCATION)
+
+def after_scenario(context, scenario):
+    if scenario.status == model.Status.failed:
+        context.dnf.scenario_failed = True
+
+    del context.dnf
+
+
+def before_feature(context, feature):
+    pass
+
+
+def after_feature(context, feature):
+    pass
+
+
+def after_tag(context, tag):
+    pass
+
+
+def before_all(context):
+    context.os_tag_matcher = VersionedActiveTagMatcher({"os": context.config.userdata.get("os", detect_os_version())})
+    context.repos = {}
+    context.invalid_utf8_char = consts.INVALID_UTF8_CHAR
+
+def after_all(context):
+    pass

--- a/dnf-behave-tests/dnf-bootc/steps
+++ b/dnf-behave-tests/dnf-bootc/steps
@@ -1,0 +1,1 @@
+../dnf/steps

--- a/dnf-behave-tests/dnf-bootc/transient.feature
+++ b/dnf-behave-tests/dnf-bootc/transient.feature
@@ -1,0 +1,214 @@
+Feature: Transient mode on a bootc system
+
+Background: Enable repositories
+  Given I use repository "bootc"
+
+@reboot_count_1
+Scenario: System should boot without any overlay (it is locked)
+  When I successfully execute "ostree admin status"
+  Then stdout does not contain "Unlocked:"
+   And path "/usr/bin" is not writable
+   And path "/etc" is writable
+
+@reboot_count_1
+Scenario: Installing a package without overlay fails
+ Given file "/usr/bin/hello" does not exist
+  When I execute dnf with args "install hello"
+  Then the exit code is 1
+   And stderr contains lines
+     """
+     Error: this bootc system is configured to be read-only. Pass --transient to perform this operation in a transient overlay which will reset when the system reboots.
+     """
+   And file "/usr/bin/hello" does not exist
+
+@reboot_count_1
+Scenario: Install a package using --transient without any overlay produces a warning
+ Given file "/usr/bin/hello" does not exist
+  When I execute dnf with args "install hello --transient"
+  Then the exit code is 0
+   And Transaction is following
+     | Action        | Package                   |
+     | install       | hello-0:1.0-1.fc29.x86_64 |
+   And stderr contains lines
+     """
+     A transient overlay will be created on /usr that will be discarded on reboot. Keep in mind that changes to /etc and /var will still persist, and packages commonly modify these directories.
+     """
+   And stderr does not contain "Error"
+   And file "/usr/bin/hello" exists
+
+@reboot_count_1
+Scenario: After using DNF --transient, transient overlay should exist
+  When I successfully execute "ostree admin status"
+  Then stdout contains lines
+     """
+     Unlocked: transient
+     """
+   And path "/usr/bin" is not writable
+
+@reboot_count_1
+Scenario: Remove and install a package using --transient with transient overlay doesn't produce warning
+ Given file "/usr/bin/hello" exists
+  When I execute dnf with args "remove hello --transient"
+  Then the exit code is 0
+   And Transaction is following
+     | Action | Package                   |
+     | remove | hello-0:1.0-1.fc29.x86_64 |
+   And file "/usr/bin/hello" does not exist
+   And stderr does not contain "transient overlay"
+   And stderr does not contain "Error"
+  When I execute dnf with args "install hello --transient"
+  Then the exit code is 0
+   And Transaction is following
+     | Action        | Package                   |
+     | install       | hello-0:1.0-1.fc29.x86_64 |
+   And stderr does not contain "transient overlay"
+   And stderr does not contain "Error"
+   And file "/usr/bin/hello" exists
+
+@reboot_count_1
+Scenario: Removing a package without --transient and with transient overlay fails
+  When I execute dnf with args "remove hello"
+  Then the exit code is 1
+   And stderr contains lines
+     """
+     Error: this bootc system is configured to be read-only. Pass --transient to perform this operation in a transient overlay which will reset when the system reboots.
+     """
+   And file "/usr/bin/hello" exists
+
+@reboot_count_1
+Scenario: Paths in usr_drift_protected_paths are protected
+ Given I create file "/etc/dnf/usr-drift-protected-paths.d/configurable.conf" with
+       """
+       /etc/configurable-2/*
+       /etc/configurable-3/configurable.conf
+       /var/lib/configurable/*
+       """
+  When I execute dnf with args "install configurable --transient"
+  Then the exit code is 1
+   And stderr contains lines
+     """
+     This transaction would modify the following paths, possibly introducing inconsistencies when the transient overlay on /usr is discarded. See the usr_drift_protected_paths configuration option for more information.
+     configurable-1.0-1.fc29.x86_64
+       /etc/configurable-2/configurable.conf
+       /etc/configurable-3/configurable.conf
+       /var/lib/configurable/configurable.db
+     Operation aborted. Pass --setopt=usr_drift_protected_paths= to disable this check and proceed anyway.
+     """
+
+@reboot_count_1
+Scenario: usr_drift_protected_paths can be bypassed on the command line
+ Given I create file "/etc/dnf/usr-drift-protected-paths.d/configurable.conf" with
+       """
+       /etc/configurable-2/*
+       /etc/configurable-3/configurable.conf
+       """
+  When I execute dnf with args "install configurable --transient --setopt=usr_drift_protected_paths="
+  Then the exit code is 0
+   And Transaction is following
+     | Action        | Package                          |
+     | install       | configurable-0:1.0-1.fc29.x86_64 |
+   And stderr does not contain "Error"
+   And file "/etc/configurable-2/configurable.conf" exists
+   And file "/etc/configurable-3/configurable.conf" exists
+
+@reboot_count_2
+Scenario: After reboot, the transient overlay should disappear
+  When I successfully execute "ostree admin status"
+  Then stdout does not contain lines
+     """
+     Unlocked: transient
+     """
+   And path "/usr/bin" is not writable
+   And file "/usr/bin/hello" does not exist
+   And file "/etc/configurable-1/configurable.conf" exists
+   And file "/etc/configurable-2/configurable.conf" exists
+   And file "/etc/configurable-3/configurable.conf" exists
+
+@reboot_count_2
+Scenario: Create writable overlay (unlock the system)
+  When I successfully execute "ostree admin unlock"
+   And I successfully execute "ostree admin status"
+  Then stdout contains lines
+     """
+     Unlocked: development
+     """
+
+@reboot_count_2
+Scenario: dnf install and remove work without --transient with writable overlay
+ Given file "/usr/bin/hello" does not exist
+  When I execute dnf with args "install hello"
+  Then the exit code is 0
+   And Transaction is following
+     | Action  | Package                   |
+     | install | hello-0:1.0-1.fc29.x86_64 |
+   And file "/usr/bin/hello" exists
+   And stderr does not contain "transient overlay"
+   And stderr does not contain "Error"
+  When I execute dnf with args "remove hello"
+  Then the exit code is 0
+   And Transaction is following
+     | Action | Package                   |
+     | remove | hello-0:1.0-1.fc29.x86_64 |
+   And file "/usr/bin/hello" does not exist
+   And stderr does not contain "transient overlay"
+   And stderr does not contain "Error"
+
+@reboot_count_2
+Scenario: dnf install --transient with writable overlay doesn't warn about transient overlay
+ Given file "/usr/bin/hello" does not exist
+  When I execute dnf with args "install hello --transient"
+  Then the exit code is 0
+   And Transaction is following
+     | Action        | Package                   |
+     | install       | hello-0:1.0-1.fc29.x86_64 |
+   And file "/usr/bin/hello" exists
+   And stderr does not contain "transient overlay"
+   And stderr does not contain "Error"
+
+@reboot_count_3
+Scenario: After reboot, the writable overlay should disappear
+  When I successfully execute "ostree admin status"
+  Then stdout does not contain lines
+     """
+     Unlocked: development
+     """
+   And path "/usr/bin" is not writable
+   And file "/usr/bin/hello" does not exist
+
+@reboot_count_3
+Scenario: transient mode is configured by config option
+ Given file "/usr/bin/hello" does not exist
+   And I configure dnf with
+       | key         | value     |
+       | persistence | transient |
+  When I execute dnf with args "install hello"
+  Then the exit code is 0
+   And Transaction is following
+     | Action        | Package                   |
+     | install       | hello-0:1.0-1.fc29.x86_64 |
+   And stderr contains lines
+     """
+     A transient overlay will be created on /usr that will be discarded on reboot. Keep in mind that changes to /etc and /var will still persist, and packages commonly modify these directories.
+     """
+   And file "/usr/bin/hello" exists
+  When I execute dnf with args "remove hello"
+  Then the exit code is 0
+   And Transaction is following
+     | Action | Package                   |
+     | remove | hello-0:1.0-1.fc29.x86_64 |
+   And file "/usr/bin/hello" does not exist
+   And stderr does not contain "Error"
+
+@reboot_count_3
+Scenario: persist mode with transient overlay
+ Given file "/usr/bin/hello" does not exist
+   And I configure dnf with
+       | key         | value   |
+       | persistence | persist |
+  When I execute dnf with args "install hello"
+  Then the exit code is 1
+   And stderr contains lines
+     """
+     Error: persistent transactions aren't supported on bootc systems. Pass --transient to perform this operation in a transient overlay which will reset when the system reboots.
+     """
+   And file "/usr/bin/hello" does not exist

--- a/dnf-behave-tests/fixtures/specs/bootc/configurable-1.0.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/bootc/configurable-1.0.0-1.fc29.spec
@@ -1,0 +1,32 @@
+Name: configurable
+Version: 1.0
+Release: 1.fc29
+Summary: A package with config file
+
+License: GPLv3+
+Url: None
+
+%description
+Description of a pkg that provides a file in /usr/bin and /etc
+
+%install
+mkdir -p %{buildroot}/usr/bin
+mkdir -p %{buildroot}/etc/configurable-1
+mkdir -p %{buildroot}/etc/configurable-2
+mkdir -p %{buildroot}/etc/configurable-3
+mkdir -p %{buildroot}/var/lib/configurable
+touch %{buildroot}/usr/bin/configurable
+touch %{buildroot}/etc/configurable-1/configurable.conf
+touch %{buildroot}/etc/configurable-2/configurable.conf
+touch %{buildroot}/etc/configurable-3/configurable.conf
+# Include a path that is not usually listed in primary.xml
+touch %{buildroot}/var/lib/configurable/configurable.db
+
+%files
+/usr/bin/configurable
+/etc/configurable-1/configurable.conf
+/etc/configurable-2/configurable.conf
+/etc/configurable-3/configurable.conf
+/var/lib/configurable/configurable.db
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/bootc/hello-1.0.0-1.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/bootc/hello-1.0.0-1.fc29.spec
@@ -1,0 +1,25 @@
+Name: hello
+Version: 1.0
+Release: 1.fc29
+Summary: Made up package
+
+License: GPLv3+
+Url: None
+
+Conflicts: hello
+Provides: hello
+
+%description
+Description of a pkg that provides a file in /usr/bin and /etc
+
+%install
+mkdir -p %{buildroot}/usr/bin
+touch %{buildroot}/usr/bin/hello
+mkdir -p %{buildroot}/etc
+touch %{buildroot}/etc/hello.conf
+
+%files
+/usr/bin/hello
+/etc/hello.conf
+
+%changelog

--- a/plans/integration/behave-dnf5-bootc.fmf
+++ b/plans/integration/behave-dnf5-bootc.fmf
@@ -1,0 +1,23 @@
+summary: Build and run a bootc VM for testing
+tag: dnf
+
+provision:
+  how: virtual
+
+prepare:
+- how: install
+  package:
+  - podman
+  - skopeo
+  - jq
+
+execute:
+  how: tmt
+
+/test-transient:
+  summary: Test DNF transient mode (--transient, persistence=transient)
+  discover:
+    how: fmf
+    test:
+    - /tmt/tests/00-bootc-install
+    - /tmt/tests/01-test-transient

--- a/tmt/tests/00-bootc-install.fmf
+++ b/tmt/tests/00-bootc-install.fmf
@@ -1,0 +1,3 @@
+summary: Run bootc install to-existing-root to deploy bootc image
+test: ./00-bootc-install.sh
+duration: 30m

--- a/tmt/tests/00-bootc-install.sh
+++ b/tmt/tests/00-bootc-install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+if [ "$TMT_REBOOT_COUNT" -eq 0 ]; then
+    BOOTC_TEMPDIR=$(mktemp -d)
+    trap 'rm -rf -- "$BOOTC_TEMPDIR"' EXIT
+
+    # Get OS info
+    source /etc/os-release
+    case "$ID" in
+        "centos")
+            BASE_IMAGE="${BASE_IMAGE:-quay.io/centos-bootc/centos-bootc:stream${VERSION_ID}}"
+            ;;
+        "fedora")
+            BASE_IMAGE="${BASE_IMAGE:-quay.io/fedora/fedora-bootc:${VERSION_ID}}"
+            ;;
+    esac
+
+    # TMT needs this key
+    cp -r /root/.ssh "$BOOTC_TEMPDIR"
+
+    # Running on Testing Farm
+    if [[ -d "/var/ARTIFACTS" ]]; then
+        cp -r /var/ARTIFACTS "$BOOTC_TEMPDIR"
+    # Running on local machine with tmt run
+    else
+        cp -r /var/tmp/tmt "$BOOTC_TEMPDIR"
+    fi
+
+    # Some rhts-*, rstrnt-* and tmt-* commands are in /usr/local/bin
+    cp -r /usr/local/bin "$BOOTC_TEMPDIR"
+
+    # Check image building folder content
+    ls -al "$BOOTC_TEMPDIR"
+
+    pushd "$TMT_TREE"
+        ./container-test \
+        --container localhost/dnf-bot/dnf-testing-bootc:latest \
+        build \
+        --file ./bootc/Containerfile \
+        --base "$BASE_IMAGE" \
+        ${PACKIT_COPR_PROJECT:+--container-arg="--env=COPR=$PACKIT_COPR_PROJECT"} \
+        ${PACKIT_COPR_PROJECT:+--container-arg="--env=COPR_RPMS=$PACKIT_COPR_RPMS"}
+    popd
+
+    CONTAINERFILE="$BOOTC_TEMPDIR/Containerfile"
+
+    tee "$CONTAINERFILE" > /dev/null << REALEOF
+FROM localhost/dnf-bot/dnf-testing-bootc:latest
+
+RUN <<EORUN
+set -xeuo pipefail
+
+# For testing farm
+mkdir -p -m 0700 /var/roothome
+
+# Enable ttyS0 console
+mkdir -p /usr/lib/bootc/kargs.d/
+cat <<KARGEOF >> /usr/lib/bootc/kargs.d/20-console.toml
+kargs = ["console=ttyS0,115200n8"]
+KARGEOF
+
+# cloud-init and rsync are required by TMT
+dnf -y install cloud-init rsync
+ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants
+dnf -y clean all
+
+rm -rf /var/cache /var/lib/dnf
+EORUN
+
+# Some rhts-*, rstrnt-* and tmt-* commands are in /usr/local/bin
+COPY bin /usr/local/bin
+
+# In Testing Farm, all ssh things should be reserved for ssh command run after reboot
+COPY .ssh /var/roothome/.ssh
+REALEOF
+
+    if [[ -d "/var/ARTIFACTS" ]]; then
+        # In Testing Farm, TMT work dir /var/ARTIFACTS should be reserved
+        echo "COPY ARTIFACTS /var/ARTIFACTS" >> "$CONTAINERFILE"
+    else
+        # In local machine, TMT work dir /var/tmp/tmt should be reserved
+        echo "COPY tmt /var/tmp/tmt" >> "$CONTAINERFILE"
+    fi
+
+    podman build --retry 5 --retry-delay 5s --tls-verify=false -t localhost/dnf-bot/dnf-testing-bootc-tmt:latest -f "$CONTAINERFILE" "$BOOTC_TEMPDIR"
+
+    podman images
+    podman run \
+        --rm \
+        --tls-verify=false \
+        --privileged \
+        --pid=host \
+        -v /:/target \
+        -v /dev:/dev \
+        -v /var/lib/containers:/var/lib/containers \
+        -v /root/.ssh:/output \
+        --security-opt label=type:unconfined_t \
+        localhost/dnf-bot/dnf-testing-bootc-tmt:latest \
+        bootc install to-existing-root --target-transport containers-storage --acknowledge-destructive
+
+    tmt-reboot
+elif [ "$TMT_REBOOT_COUNT" -eq 1 ]; then
+    # Some simple and fast checks
+    bootc status
+    echo "$PATH"
+    printenv
+    if [[ -d "/var/ARTIFACTS" ]]; then
+        ls -al /var/ARTIFACTS
+    else
+        ls -al /var/tmp/tmt
+    fi
+    ls -al /usr/local/bin
+    echo "Bootc system on TMT/TF runner"
+
+    exit 0
+fi

--- a/tmt/tests/01-test-transient.fmf
+++ b/tmt/tests/01-test-transient.fmf
@@ -1,0 +1,6 @@
+summary: Test DNF transient mode (--transient, persistence=transient)
+test: |
+  cd /opt/ci/dnf-behave-tests
+  "$TMT_TREE"/container-test --suite dnf-bootc --run-on-host run --reboot --command dnf5 transient.feature
+
+duration: 30m


### PR DESCRIPTION
Implement a framework for running tests on bootc systems, and add tests for `dnf5 --transient`

This is mostly a straightforward merge of the bootc testing framework from the dnf-4-stack branch to the main DNF5 branch.