### PR TITLE
[dnf-4-stack] Normalize percent-encoding in "HTTP log contains"

### DIFF
--- a/dnf-behave-tests/dnf/steps/server.py
+++ b/dnf-behave-tests/dnf/steps/server.py
@@ -7,6 +7,7 @@ import behave
 from fnmatch import fnmatch
 import os
 import parse
+import re
 
 from fixtures import start_server_based_on_type
 
@@ -102,10 +103,11 @@ def step_check_http_log(context, quantifier, command):
 @behave.step("HTTP log contains")
 def step_http_log_contains(context):
     expected = context.text.format(context=context).rstrip().split('\n')
-    found = ["%s %s" % (r.command, r.path) for r in context.scenario.httpd.log]
-
+    # curl 8.20.0+ normalizes percent-encoding to uppercase
+    normalize = lambda s: re.sub(r'%[0-9a-fA-F]{2}', lambda m: m.group().upper(), s)
+    found = ["%s %s" % (r.command, normalize(r.path)) for r in context.scenario.httpd.log]
     for e in expected:
-        if e not in found:
+        if normalize(e) not in found:
             raise AssertionError('HTTP log does not contain "%s": %s' % (e, "\n" + "\n".join(found) + "\n"))
 
 


### PR DESCRIPTION
Backport of https://github.com/rpm-software-management/ci-dnf-stack/pull/1875 for dnf-4-stack.