### PR TITLE
Add test for RHEL-80156: non-modular advisory filtered for modular packages

### DIFF
--- a/dnf-behave-tests/dnf/module/updateinfo.feature
+++ b/dnf-behave-tests/dnf/module/updateinfo.feature
@@ -133,3 +133,28 @@ Given I use repository "dnf-ci-multicontext-modular-advisory"
       <REPOSYNC>
 
       """
+
+
+# https://redhat.atlassian.net/browse/RHEL-80156
+@RHEL-80156
+Scenario: non-modular advisory is not shown when modular stream is enabled
+Given I use repository "dnf-ci-fedora"
+  And I use repository "dnf-ci-fedora-non-modular-advisory"
+  And I successfully execute dnf with args "install nodejs"
+  # Non-modular advisory is visible before enabling the module
+ When I execute dnf with args "updateinfo --list"
+ Then the exit code is 0
+  And stdout is
+      """
+      <REPOSYNC>
+      NONMOD-2024-9291 bugfix nodejs-2:5.12.1-20.fc29.x86_64
+      """
+  # After enabling the module, the non-modular advisory is filtered out
+Given I use repository "dnf-ci-fedora-modular"
+  And I successfully execute dnf with args "module enable nodejs:8"
+ When I execute dnf with args "updateinfo --list"
+ Then the exit code is 0
+  And stdout is
+      """
+      <REPOSYNC>
+      """

--- a/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-non-modular-advisory/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/dnf-ci-fedora-non-modular-advisory/updateinfo.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+  <update from="secresponseteam@foo.bar" status="final" type="bugfix" version="3">
+    <id>NONMOD-2024-9291</id>
+    <title>nodejs non-modular bug fix</title>
+    <issued date="2024-09-29 00:00:00"/>
+    <updated date="2024-09-29 00:00:00"/>
+    <severity>none</severity>
+    <summary>Non-modular nodejs advisory</summary>
+    <description>Bug fix for non-modular nodejs</description>
+    <pkglist>
+      <collection short="named collection">
+        <name>Non-modular component</name>
+        <package name="nodejs" version="5.12.1" release="20.fc29" epoch="2" arch="x86_64">
+          <filename>nodejs-2:5.12.1-20.fc29.x86_64.rpm</filename>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
+</updates>


### PR DESCRIPTION
Add a behave scenario that verifies 'updateinfo --list' does not show non-modular advisories when a modular stream of the same package is enabled.

Requires: https://github.com/rpm-software-management/libdnf/pull/1771
