### PR TITLE
Adapt to changes in libxml2 2.13

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/groups-manager-errors.feature
+++ b/dnf-behave-tests/dnf/plugins-core/groups-manager-errors.feature
@@ -34,10 +34,10 @@ Scenario: attempt to write to non-existent directory
   Given file "nonexistent/path" does not exist
    When I execute dnf with args "groups-manager --save=nonexistent/path/out.xml"
    Then the exit code is 1
-    And stderr is
+    And stderr matches line by line
     """
-    I/O error : No such file or directory
-    I/O error : No such file or directory
+    ?I/O error : No such file or directory
+    ?I/O error : No such file or directory
     Error: Can't save file "nonexistent/path/out.xml": Can't write file nonexistent/path/out.xml
     """
 


### PR DESCRIPTION
After upgrading libxml2 from 2.12.10 to 2.13.9
dnf/plugins-core/groups-manager-errors.feature started to fail:

~~~
  Scenario: attempt to write to non-existent directory                            # dnf/plugins-core/groups-manager-errors.feature:33
    Given I enable plugin "groups_manager"                                        # dnf/steps/cmd.py:197
    Given file "nonexistent/path" does not exist                                  # common/file.py:82
    When I execute dnf with args "groups-manager --save=nonexistent/path/out.xml" # dnf/steps/cmd.py:106
    Then the exit code is 1                                                       # common/output.py:57
    And stderr is                                                                 # common/output.py:141
      """
      I/O error : No such file or directory
      I/O error : No such file or directory
      Error: Can't save file "nonexistent/path/out.xml": Can't write file nonexistent/path/out.xml
      """
      Assertion Failed: Stderr is not: I/O error : No such file or directory
      I/O error : No such file or directory
      Error: Can't save file "nonexistent/path/out.xml": Can't write file nonexistent/path/out.xml
      Captured stdout:
      expected                                                                                      |  found
      I/O error : No such file or directory                                                         |  Error: Can't save file "nonexistent/path/out.xml": Can't write file nonexistent/path/out.xml
      I/O error : No such file or directory                                                         |
      Error: Can't save file "nonexistent/path/out.xml": Can't write file nonexistent/path/out.xml  |
~~~~

The cause was that libxml2's xmlSaveFormatFileEnc() function, excuted by libcomps' comps2xml_f(), independently from DNF printed the "I/O error" lines on stderr and the test expected it. New libxml2 does not do it and the test failed.

This patch makes the libxml2's output optional to work with both libxml2 versions.

Currently only Fedora 45 is affected, example <https://github.com/rpm-software-management/dnf/pull/2329/checks>.