### PR TITLE
Don't ignore advisory upgrade with lover libsolv id evr

### DIFF
--- a/dnf-behave-tests/dnf/updateinfo.feature
+++ b/dnf-behave-tests/dnf/updateinfo.feature
@@ -715,3 +715,40 @@ Given I successfully execute dnf with args "install kernel flac glibc"
       Name               Type        Severity                  Package              Issued
       FEDORA-2999:002-02 enhancement Moderate flac-1.3.3-8.fc29.x86_64 2019-01-17 00:00:00
       """
+
+
+# https://github.com/rpm-software-management/dnf5/issues/2754
+Scenario: package is upgraded if it has both resolved and unresolved advisories
+  Given I use repository "z-kernel"
+    And I successfully execute dnf with args "install kernel-4.19.15-301.fc29"
+    And I use repository "dnf-ci-fedora-updates"
+   # advisory shows bugfix upgrade available
+   When I execute dnf with args "advisory list --bugfix"
+   Then the exit code is 0
+    And stderr is
+        """
+        <REPOSYNC>
+        """
+    And stdout is
+        """
+        Name              Type   Severity                        Package              Issued
+        FEDORA-2026-10-06 bugfix Moderate kernel-4.19.15-302.fc29.x86_64 2026-06-10 00:00:00
+        """
+  # Clean all solv files because libsolv loads ids differently when using them
+  Given I successfully execute dnf with args "clean all"
+  # To reproduce this several conditions are required:
+  # > an unresolved advisory for kernel kernel-4.19.15-302.fc29, correctly listed
+  #   by the previous $ advisory list --bugfix command, present in the z-kernel repository
+  # > resolved advisory of the same type for kernel-4.19.15-300.fc29, present in dnf-ci-fedora-updates
+  # > the evr string of the higher 4.19.15-302.fc29 has to have lower libsolv id than 4.19.15-300.fc29
+  #   - when no solv files are present libsolv assigns string ids roughly in the following
+  #     order: hard-coded libsolv KNOWNIDs, installed repository strings, other repositories
+  #     strings as added by the client (libdnf)
+  #   - dnf5 sorts repositories alphabetically and for local repositories loads them
+  #     in reverse order (z-kernel is first)
+   When I execute dnf with args "upgrade kernel --bugfix"
+   Then Transaction is following
+        | Action        | Package                                  |
+        | install       | kernel-0:4.19.15-302.fc29.x86_64         |
+        | install-dep   | kernel-core-0:4.19.15-302.fc29.x86_64    |
+        | install-dep   | kernel-modules-0:4.19.15-302.fc29.x86_64 |

--- a/dnf-behave-tests/fixtures/specs/z-kernel/kernel-4.19.15-301.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/z-kernel/kernel-4.19.15-301.fc29.spec
@@ -1,0 +1,57 @@
+Name:           kernel
+Epoch:          0
+Version:        4.19.15
+Release:        301.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       kernel = 4.19.15-301.fc29
+Provides:       kernel(x86-64) = 4.19.15-301.fc29
+
+Requires:       kernel-modules-uname-r = 4.19.15-301.fc29.x86_64
+Requires:       kernel-core-uname-r = 4.19.15-301.fc29.x86_64
+
+%description
+The kernel meta package
+
+%package core
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+Provides:       kernel = 4.19.15-301.fc29
+Provides:       kernel-uname-r = 4.19.15-301.fc29.x86_64
+Provides:       kernel-core-uname-r = 4.19.15-301.fc29.x86_64
+Provides:       kernel-core = 4.19.15-301.fc29
+Provides:       kernel-core(x86-64) = 4.19.15-301.fc29
+Provides:       kernel-x86_64 = 4.19.15-301.fc29
+
+%description core
+The kernel package contains the Linux kernel (vmlinuz), the core of any
+Linux operating system.  The kernel handles the basic functions
+of the operating system: memory allocation, process allocation, device
+input and output, etc.
+
+%package modules
+Summary:        kernel modules to match the core kernel
+
+Provides:       installonlypkg(kernel-module)
+Provides:       kernel-modules-uname-r = 4.19.15-301.fc29.x86_64
+Provides:       kernel-modules = 4.19.15-301.fc29
+Provides:       kernel-modules(x86-64) = 4.19.15-301.fc29
+Provides:       kernel-modules-x86_64 = 4.19.15-301.fc29
+
+Requires:       kernel-uname-r = 4.19.15-301.fc29.x86_64
+
+%description modules
+This package provides commonly used kernel modules for the core kernel package.
+
+%files
+
+%files core
+
+%files modules
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/z-kernel/kernel-4.19.15-302.fc29.spec
+++ b/dnf-behave-tests/fixtures/specs/z-kernel/kernel-4.19.15-302.fc29.spec
@@ -1,0 +1,58 @@
+Name:           kernel
+Epoch:          0
+Version:        4.19.15
+Release:        302.fc29
+
+License:        GPLv2 and Redistributable, no modification permitted
+URL:            https://www.kernel.org/
+
+Summary:        The Linux kernel
+
+Provides:       kernel = 4.19.15-302.fc29
+Provides:       kernel(x86-64) = 4.19.15-302.fc29
+
+Requires:       kernel-modules-uname-r = 4.19.15-302.fc29.x86_64
+Requires:       kernel-core-uname-r = 4.19.15-302.fc29.x86_64
+
+%description
+The kernel meta package
+
+%package core
+Summary:        The Linux kernel
+
+Provides:       installonlypkg(kernel)
+Provides:       kernel = 4.19.15-302.fc29
+Provides:       kernel-uname-r = 4.19.15-302.fc29.x86_64
+Provides:       kernel-core-uname-r = 4.19.15-302.fc29.x86_64
+Provides:       kernel-core = 4.19.15-302.fc29
+Provides:       kernel-core(x86-64) = 4.19.15-302.fc29
+Provides:       kernel-x86_64 = 4.19.15-302.fc29
+
+%description core
+The kernel package contains the Linux kernel (vmlinuz), the core of any
+Linux operating system.  The kernel handles the basic functions
+of the operating system: memory allocation, process allocation, device
+input and output, etc.
+
+
+%package modules
+Summary:        kernel modules to match the core kernel
+
+Provides:       installonlypkg(kernel-module)
+Provides:       kernel-modules-uname-r = 4.19.15-302.fc29.x86_64
+Provides:       kernel-modules = 4.19.15-302.fc29
+Provides:       kernel-modules(x86-64) = 4.19.15-302.fc29
+Provides:       kernel-modules-x86_64 = 4.19.15-302.fc29
+
+Requires:       kernel-uname-r = 4.19.15-302.fc29.x86_64
+
+%description modules
+This package provides commonly used kernel modules for the core kernel package.
+
+%files
+
+%files core
+
+%files modules
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/z-kernel/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/z-kernel/updateinfo.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+  <update from="secresponseteam@foo.bar" status="final" type="bugfix" version="3">
+    <id>FEDORA-2026-10-06</id>
+    <title>kernel bug fix</title>
+    <issued date="2026-06-10 00:00:00"/>
+    <updated date="2026-06-10 00:00:00"/>
+    <severity>Moderate</severity>
+    <summary>summary_1</summary>
+    <description>Kernel advisory</description>
+    <pkglist>
+      <collection short="named collection">
+        <name>Bar component</name>
+        <package name="kernel" version="4.19.15" release="302.fc29" epoch="0" arch="x86_64" src="kernel-0:4.19.15-302.fc29.x86_64.rpm">
+          <filename>kernel-0:4.19.15-302.fc29.x86_64.rpm</filename>
+          <reboot_suggested/>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
+</updates>


### PR DESCRIPTION
For https://github.com/rpm-software-management/dnf5/issues/2754

Requires: https://github.com/rpm-software-management/dnf5/pull/2759