### PR TITLE
Adjust download-source and repo-sync tests for the latest curl

### DIFF
--- a/dnf-behave-tests/dnf/download-source.feature
+++ b/dnf-behave-tests/dnf/download-source.feature
@@ -72,7 +72,7 @@ Given I create directory "/baseurlrepo"
  Then the exit code is 1
   And stderr contains "Errors during downloading metadata for repository 'testrepo':"
   And stderr contains "- Curl error \(37\): Could not read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[(Couldn't|Could not) open file /nonexistent.repo/repodata/repomd.xml\]"
-  And stderr contains "- Curl error \(7\): Could not connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Could not connect to server]"
+  And stderr contains "- Curl error \(7\): Could not connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1(:| port )5000 after 0 ms: Could not connect to server]"
   And stderr contains "- Curl error \(37\): Could not read a file:// file for file:///tmp/dnf_ci_installroot_.*/I_dont_exist/repodata/repomd.xml \[(Couldn't|Could not) open file /tmp/dnf_ci_installroot_.*/I_dont_exist/repodata/repomd.xml\]"
   And stderr contains "Error: Failed to download metadata for repo 'testrepo': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
 

--- a/dnf-behave-tests/dnf/repo-sync.feature
+++ b/dnf-behave-tests/dnf/repo-sync.feature
@@ -175,13 +175,13 @@ Scenario: Mirrorlist with invalid mirrors
    Then the exit code is 1
     And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
     And stderr contains "  - Curl error \(37\): (Couldn't|Could not) read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[(Couldn't|Could not) open file /nonexistent.repo/repodata/repomd.xml\]"
-    And stderr contains "  - Curl error \(7\): (Couldn't|Could not) connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Could not connect to server\]"
+    And stderr contains "  - Curl error \(7\): (Couldn't|Could not) connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1(:| port )5000 after 0 ms: Could not connect to server\]"
     And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
    When I execute dnf with args "makecache --setopt=*.skip_if_unavailable=1"
    Then the exit code is 0
     And stderr contains "Errors during downloading metadata for repository 'dnf-ci-fedora':"
     And stderr contains "  - Curl error \(37\): (Couldn't|Could not) read a file:// file for file:///nonexistent.repo/repodata/repomd.xml \[(Couldn't|Could not) open file /nonexistent.repo/repodata/repomd.xml\]"
-    And stderr contains "  - Curl error \(7\): (Couldn't|Could not) connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1 port 5000 after 0 ms: Could not connect to server\]"
+    And stderr contains "  - Curl error \(7\): (Couldn't|Could not) connect to server for http://127.0.0.1:5000/nonexistent/repodata/repomd.xml \[Failed to connect to 127.0.0.1(:| port )5000 after 0 ms: Could not connect to server\]"
     And stderr contains "Error: Failed to download metadata for repo 'dnf-ci-fedora': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried"
     And stderr contains "Ignoring repositories: dnf-ci-fedora"
 


### PR DESCRIPTION
Curl changed the format of an error message in its latest release (see curl upstream commit bc40e09f638). Adjust the tests to cover both variants.