### PR TITLE
Adapt tests to DNF5 in ELN

### DIFF
--- a/dnf-behave-tests/dnf/protected-dnf.feature
+++ b/dnf-behave-tests/dnf/protected-dnf.feature
@@ -1,0 +1,13 @@
+# - doesn't makes sense to test in installroot
+# - a potentially destructive test
+@no_installroot
+Feature: Dnf protects itself
+
+
+@not.with_os=rhel__lt__11
+Scenario: Dnf5 when installed protects itself
+  Given I execute dnf with args "install dnf5"
+   Then the exit code is 0
+   When I execute dnf with args "remove dnf5"
+   Then the exit code is 1
+    And stderr contains "operation would result in removing the following protected packages: dnf5"

--- a/dnf-behave-tests/dnf/protected-packages.feature
+++ b/dnf-behave-tests/dnf/protected-packages.feature
@@ -137,19 +137,3 @@ Scenario: Package protected via a configuration file cannot be removed
    Then the exit code is 1
     And Transaction is empty
     And stderr contains "Problem: The operation would result in removing the following protected packages: filesystem"
-
-
-# TODO: Removal of DNF itself
-# - doesn't makes sense to test in installroot
-# - a potentially destructive test
-
-
-@use.with_os=rhel__ge__8
-@no_installroot
-Scenario: Dnf when installed protects yum package, because of dnf yum alias
-  Given I use repository "dnf-ci-fedora"
-   When I execute dnf with args "install yum"
-   Then the exit code is 0
-   When I execute dnf with args "remove yum"
-   Then the exit code is 1
-    And stderr contains "operation would result in removing the following protected packages: yum"

--- a/dnf-behave-tests/dnf/zchunk.feature
+++ b/dnf-behave-tests/dnf/zchunk.feature
@@ -1,3 +1,5 @@
+# librepo is built without zchunk support on RHEL.
+@not.with_os=rhel__ge__11
 Feature: zchunk tests
 
 


### PR DESCRIPTION
This patch set makes the tests passing in ELN (RHEL 11). You can see the addressed failures in <https://github.com/rpm-software-management/dnf5/pull/2669> (results at <https://artifacts.dev.testing-farm.io/4e3b8ee4-6499-4a18-948c-d083bfa300e6/>).

This ci-dnf-stack patch should be merged before merging the linked dnf5 merge request.