### PR TITLE
Pin pyftpdlib to 2.1.0

### DIFF
--- a/dnf-behave-tests/requirements.txt
+++ b/dnf-behave-tests/requirements.txt
@@ -1,3 +1,3 @@
 behave == 1.2.6
 pexpect
-pyftpdlib
+pyftpdlib == 2.1.0


### PR DESCRIPTION
Newer pyftpdlib 2.2.0 requires newer python 3.9.