### PR TITLE
Add more test suite dependencies

### DIFF
--- a/dnf-behave-tests/requirements.spec
+++ b/dnf-behave-tests/requirements.spec
@@ -17,23 +17,39 @@ License:        GPLv3
 
 # test suite dependencies
 BuildRequires:  acl
+# attr for "getfattr" command
 BuildRequires:  attr
+# coreutils for "chmod", "head', "id", "ln", "ls", "mv", "sha256sum", "sleep",
+# "sort", "stat", "touch" commands
+BuildRequires:  coreutils
 BuildRequires:  createrepo_c
+# diffutils for "diff" command
+BuildRequires:  diffutils
 BuildRequires:  fakeuname
 BuildRequires:  findutils
 BuildRequires:  glibc-langpack-en
 BuildRequires:  glibc-langpack-de
+BuildRequires:  grep
+BuildRequires:  gzip
 BuildRequires:  libfaketime
 BuildRequires:  openssl
+# psmisc for "killall" command
+BuildRequires:  psmisc
 BuildRequires:  python3 >= 3.11
 BuildRequires:  python3-distro
 BuildRequires:  python3-pip
 BuildRequires:  python3-rpm
 # a missing dep of python3-pip on f35 beta, remove when unneeded
 BuildRequires:  python3-setuptools
+BuildRequires:  rpm
 BuildRequires:  rpm-build
 BuildRequires:  rpm-sign
+BuildRequires:  sed
+# shadow-utils for "useradd" command
+BuildRequires:  shadow-utils
 BuildRequires:  sqlite
+# util-linux for "su" command
+BuildRequires:  util-linux
 BuildRequires:  yq
 BuildRequires:  zstd
 %if 0%{?fedora}


### PR DESCRIPTION
Some tests failed on ELN (based on F45) with:

      ASSERT FAILED: Running command "id -u testuser || useradd testuser" failed: 127

The cause was that the /usr/bin/useradd program was not available because shadow-utils package was not listed in the test suite dependencies.

This patch declares RPM dependencies for all the commands executed by run_in_context() function.