### PR TITLE
Python API tests: lock system repo since some tests do transactions

### DIFF
--- a/dnf-behave-tests/dnf/repoquery/modules.feature
+++ b/dnf-behave-tests/dnf/repoquery/modules.feature
@@ -32,7 +32,7 @@ Scenario: Test --disable-modular-filtering with a default module stream
       """
 
 Scenario: Test --disable-modular-filtering with an enabled module stream
- When I execute dnf with args "module enable nodejs:5"
+Given I successfully execute dnf with args "module enable nodejs:5"
  When I execute dnf with args "repoquery nodejs"
  Then the exit code is 0
   And stderr is

--- a/dnf-behave-tests/dnf/steps/cmd.py
+++ b/dnf-behave-tests/dnf/steps/cmd.py
@@ -394,6 +394,8 @@ base.load_config()
 
 base.setup()
 
+base.lock_system_repo(libdnf5.utils.LockAccess_WRITE, libdnf5.utils.LockBlocking_BLOCKING)
+
 repo_sack = base.get_repo_sack()
 repo_sack.create_repos_from_system_configuration()
 repo_sack.load_repos()


### PR DESCRIPTION
Requires and required for: https://github.com/rpm-software-management/dnf5/pull/2785