### PR TITLE
Disable modularity tests for DNF5 since RHEL 11

### DIFF
--- a/dnf-behave-tests/common/lib/os_version.py
+++ b/dnf-behave-tests/common/lib/os_version.py
@@ -20,3 +20,10 @@ def detect_os_version():
         major_version = str(rhel_macro_version)
 
     return os_id + "__" + major_version
+
+# Whether the current operating systems is supposed to support modularity.
+def want_modularity():
+    os, version = detect_os_version().split('__')
+    if os == 'rhel' and int(version) >= 11:
+        return False;
+    return True;

--- a/dnf-behave-tests/dnf/command-aliases.feature
+++ b/dnf-behave-tests/dnf/command-aliases.feature
@@ -43,7 +43,6 @@ Examples:
         | list                | ls                           |
         | makecache           | mc                           |
         | mark                | mark                         |
-        | module              | module                       |
         | reinstall           | rei                          |
         | reinstall           | reinstall                    |
         | remove              | remove                       |
@@ -58,3 +57,9 @@ Examples:
         | upgrade             | update                       |
         | upgrade             | upgrade                      |
         | upgrade             | upgrade-minimal              |
+
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
+Examples:
+        | command             | alias                        |
+        | module              | module                       |

--- a/dnf-behave-tests/dnf/history-undo-dependant.feature
+++ b/dnf-behave-tests/dnf/history-undo-dependant.feature
@@ -1,5 +1,7 @@
 Feature: Transaction history undo
 
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @bz1700529
 Scenario: Undo module install with dependent userinstalled package
   Given I use repository "dnf-ci-fedora"

--- a/dnf-behave-tests/dnf/module/add-new-stream-static-context.feature
+++ b/dnf-behave-tests/dnf/module/add-new-stream-static-context.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/defaults-conflict.feature
+++ b/dnf-behave-tests/dnf/module/defaults-conflict.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Not fail if conflicts in module metadata.
 
   @bz1656019

--- a/dnf-behave-tests/dnf/module/defaults-from-config-file.feature
+++ b/dnf-behave-tests/dnf/module/defaults-from-config-file.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/defaults-profiles.feature
+++ b/dnf-behave-tests/dnf/module/defaults-profiles.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/defaults-streams.feature
+++ b/dnf-behave-tests/dnf/module/defaults-streams.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Default streams are properly switched to enabled 
 
 Background:

--- a/dnf-behave-tests/dnf/module/defaults.feature
+++ b/dnf-behave-tests/dnf/module/defaults.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Modulemd defaults are followed by dnf module commands
 
 Background:

--- a/dnf-behave-tests/dnf/module/demodularization.feature
+++ b/dnf-behave-tests/dnf/module/demodularization.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Demodularization is not implemented
 # https://github.com/rpm-software-management/dnf5/issues/1852
 @xfail

--- a/dnf-behave-tests/dnf/module/disable-errors.feature
+++ b/dnf-behave-tests/dnf/module/disable-errors.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Disabling module - error handling
 
 

--- a/dnf-behave-tests/dnf/module/disable.feature
+++ b/dnf-behave-tests/dnf/module/disable.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Disabling module stream
 
 

--- a/dnf-behave-tests/dnf/module/enable-confirmation.feature
+++ b/dnf-behave-tests/dnf/module/enable-confirmation.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Enable module requires confirmation
 
 

--- a/dnf-behave-tests/dnf/module/enable-contexts.feature
+++ b/dnf-behave-tests/dnf/module/enable-contexts.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Dependency resolution must occur to determine the appropriate dependent stream+context to use
 
 Background:

--- a/dnf-behave-tests/dnf/module/enable-dependencies.feature
+++ b/dnf-behave-tests/dnf/module/enable-dependencies.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Enable module streams with modular dependencies
 
 

--- a/dnf-behave-tests/dnf/module/enable-errors.feature
+++ b/dnf-behave-tests/dnf/module/enable-errors.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Enabling module streams - error handling
 
 

--- a/dnf-behave-tests/dnf/module/enable-latest.feature
+++ b/dnf-behave-tests/dnf/module/enable-latest.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Enabling module streams that are not latest
 
 

--- a/dnf-behave-tests/dnf/module/enable.feature
+++ b/dnf-behave-tests/dnf/module/enable.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Enabling module streams
 
 

--- a/dnf-behave-tests/dnf/module/filter-rpms.feature
+++ b/dnf-behave-tests/dnf/module/filter-rpms.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @jiraRHELPLAN-6073
 Feature: Filter RPMs by enabled and default module streams
 

--- a/dnf-behave-tests/dnf/module/filtering.feature
+++ b/dnf-behave-tests/dnf/module/filtering.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Modular filtering must provide onlu relevant source packages
 
 Background:

--- a/dnf-behave-tests/dnf/module/help.feature
+++ b/dnf-behave-tests/dnf/module/help.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Module usage help
 
 Scenario: I can print help using dnf module --help

--- a/dnf-behave-tests/dnf/module/hotfixes.feature
+++ b/dnf-behave-tests/dnf/module/hotfixes.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: hotfix repo content is not masked by a modular content
 
 

--- a/dnf-behave-tests/dnf/module/info-without-install.feature
+++ b/dnf-behave-tests/dnf/module/info-without-install.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Module info without the install command implemented
 
 

--- a/dnf-behave-tests/dnf/module/info.feature
+++ b/dnf-behave-tests/dnf/module/info.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/install-default.feature
+++ b/dnf-behave-tests/dnf/module/install-default.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/install-dependency.feature
+++ b/dnf-behave-tests/dnf/module/install-dependency.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/install-errors.feature
+++ b/dnf-behave-tests/dnf/module/install-errors.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/install-globs.feature
+++ b/dnf-behave-tests/dnf/module/install-globs.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/install-latest.feature
+++ b/dnf-behave-tests/dnf/module/install-latest.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/install-local-package.feature
+++ b/dnf-behave-tests/dnf/module/install-local-package.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: RPMs can be installed locally regardless the modular content
 
 

--- a/dnf-behave-tests/dnf/module/install-module-static-context.feature
+++ b/dnf-behave-tests/dnf/module/install-module-static-context.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/install-multicontext.feature
+++ b/dnf-behave-tests/dnf/module/install-multicontext.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/install-package-ursine.feature
+++ b/dnf-behave-tests/dnf/module/install-package-ursine.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Installing package from ursine repo
 
 Background: Enable repositories

--- a/dnf-behave-tests/dnf/module/install-package.feature
+++ b/dnf-behave-tests/dnf/module/install-package.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Installing package from module
 
 

--- a/dnf-behave-tests/dnf/module/install.feature
+++ b/dnf-behave-tests/dnf/module/install.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/list.feature
+++ b/dnf-behave-tests/dnf/module/list.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module install command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/metadata-errors.feature
+++ b/dnf-behave-tests/dnf/module/metadata-errors.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @xfail
 # Reported as https://github.com/rpm-software-management/dnf5/issues/1855
 Feature: Error reading modular metadata

--- a/dnf-behave-tests/dnf/module/metadata-format.feature
+++ b/dnf-behave-tests/dnf/module/metadata-format.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: libmodulemd document format tests
 
 

--- a/dnf-behave-tests/dnf/module/obsoletes.feature
+++ b/dnf-behave-tests/dnf/module/obsoletes.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @xfail
 # Obsoletes are not implemented in dnf5
 # Mentioned in https://github.com/rpm-software-management/dnf5/issues/146

--- a/dnf-behave-tests/dnf/module/platform-detection.feature
+++ b/dnf-behave-tests/dnf/module/platform-detection.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @bz1688462
 Feature: Detecting proper modular platform
 

--- a/dnf-behave-tests/dnf/module/platform.feature
+++ b/dnf-behave-tests/dnf/module/platform.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @jiraRHELPLAN-6083
 Feature: platform pseudo-module based on /etc/os-release
 

--- a/dnf-behave-tests/dnf/module/provides.feature
+++ b/dnf-behave-tests/dnf/module/provides.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module provides command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/remove.feature
+++ b/dnf-behave-tests/dnf/module/remove.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module remove command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/repoquery.feature
+++ b/dnf-behave-tests/dnf/module/repoquery.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module repoquery command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/reset.feature
+++ b/dnf-behave-tests/dnf/module/reset.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Reset modules
 
 

--- a/dnf-behave-tests/dnf/module/switch.feature
+++ b/dnf-behave-tests/dnf/module/switch.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module switch-to command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/update.feature
+++ b/dnf-behave-tests/dnf/module/update.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 # Missing module update command
 # https://github.com/rpm-software-management/dnf5/issues/146
 @xfail

--- a/dnf-behave-tests/dnf/module/updateinfo.feature
+++ b/dnf-behave-tests/dnf/module/updateinfo.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Advisory aplicability on a modular system
 
 

--- a/dnf-behave-tests/dnf/option-hint.feature
+++ b/dnf-behave-tests/dnf/option-hint.feature
@@ -1,6 +1,21 @@
 Feature: Hints for misplaced options
 
 
+# Modularity is disabled since RHEL 11
+@use.with_os=rhel__ge__11
+Scenario: command specific long option used with root dnf command
+   When I execute dnf with args "--skip-broken update"
+   Then the exit code is 2
+    And stdout is empty
+    And stderr is
+        """
+        Unknown argument "--skip-broken" for command "dnf5". Add "--help" for more information about the arguments.
+        The argument is available for commands: environment install, group install, replay, reinstall, downgrade, debuginfo-install, distro-sync, install, do. (It has to be placed after the command.)
+        """
+
+
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Scenario: command specific long option used with root dnf command
    When I execute dnf with args "--skip-broken update"
    Then the exit code is 2

--- a/dnf-behave-tests/dnf/plugins-core/builddep-modularity.feature
+++ b/dnf-behave-tests/dnf/plugins-core/builddep-modularity.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: Tests for builddep command on modular system
 
 Background:

--- a/dnf-behave-tests/dnf/plugins-core/reposync.feature
+++ b/dnf-behave-tests/dnf/plugins-core/reposync.feature
@@ -96,6 +96,8 @@ Scenario: Reposync with --download-metadata option
    """
 
 
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @bz1714788
 Scenario: Reposync downloads packages from all streams of modular repository
   Given I use repository "dnf-ci-fedora-modular" as http
@@ -106,6 +108,8 @@ Scenario: Reposync downloads packages from all streams of modular repository
     And file "//{context.dnf.tempdir}/dnf-ci-fedora-modular/x86_64/nodejs-11.0.0-1.module_2311+8d497411.x86_64.rpm" exists
 
 
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @bz1714788
 Scenario: Reposync downloads packages from all streams of modular repository even if the module is disabled
   Given I use repository "dnf-ci-fedora-modular" as http
@@ -154,6 +158,8 @@ Scenario: Reposync respects includes
     """
 
 
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Scenario: Reposync respects excludes, but not modular excludes
   Given I use repository "dnf-ci-fedora-modular" as http
    When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --setopt=includepkgs=postgresql"

--- a/dnf-behave-tests/dnf/repoquery/modules.feature
+++ b/dnf-behave-tests/dnf/repoquery/modules.feature
@@ -1,3 +1,5 @@
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 Feature: repoquery tests for handling modularity.
 
 Background:

--- a/dnf-behave-tests/dnf/steps/repo.py
+++ b/dnf-behave-tests/dnf/steps/repo.py
@@ -23,6 +23,7 @@ from common.lib.file import (
     ensure_file_exists,
     find_file_by_glob,
 )
+from common.lib.os_version import want_modularity
 from fixtures import start_server_based_on_type, stop_server_type
 from fixtures.osrelease import osrelease_fixture
 from fixtures.machineid import machineid_fixture
@@ -72,7 +73,6 @@ def create_repo_conf(context, repo):
 
     write_repo_config(context, repo, repo_info.config)
 
-
 def generate_repodata(context, repo, extra_args=None, explicit=False, can_fail=False, expected_exit_code=None):
     repo_subst = repo.replace("$releasever", context.dnf.releasever)
     repo_info = get_repo_info(context, repo)
@@ -101,9 +101,10 @@ def generate_repodata(context, repo, extra_args=None, explicit=False, can_fail=F
     if os.path.isfile(updateinfo_filename):
         run_in_context(context, "modifyrepo_c %s '%s'" % (updateinfo_filename, repodata_path))
 
-    modules_filename = os.path.join(context.dnf.fixturesdir, "specs", repo_subst, "modules.yaml")
-    if os.path.isfile(modules_filename):
-        run_in_context(context, "modifyrepo_c --mdtype=modules %s '%s'" % (modules_filename, repodata_path))
+    if want_modularity():
+        modules_filename = os.path.join(context.dnf.fixturesdir, "specs", repo_subst, "modules.yaml")
+        if os.path.isfile(modules_filename):
+            run_in_context(context, "modifyrepo_c --mdtype=modules %s '%s'" % (modules_filename, repodata_path))
 
     if not repo_info.copied:
         context.repos[repo_subst] = True

--- a/dnf-behave-tests/fixtures/specs/build.sh
+++ b/dnf-behave-tests/fixtures/specs/build.sh
@@ -13,6 +13,7 @@ GPGDIR="$DIR/../gpgkeys"
 CERTSDIR="$DIR/../certificates"
 GROUPS_FILENAME="comps.xml"
 UPDATEINFO_FILENAME="updateinfo.xml"
+MODULARITY="true"
 MODULES_FILENAME="modules.yaml"
 FORCE_REBUILD=
 
@@ -21,6 +22,20 @@ fatal()
     printf >&2 "Error: %s\n" "$*"
     exit 1
 }
+
+# Modularity is disabled since RHEL 11.
+# Detect OS with behave code because it implements workarounds.
+want_modularity()
+{
+    PYTHONPATH="$DIR/../.." python3 - <<'EOF'
+from common.lib.os_version import want_modularity
+if want_modularity():
+   print('true')
+else:
+   print('false')
+EOF
+}
+MODULARITY=$(want_modularity)
 
 while [ "$1" != "" ]; do
     case "$1" in
@@ -44,6 +59,11 @@ for path in "$DIR"/*/*.spec; do
     CSUM_FILE="$SPEC_NAME.sha256"
     CSUM_CHANGED=0
     RPMBUILD_OPTS_FILE="$SPEC_NAME.rpmbuild_opts"
+
+    if [[ "$MODULARITY" != "true" && "$SPEC_NAME" =~ '.module' ]]; then
+        echo "Not building modular $path."
+        continue
+    fi
 
     # detect spec change -> force rebuild
     pushd "$SPEC_DIR" > /dev/null


### PR DESCRIPTION
DNF5 will be compiled without modularity support there.

This patch skips building modular packages, adding modulemd.yaml into a repository, and performing modularity tests.

For and requires: https://github.com/rpm-software-management/dnf5/pull/2786

Test results are affected by this <https://github.com/rpm-software-management/dnf5/issues/2797> RPM-6.1/DNF5 regression.

Question1: Do we want to replace the os-release conditions (`@not.with_os=rhel__lt__11`) with a new Behave tag (e.g. `@with_modularity`). Because of dnf/option-hint.feature we would also need a negative form (`@without_modularity`).

Question2: Does `command specific long option used with root dnf command` scenario in dnf/option-hint.feature test explicit list of commands intentionally? Or should be replace the exact list of commands with a glob? That would allow us to shrink the two scenarios into one regardless of modularity support. We could have similar problem in the future when we enable/disable other features differently on different distributions.
