### PR TITLE
Fix upgrading BASE image packages in case the repositories are older than the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,10 @@ COPY ./repos.d/ /etc/yum.repos.d/
 
 # enable dnf5
 RUN set -x && \
-    dnf -y --refresh upgrade; \
+    # If BASE image is released before the repositories are mirrored,
+    # old packages from repositories can be incompatible with already
+    # installed packages. Therefore do distro-sync instead of an upgrade.
+    dnf -y --refresh distro-sync; \
     # Since Fedora 42, `systemd-standalone-sysuser` comes pre-installed.  This package 
     # conflicts with `systemd`, preventing `dnf5daemon-server` from being installed.
     dnf -y install systemd --allowerasing; \


### PR DESCRIPTION
Installing test RPM dependencies sometimes fails like this:

    Step 14/18 : RUN set -x &&     dnf5 -y builddep /opt/ci/dnf-behave-tests/requirements.spec -x libfaketime-0.9.12-1.* &&     pip3 install -r /opt/ci/dnf-behave-tests/requirements.txt
     ---> Running in 2351b6a522f7
    + dnf5 -y builddep /opt/ci/dnf-behave-tests/requirements.spec -x 'libfaketime-0.9.12-1.*'
    Updating and loading repositories:
    Repositories loaded.
    Failed to resolve the transaction:
    Package "coreutils-9.11-3.eln157.x86_64" is already installed.
    Package "dnf5-5.4.3.0^20260625024738295078.main.42.ga2b65057-1.eln157.x86_64" is already installed.
    Package "dnf5-plugins-5.4.3.0^20260625024738295078.main.42.ga2b65057-1.eln157.x86_64" is already installed.
    Package "findutils-1:4.10.0-7.eln154.x86_64" is already installed.
    Package "grep-3.12-3.eln154.x86_64" is already installed.
    Package "gzip-1.14-2.eln154.x86_64" is already installed.
    Package "rpm-6.0.91-2.eln157.x86_64" is already installed.
    Package "sed-4.10-1.eln156.x86_64" is already installed.
    Package "zstd-1.5.7-5.eln154.x86_64" is already installed.
    Problem: cannot install both rpm-6.0.91-1.eln157.x86_64 from eln-baseos and rpm-6.0.91-2.eln157.x86_64 from @System
      - package rpm-libs-6.0.91-1.eln157.x86_64 from eln-baseos requires rpm = 6.0.91-1.eln157, but none of the providers can be installed
      - package rpm-build-6.0.91-2.eln157.x86_64 from eln-appstream requires rpm = 6.0.91-2.eln157, but none of the providers can be installed
      - package python3-rpm-6.0.91-1.eln157.x86_64 from eln-baseos requires rpm-libs(x86-64) = 6.0.91-1.eln157, but none of the providers can be installed
      - conflicting requests

This happpens when rpm preinstaled in BASE image is newer than rpm-libs (and rpm) in the repositories. The cause is that the BASE image is sometimes available before the repositories are mirrored, creating the conflicts.

This fix replaces the initial "dnf5 upgrade" with "dnf5 distro-sync".