### PR TITLE
Sort find command output

### DIFF
--- a/dnf-behave-tests/dnf/keepcache.feature
+++ b/dnf-behave-tests/dnf/keepcache.feature
@@ -61,7 +61,8 @@ Scenario: Reseting keepcache does not remove previously kept packages from cache
         | Action        | Package                                   |
         | install       | labirinto-0:1.0-1.fc29.x86_64             |
         | install       | vagare-0:1.0-1.fc29.x86_64                |
-   When I execute "find -type f -name '*.rpm'" in "{context.dnf.installroot}/var/cache/dnf"
+   When I set LC_ALL to "C.UTF-8"
+    And I execute "find -type f -name '*.rpm' | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
    """
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
@@ -72,7 +73,8 @@ Scenario: Reseting keepcache does not remove previously kept packages from cache
     And Transaction is following
         | Action        | Package                            |
         | install       | dedalo-0:1.0-1.fc29.x86_64         |
-   When I execute "find -type f -name '*.rpm'" in "{context.dnf.installroot}/var/cache/dnf"
+   When I set LC_ALL to "C.UTF-8"
+    And I execute "find -type f -name '*.rpm' | sort" in "{context.dnf.installroot}/var/cache/dnf"
    Then stdout matches line by line
    """
    \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm

--- a/dnf-behave-tests/dnf/plugins-core/reposync.feature
+++ b/dnf-behave-tests/dnf/plugins-core/reposync.feature
@@ -144,7 +144,8 @@ Scenario: Reposync respects includes
   When I execute dnf with args "reposync --download-path={context.dnf.tempdir} --arch=noarch --setopt=includepkgs=abcde"
    Then the exit code is 0
     And stderr contains "abcde-0:2.9.2-1.fc29.noarch"
-   When I execute "find" in "{context.dnf.tempdir}"
+   When I set LC_ALL to "C.UTF-8"
+    And I execute "find | sort" in "{context.dnf.tempdir}"
    Then stdout is
     """
     .


### PR DESCRIPTION
Some tests randomly fail like this:

      Scenario: Reseting keepcache does not remove previously kept packages from cache           # dnf/keepcache.feature:57
	Given I use repository "simple-base"                                                     # dnf/steps/repo.py:185 0.001s
	When I execute dnf with args "--setopt=keepcache=true install labirinto vagare"          # dnf/steps/cmd.py:109 0.195s
	Then the exit code is 0                                                                  # common/output.py:46 0.000s
	And Transaction is following                                                             # dnf/steps/transaction.py:158 0.003s
	  | Action  | Package                       |
	  | install | labirinto-0:1.0-1.fc29.x86_64 |
	  | install | vagare-0:1.0-1.fc29.x86_64    |
	When I execute "find -type f -name '*.rpm'" in "{context.dnf.installroot}/var/cache/dnf" # common/cmd.py:19 0.005s
	Then stdout matches line by line                                                         # common/output.py:105 0.000s
	  """
	  \./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm
	  \./simple-base-[0-9a-f]{16}/packages/vagare-1\.0-1\.fc29\.x86_64\.rpm
	  """
	  ASSERT FAILED: '\./simple-base-[0-9a-f]{16}/packages/labirinto-1\.0-1\.fc29\.x86_64\.rpm' regexp does not match line: './simple-base-ccf46adfeeda5366/packages/vagare-1.0-1.fc29.x86_64.rpm'
    [...]
    CAPTURED STDOUT: scenario

    Last Command: find -type f -name '*.rpm'

    Last Command stdout:
    ./simple-base-ccf46adfeeda5366/packages/vagare-1.0-1.fc29.x86_64.rpm
    ./simple-base-ccf46adfeeda5366/packages/labirinto-1.0-1.fc29.x86_64.rpm

The cause is that find returns files in a directory order which is generally nondeterministic.

This fix sorts the find command output where we later match more than a line.