### PR TITLE
Set PYTHONUTF8=0 when testing non-UTF-8 characters with corresponding…

### DIFF
--- a/dnf-behave-tests/dnf/encoding.feature
+++ b/dnf-behave-tests/dnf/encoding.feature
@@ -88,6 +88,7 @@ Scenario: non-UTF-8 character in an option when using corresponding locale
         """
         """
     And I set LC_ALL to "en_US.ISO-8859-1"
+    And I set environment variable "PYTHONUTF8" to "0"
    When I execute dnf with args "install dummy --config={context.dnf.installroot}/{context.invalid_utf8_char}"
    Then the exit code is 0
     And Transaction is following


### PR DESCRIPTION
… locale

This is due to https://peps.python.org/pep-0686/ which made the UTF-8 mode default.

Resolves: https://github.com/rpm-software-management/ci-dnf-stack/issues/1893