### PR TITLE
dnf4: Adapt to RPM 6.1 indentation

### DIFF
--- a/dnf-behave-tests/dnf/stick-to-vendor.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor.feature
@@ -14,7 +14,7 @@ Background:
 
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 @dnf5
 @bz1788371
@@ -28,7 +28,7 @@ Scenario: Upgrade sticks to vendor
        | upgrade | vendor-1.1-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 @dnf5
 @bz1788371
@@ -39,7 +39,7 @@ Scenario: No upgrade if same vendor not found
    And transaction is empty
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 # @dnf5
 # TODO(nsella) different exit code


### PR DESCRIPTION
After upgrading RPM to 6.1, dnf/stick-to-vendor.feature failed:

    Given I successfully execute rpm with args "-qi vendor"   # dnf/steps/cmd.py:217 0.017s
    Then the exit code is 0                                   # common/output.py:57 0.000s
    And stdout contains "Vendor      : First Vendor"          # dnf/steps/cmd.py:237 0.000s
      Assertion Failed: Stdout doesn't contain: Vendor      : First Vendor
      Captured stdout:
    [...]
      Vendor       : First Vendor

The cause is RPM 6.1 which changed an indentation in "rpm -qi" output: Before:

    Architecture: x86_64
    Vendor      : Fedora Project

After:

    Architecture : x86_64
    Vendor       : Fedora Project

This fix accepts any number of spaces beween Vendor and the colon.