### PR TITLE
dnf5: Adapt to RPM 6.1 indentation

### DIFF
--- a/dnf-behave-tests/dnf/stick-to-vendor-default.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor-default.feature
@@ -12,7 +12,7 @@ Background:
 
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 
 Scenario: Upgrade sticks to vendor by default
@@ -25,7 +25,7 @@ Scenario: Upgrade sticks to vendor by default
        | upgrade | vendor-1.1-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 
 Scenario: No upgrade if same vendor not found by default
@@ -35,7 +35,7 @@ Scenario: No upgrade if same vendor not found by default
    And Transaction is empty
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 
 Scenario: Hint shown when vendor change blocked by default
@@ -60,4 +60,4 @@ Scenario: Override default with --setopt=allow_vendor_change=true
        | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : Second Vendor"
+   And stdout contains "Vendor *: Second Vendor"

--- a/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
@@ -16,7 +16,7 @@ Background:
 
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor
@@ -40,7 +40,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
        | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : Second Vendor"
+   And stdout contains "Vendor *: Second Vendor"
 
 
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (conf file in /usr)
@@ -64,7 +64,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
        | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : Second Vendor"
+   And stdout contains "Vendor *: Second Vendor"
 
 
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (conf in /etc overrides /usr)
@@ -98,7 +98,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
        | upgrade | vendor-1.3-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : Third Vendor"
+   And stdout contains "Vendor *: Third Vendor"
 
 
 Scenario: Upgrade with vendor policy - equivalent vendors (mutual change allowed)
@@ -122,7 +122,7 @@ Scenario: Upgrade with vendor policy - equivalent vendors (mutual change allowed
        | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : Second Vendor"
+   And stdout contains "Vendor *: Second Vendor"
 
 
 Scenario: Upgrade with vendor policy - change for "First vendor" is not allowed
@@ -146,7 +146,7 @@ Scenario: Upgrade with vendor policy - change for "First vendor" is not allowed
        | upgrade | vendor-1.1-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 
 Scenario: Upgrade with vendor policy - glob pattern matching
@@ -171,7 +171,7 @@ Scenario: Upgrade with vendor policy - glob pattern matching
        | upgrade | vendor-1.3-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : Third Vendor"
+   And stdout contains "Vendor *: Third Vendor"
 
 
 Scenario: Upgrade with vendor policy - case insensitive matching and starts with
@@ -197,7 +197,7 @@ Scenario: Upgrade with vendor policy - case insensitive matching and starts with
        | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : Second Vendor"
+   And stdout contains "Vendor *: Second Vendor"
 
 
 Scenario: Upgrade with vendor policy - using exclude to prevent specific vendor
@@ -225,4 +225,4 @@ Scenario: Upgrade with vendor policy - using exclude to prevent specific vendor
        | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : Second Vendor"
+   And stdout contains "Vendor *: Second Vendor"

--- a/dnf-behave-tests/dnf/stick-to-vendor.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor.feature
@@ -14,7 +14,7 @@ Background:
 
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 @bz1788371
 Scenario: Upgrade sticks to vendor
@@ -27,7 +27,7 @@ Scenario: Upgrade sticks to vendor
        | upgrade | vendor-1.1-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 @bz1788371
 Scenario: No upgrade if same vendor not found
@@ -37,7 +37,7 @@ Scenario: No upgrade if same vendor not found
    And Transaction is empty
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor      : First Vendor"
+   And stdout contains "Vendor *: First Vendor"
 
 
 @bz1788371


### PR DESCRIPTION
After upgrading RPM to 6.1, various tests, like
dnf/stick-to-vendor-default.feature, failed:

    Given I successfully execute rpm with args "-qi vendor"   # dnf/steps/cmd.py:197 0.022s
    Then the exit code is 0                                   # common/output.py:46 0.000s
    And stdout contains "Vendor      : First Vendor"          # dnf/steps/cmd.py:217 0.000s
      ASSERT FAILED: Stdout doesn't contain: Vendor      : First Vendor
    [...]
    CAPTURED STDOUT: scenario
    [...]
    Vendor       : First Vendor

The cause is RPM 6.1 which changed an indentation in "rpm -qi" output: Before:

    Architecture: x86_64
    Vendor      : Fedora Project

After:

    Architecture : x86_64
    Vendor       : Fedora Project

This fix accepts any number of spaces beween Vendor and the colon.