### PR TITLE
[rhel-9.9] Expect clean_command.lock in cachefiles

### DIFF
--- a/dnf-behave-tests/dnf/clean-cachefiles.feature
+++ b/dnf-behave-tests/dnf/clean-cachefiles.feature
@@ -15,6 +15,7 @@ Background: Fill the cache
    Then stdout matches line by line
    """
    \.
+   \./clean_command.lock
    \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages
@@ -34,6 +35,7 @@ Scenario: Cleanup of the whole cache (dnf clean all)
    Then stdout matches line by line
    """
    \.
+   \./clean_command.lock
    \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages
@@ -47,6 +49,7 @@ Scenario: Cached metadata cleanup (dnf clean metadata)
    Then stdout matches line by line
    """
    \.
+   \./clean_command.lock
    \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages
@@ -61,6 +64,7 @@ Scenario: Cached packages cleanup (dnf clean packages)
    Then stdout matches line by line
    """
    \.
+   \./clean_command.lock
    \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages
@@ -79,6 +83,7 @@ Scenario: Database cached cleanup (dnf clean dbcache)
    Then stdout matches line by line
    """
    \.
+   \./clean_command.lock
    \./expired_repos\.json
    \./simple-base-[0-9a-f]{16}
    \./simple-base-[0-9a-f]{16}/packages


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf/pull/2341

Backports: https://github.com/rpm-software-management/ci-dnf-stack/pull/1911