### PR TITLE
manifest: Test that download requires exact checksums

### DIFF
--- a/dnf-behave-tests/dnf/plugins-core/manifest.feature
+++ b/dnf-behave-tests/dnf/plugins-core/manifest.feature
@@ -640,6 +640,29 @@ Scenario: Download multiarch packages from per-arch manifests
         | {context.dnf.tempdir}/packages.manifest.ppc64/waldo-1.0-1.noarch.rpm        | file://{context.dnf.fixturesdir}/repos/manifest-multiarch/noarch/waldo-1.0-1.noarch.rpm         |
 
 
+Scenario: Download packages from the manifest when a checksum is incorrect
+  Given I create and substitute file "/{context.dnf.tempdir}/packages.manifest.yaml" with
+    """
+    document: rpm-package-manifest
+    version: 0.2.2
+    data:
+      repositories:
+        - id: dnf-ci-fedora
+          baseurl: file://{context.dnf.fixturesdir}/repos/dnf-ci-fedora
+      packages:
+        x86_64:
+          - name: http-parser
+            repo_id: dnf-ci-fedora
+            location: x86_64/http-parser-2.4.0-1.fc29.x86_64.rpm
+            checksum: sha256:1111111111111111111111111111111111111111111111111111111111111111
+            size: 1
+            evr: 2.4.0-1.fc29
+    """
+   When I execute dnf with args "manifest download"
+   Then the exit code is 1
+    And stderr contains "No package http-parser-2.4.0-1.fc29.x86_64 with checksum 1111111111111111111111111111111111111111111111111111111111111111 available."
+
+
 Scenario: Install packages from the manifest
   Given I successfully execute dnf with args "manifest new abcde http-parser"
    When I execute dnf with args "manifest install"


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf5/pull/2791