### PR TITLE
Add tests for vendor change restriction hints

### DIFF
--- a/dnf-behave-tests/dnf/stick-to-vendor-default.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor-default.feature
@@ -46,7 +46,10 @@ Scenario: Hint shown when vendor change blocked by default
    When I execute dnf with args "downgrade vendor"
    Then the exit code is 1
    And Transaction is empty
-   And stdout is empty
+   And stdout contains lines
+       """
+       Skipping 1 package due to vendor change restriction: "First Vendor" -> "Second Vendor".
+       """
    And stderr contains "--allow-vendor-change to allow changing package vendors"
 
 

--- a/dnf-behave-tests/dnf/stick-to-vendor.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor.feature
@@ -49,7 +49,10 @@ Scenario: Downgrade is unable to resolve transaction
    When I execute dnf with args "downgrade vendor"
    Then the exit code is 1
    And Transaction is empty
-   And stdout is empty
+   And stdout contains lines
+       """
+       Skipping 1 package due to vendor change restriction: "First Vendor" -> "Second Vendor".
+       """
    And stderr is
        """
        <REPOSYNC>
@@ -59,6 +62,6 @@ Scenario: Downgrade is unable to resolve transaction
          - cannot install both vendor-1.0-1.x86_64 from dnf-ci-vendor-2 and vendor-1.1-1.x86_64 from dnf-ci-vendor-1-updates
          - conflicting requests
        You can try to add to command line:
-         --allow-vendor-change to allow changing package vendors
          --skip-broken to skip uninstallable packages
+         --allow-vendor-change to allow changing package vendors
        """

--- a/dnf-behave-tests/dnf/vendor-change-hints-installonly.feature
+++ b/dnf-behave-tests/dnf/vendor-change-hints-installonly.feature
@@ -1,0 +1,74 @@
+Feature: Vendor change restriction applies to installonly packages
+
+Background:
+  Given I use repository "vendor-hints"
+    And I configure dnf with
+        | key                 | value |
+        | allow_vendor_change | False |
+        | installonlypkgs     | kernel |
+
+
+Scenario: Both regular and installonly packages from different vendor are reported as skipped
+  # During dnf upgrade the vendor change callback fires for both wrench-2.0 (a
+  # regular package) and kernel-2.0 (an installonly package) from Vendor B.
+  # Both are blocked and reported together, exercising the plural output form.
+  Given I successfully execute dnf with args "install wrench kernel"
+    And I use repository "vendor-hints-updates"
+   When I execute dnf with args "upgrade"
+   Then the exit code is 0
+    And Transaction is empty
+    And stdout contains lines
+        """
+        Skipping 2 packages due to vendor change restriction: "Vendor A" -> "Vendor B".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: Installing a specific installonly version from a different vendor shows no skipping section
+  # Installing a specific package version (dnf install kernel-2.0) installs it
+  # alongside the existing version without replacing it. Because no replacement
+  # occurs, the vendor change callback does not fire and the package installs
+  # normally regardless of the vendor.
+  Given I successfully execute dnf with args "install kernel"
+    And I use repository "vendor-hints-updates"
+   When I execute dnf with args "install kernel-2.0"
+   Then the exit code is 0
+    And Transaction is following
+        | Action    | Package             |
+        | install   | kernel-2.0-1.noarch |
+        | unchanged | kernel-1.0-1.noarch |
+    And stdout does not contain "Skipping"
+
+
+Scenario: Skipping section shown when installonly upgrade is blocked by vendor change
+  # Unlike the general upgrade sweep, "dnf upgrade kernel" explicitly requests an
+  # upgrade and the vendor change callback fires. The transaction is empty and
+  # the skipping section appears.
+  Given I successfully execute dnf with args "install kernel"
+    And I use repository "vendor-hints-installonly-upgrade-blocked"
+   When I execute dnf with args "upgrade kernel"
+   Then the exit code is 0
+    And Transaction is empty
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor A" -> "Vendor B".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: Skipping section shown when installonly versions from different vendors are present
+  # kernel-1.0 (Vendor A) is installed. kernel-2.0 (Vendor B) is then installed
+  # alongside it (no replacement, so vendor change does not apply).
+  # With both versions present, upgrading to kernel-3.0 (Vendor C) triggers the
+  # vendor change callback for each installed version. The candidate is blocked and
+  # reported with one of the installed vendors in the transition.
+  Given I successfully execute dnf with args "install kernel"
+    And I use repository "vendor-hints-updates"
+    And I successfully execute dnf with args "install kernel-2.0"
+    And I use repository "vendor-hints-installonly-multi-vendor"
+   When I execute dnf with args "upgrade kernel"
+   Then the exit code is 0
+    And Transaction is empty
+    And stdout contains "Skipping 1 package due to vendor change restriction"
+    And stdout contains "-> \"Vendor C\"."
+    And stderr contains "--allow-vendor-change to allow changing package vendors"

--- a/dnf-behave-tests/dnf/vendor-change-hints.feature
+++ b/dnf-behave-tests/dnf/vendor-change-hints.feature
@@ -1,0 +1,154 @@
+Feature: Vendor change restriction hints when allow_vendor_change=false
+
+Background:
+  Given I use repository "vendor-hints"
+    And I configure dnf with
+        | key                 | value |
+        | allow_vendor_change | False |
+
+
+Scenario: No skipping section when allow_vendor_change is enabled via command line
+  # Verifies that --allow-vendor-change (the hint shown to the user)
+  # allows wrench to upgrade to the Vendor B version without a skipping section.
+  Given I successfully execute dnf with args "install hammer wrench"
+    And I use repository "vendor-hints-updates"
+   When I execute dnf with args "upgrade --allow-vendor-change"
+   Then the exit code is 0
+    And Transaction is following
+        | Action  | Package             |
+        | upgrade | hammer-2.0-1.noarch |
+        | upgrade | wrench-2.0-1.noarch |
+    And stdout does not contain "Skipping"
+
+
+Scenario: Skipping section shown alongside a successful partial upgrade
+  # hammer has a same-vendor update (Vendor A -> Vendor A) and upgrades normally.
+  # wrench has a different-vendor update (Vendor A -> Vendor B) and is skipped.
+  Given I successfully execute dnf with args "install hammer wrench"
+    And I use repository "vendor-hints-updates"
+   When I execute dnf with args "upgrade"
+   Then the exit code is 0
+    And Transaction is following
+        | Action  | Package              |
+        | upgrade | hammer-2.0-1.noarch  |
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor A" -> "Vendor B".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: Skipping section and hint shown when all upgrades are blocked (nothing to do)
+  # Only a different-vendor update for wrench is available; no same-vendor updates exist.
+  # The transaction is empty but the skipping section and the hint still appear.
+  Given I successfully execute dnf with args "install wrench"
+    And I use repository "vendor-hints-updates"
+   When I execute dnf with args "upgrade wrench"
+   Then the exit code is 0
+    And Transaction is empty
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor A" -> "Vendor B".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: Skipping section shown when reinstall is blocked by vendor change
+  # chisel-1.0-1.noarch is installed from Vendor A. The only available copy in the
+  # enabled repo is from Vendor B (same NEVRA, different vendor). The reinstall
+  # fails with a solver error, but the skipping section still appears.
+  # vendor-hints is dropped so the solver cannot fall back to the same-vendor copy.
+  Given I successfully execute dnf with args "install chisel"
+    And I drop repository "vendor-hints"
+    And I use repository "vendor-hints-reinstall"
+   When I execute dnf with args "reinstall chisel"
+   Then the exit code is 1
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor A" -> "Vendor B".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: Skipping section shown when downgrade is blocked by vendor change
+  # wrench-2.0 (Vendor B) is installed as a new package (no vendor check for
+  # first-time installs). The base repo provides wrench-1.0 (Vendor A) as the
+  # only downgrade candidate. The downgrade is blocked due to vendor change.
+  Given I use repository "vendor-hints-updates"
+    And I successfully execute dnf with args "install wrench-2.0"
+   When I execute dnf with args "downgrade wrench"
+   Then the exit code is 1
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor B" -> "Vendor A".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: Skipping section shown when install-via-obsolete is blocked by vendor change
+  # hammer-1.0 (Vendor A) is installed. socket-1.0 (Vendor B) obsoletes hammer, so
+  # installing socket would replace hammer with a vendor change. The install fails
+  # with a solver error but the skipping section appears for socket.
+  # This exercises the SOLVER_TRANSACTION_OBSOLETES path in the detection code.
+  Given I successfully execute dnf with args "install hammer"
+    And I use repository "vendor-hints-obsolete"
+   When I execute dnf with args "install socket"
+   Then the exit code is 1
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor A" -> "Vendor B".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: distro-sync shows skipping section when vendor change is blocked
+  # Same code path as upgrade but exercising the distro-sync command.
+  Given I successfully execute dnf with args "install hammer wrench"
+    And I use repository "vendor-hints-updates"
+   When I execute dnf with args "distro-sync"
+   Then the exit code is 0
+    And Transaction is following
+        | Action  | Package             |
+        | upgrade | hammer-2.0-1.noarch |
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor A" -> "Vendor B".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: Multiple vendor transitions shown as separate lines in the skipping section
+  # wrench-2.0 (Vendor B) and nail-2.0 (Vendor C) are both blocked, producing two
+  # distinct vendor transitions in the output.
+  Given I successfully execute dnf with args "install hammer wrench nail"
+    And I use repository "vendor-hints-updates"
+   When I execute dnf with args "upgrade"
+   Then the exit code is 0
+    And Transaction is following
+        | Action  | Package             |
+        | upgrade | hammer-2.0-1.noarch |
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor A" -> "Vendor B".
+        """
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "Vendor A" -> "Vendor C".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"
+
+
+Scenario: Skipping section renders "(none)" for packages with no vendor metadata
+  # bolt-1.0 is installed with no Vendor field. bolt-2.0 (Vendor B) is the only
+  # available update. The vendor change from "(none)" to "Vendor B" is blocked and
+  # reported with the "(none)" placeholder.
+  Given I successfully execute dnf with args "install bolt"
+    And I use repository "vendor-hints-updates"
+   When I execute dnf with args "upgrade bolt"
+   Then the exit code is 0
+    And Transaction is empty
+    And stdout contains lines
+        """
+        Skipping 1 package due to vendor change restriction: "(none)" -> "Vendor B".
+        """
+    And stderr contains "--allow-vendor-change to allow changing package vendors"

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-installonly-multi-vendor/kernel-3.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-installonly-multi-vendor/kernel-3.0.spec
@@ -1,0 +1,16 @@
+Name:          kernel
+Version:       3.0
+Release:       1
+Summary:       Vendor change hints: kernel 3.0 from Vendor C
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor C
+Packager:      Vendor C
+
+%description
+Third kernel version from a third vendor. Used to test vendor change detection
+when multiple installonly versions from different vendors are already present.
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-installonly-upgrade-blocked/kernel-2.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-installonly-upgrade-blocked/kernel-2.0.spec
@@ -1,0 +1,15 @@
+Name:          kernel
+Version:       2.0
+Release:       1
+Summary:       Vendor change hints: kernel 2.0 from Vendor B
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor B
+Packager:      Vendor B
+
+%description
+Vendor change hints: kernel-2.0 from Vendor B (no wrench in this repo)
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-obsolete/socket-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-obsolete/socket-1.0.spec
@@ -1,0 +1,15 @@
+Name:          socket
+Version:       1.0
+Release:       1
+Summary:       Vendor change hints: socket from Vendor B, obsoletes hammer
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor B
+Packager:      Vendor B
+Obsoletes:     hammer
+%description
+Vendor change hints: socket from Vendor B, obsoletes hammer
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-reinstall/chisel-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-reinstall/chisel-1.0.spec
@@ -1,0 +1,15 @@
+Name:          chisel
+Version:       1.0
+Release:       1
+Summary:       Vendor change hints: chisel 1.0 from Vendor B
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor B
+Packager:      Vendor B
+
+%description
+Vendor change hints: chisel-1.0 same NEVRA different vendor (reinstall target)
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-updates/bolt-2.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-updates/bolt-2.0.spec
@@ -1,0 +1,15 @@
+Name:          bolt
+Version:       2.0
+Release:       1
+Summary:       Vendor change hints: bolt update from Vendor B
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor B
+Packager:      Vendor B
+
+%description
+Update for bolt with a vendor, producing a "(none)" -> "Vendor B" transition.
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-updates/hammer-2.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-updates/hammer-2.0.spec
@@ -1,0 +1,15 @@
+Name:          hammer
+Version:       2.0
+Release:       1
+Summary:       Vendor change hints: hammer 2.0 from Vendor A
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor A
+Packager:      Vendor A
+
+%description
+Vendor change hints: hammer-2.0 same-vendor upgrade
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-updates/kernel-2.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-updates/kernel-2.0.spec
@@ -1,0 +1,15 @@
+Name:          kernel
+Version:       2.0
+Release:       1
+Summary:       Vendor change hints: kernel 2.0 from Vendor B
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor B
+Packager:      Vendor B
+
+%description
+Vendor change hints installonly: kernel v2 from Vendor B
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-updates/nail-2.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-updates/nail-2.0.spec
@@ -1,0 +1,15 @@
+Name:          nail
+Version:       2.0
+Release:       1
+Summary:       Vendor change hints: nail 2.0 from Vendor C
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor C
+Packager:      Vendor C
+
+%description
+Update for nail from a third vendor, producing a second vendor transition alongside wrench.
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints-updates/wrench-2.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints-updates/wrench-2.0.spec
@@ -1,0 +1,15 @@
+Name:          wrench
+Version:       2.0
+Release:       1
+Summary:       Vendor change hints: wrench 2.0 from Vendor B
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor B
+Packager:      Vendor B
+
+%description
+Vendor change hints: wrench-2.0 different-vendor upgrade
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints/bolt-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints/bolt-1.0.spec
@@ -1,0 +1,13 @@
+Name:          bolt
+Version:       1.0
+Release:       1
+Summary:       Vendor change hints: bolt with no vendor metadata
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+
+%description
+Package with no Vendor field; produces "(none)" in the skipping section.
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints/chisel-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints/chisel-1.0.spec
@@ -1,0 +1,15 @@
+Name:          chisel
+Version:       1.0
+Release:       1
+Summary:       Vendor change hints: chisel from Vendor A
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor A
+Packager:      Vendor A
+
+%description
+Vendor change hints: chisel from Vendor A
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints/hammer-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints/hammer-1.0.spec
@@ -1,0 +1,15 @@
+Name:          hammer
+Version:       1.0
+Release:       1
+Summary:       Vendor change hints: hammer from Vendor A
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor A
+Packager:      Vendor A
+
+%description
+Vendor change hints: hammer from Vendor A
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints/kernel-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints/kernel-1.0.spec
@@ -1,0 +1,15 @@
+Name:          kernel
+Version:       1.0
+Release:       1
+Summary:       Vendor change hints: kernel 1.0 from Vendor A
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor A
+Packager:      Vendor A
+
+%description
+Vendor change hints installonly: kernel v1 from Vendor A
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints/nail-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints/nail-1.0.spec
@@ -1,0 +1,15 @@
+Name:          nail
+Version:       1.0
+Release:       1
+Summary:       Vendor change hints: nail from Vendor A
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor A
+Packager:      Vendor A
+
+%description
+Base package for multiple-vendor-transitions test.
+%files
+%changelog

--- a/dnf-behave-tests/fixtures/specs/vendor-hints/wrench-1.0.spec
+++ b/dnf-behave-tests/fixtures/specs/vendor-hints/wrench-1.0.spec
@@ -1,0 +1,15 @@
+Name:          wrench
+Version:       1.0
+Release:       1
+Summary:       Vendor change hints: wrench from Vendor A
+BuildArch:     noarch
+
+License:       Public Domain
+URL:           None
+Vendor:        Vendor A
+Packager:      Vendor A
+
+%description
+Vendor change hints: wrench from Vendor A
+%files
+%changelog


### PR DESCRIPTION
When allow_vendor_change=false, dnf5 now detects packages silently skipped due to vendor change policy and displays a "Skipping N package(s) due to vendor change restriction" section with a hint pointing to --setopt=allow_vendor_change=true.

Requires: https://github.com/rpm-software-management/dnf5/pull/2819