### PR TITLE
add test for RHEL-80156

### DIFF
--- a/dnf-behave-tests/dnf/module/updateinfo.feature
+++ b/dnf-behave-tests/dnf/module/updateinfo.feature
@@ -133,3 +133,40 @@ Given I use repository "dnf-ci-multicontext-modular-advisory"
       <REPOSYNC>
 
       """
+
+
+@RHEL-80156
+Scenario: updateinfo list should not show advisories for non-modular packages when modular version is installed
+Given I use repository "nginx-modular-base"
+ When I execute dnf with args "module enable nginx:1.22"
+ Then the exit code is 0
+  And modules state is following
+      | Module     | State     | Stream    | Profiles  |
+      | nginx      | enabled   | 1.22      |           |
+ When I execute dnf with args "module install nginx/default"
+ Then the exit code is 0
+  And Transaction contains
+      | Action                    | Package                                                  |
+      | install-group             | nginx-1:1.22.1-1.module_el9+5000+aa9aadc5.x86_64         |
+      | install-group             | nginx-core-1:1.22.1-1.module_el9+5000+aa9aadc5.x86_64    |
+      | install-group             | nginx-filesystem-1:1.22.1-1.module_el9+5000+aa9aadc5.noarch |
+      | module-profile-install    | nginx/default                                            |
+Given I use repository "nginx-nonmodular"
+ When I execute dnf with args "updateinfo list"
+ Then the exit code is 0
+  And stdout is
+      """
+      <REPOSYNC>
+      """
+ When I execute dnf with args "updateinfo list available"
+ Then the exit code is 0
+  And stdout is
+      """
+      <REPOSYNC>
+      """
+ When I execute dnf with args "updateinfo list updates"
+ Then the exit code is 0
+  And stdout is
+      """
+      <REPOSYNC>
+      """

--- a/dnf-behave-tests/fixtures/specs/nginx-modular-base/modules.yaml
+++ b/dnf-behave-tests/fixtures/specs/nginx-modular-base/modules.yaml
@@ -1,0 +1,50 @@
+---
+document: modulemd
+version: 2
+data:
+  name: nginx
+  stream: "1.22"
+  version: 20230101000000
+  context: aa9aadc5
+  arch: x86_64
+  summary: Nginx webserver
+  description: >-
+    Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and
+    IMAP protocols, with a strong focus on high concurrency, performance and low
+    memory usage.
+  license:
+    module:
+    - MIT
+    content:
+    - BSD
+  dependencies:
+  - buildrequires:
+      platform: [f29]
+    requires:
+      platform: [f29]
+  profiles:
+    default:
+      rpms:
+      - nginx
+      - nginx-core
+      - nginx-filesystem
+    minimal:
+      rpms:
+      - nginx-core
+  api:
+    rpms:
+    - nginx
+    - nginx-core
+    - nginx-filesystem
+  components:
+    rpms:
+      nginx:
+        rationale: Main nginx package
+        ref: 1.22
+  artifacts:
+    rpms:
+    - nginx-1:1.22.1-1.module_el9+5000+aa9aadc5.x86_64
+    - nginx-1:1.22.1-1.module_el9+5000+aa9aadc5.src
+    - nginx-core-1:1.22.1-1.module_el9+5000+aa9aadc5.x86_64
+    - nginx-filesystem-1:1.22.1-1.module_el9+5000+aa9aadc5.noarch
+...

--- a/dnf-behave-tests/fixtures/specs/nginx-modular-base/nginx-1.22.1-1.spec
+++ b/dnf-behave-tests/fixtures/specs/nginx-modular-base/nginx-1.22.1-1.spec
@@ -1,0 +1,41 @@
+Name:           nginx
+Epoch:          1
+Version:        1.22.1
+Release:        1.module_el9+5000+aa9aadc5
+Summary:        A high performance web server and reverse proxy server (modular)
+
+License:        BSD
+URL:            http://nginx.org/
+
+
+%description
+Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and
+IMAP protocols, with a strong focus on high concurrency, performance and low
+memory usage. This is the modular version from stream 1.22.
+
+%package filesystem
+Summary:        The basic directory layout for the Nginx server
+BuildArch:      noarch
+
+%description filesystem
+The nginx-filesystem package contains the basic directory layout
+for the Nginx server including the correct permissions for the
+directories.
+
+%package core
+Summary:        nginx minimal core
+
+%description core
+nginx minimal core
+
+%prep
+
+%build
+
+%files
+
+%files filesystem
+
+%files core
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/nginx-nonmodular/nginx-1.20.1-20.spec
+++ b/dnf-behave-tests/fixtures/specs/nginx-nonmodular/nginx-1.20.1-20.spec
@@ -1,0 +1,41 @@
+Name:           nginx
+Epoch:          2
+Version:        1.20.1
+Release:        20.el9
+Summary:        A high performance web server and reverse proxy server (non-modular)
+
+License:        BSD
+URL:            http://nginx.org/
+
+
+%description
+Nginx is a web server and a reverse proxy server for HTTP, SMTP, POP3 and
+IMAP protocols, with a strong focus on high concurrency, performance and low
+memory usage. This is the non-modular version with epoch 2.
+
+%package filesystem
+Summary:        The basic directory layout for the Nginx server
+BuildArch:      noarch
+
+%description filesystem
+The nginx-filesystem package contains the basic directory layout
+for the Nginx server including the correct permissions for the
+directories.
+
+%package core
+Summary:        nginx minimal core
+
+%description core
+nginx minimal core
+
+%prep
+
+%build
+
+%files
+
+%files filesystem
+
+%files core
+
+%changelog

--- a/dnf-behave-tests/fixtures/specs/nginx-nonmodular/updateinfo.xml
+++ b/dnf-behave-tests/fixtures/specs/nginx-nonmodular/updateinfo.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updates>
+  <update from="secresponseteam@redhat.com" status="final" type="bugfix" version="1">
+    <id>RHBA-2024:9291</id>
+    <title>nginx bugfix update</title>
+    <issued date="2024-12-10 00:00:00"/>
+    <updated date="2024-12-10 00:00:00"/>
+    <severity>Moderate</severity>
+    <summary>Bug fix update for nginx</summary>
+    <description>This update fixes several bugs in the nginx package.</description>
+    <references>
+      <reference href="https://bugzilla.redhat.com/show_bug.cgi?id=123456" id="123456" type="bugzilla" title="Bug 123456"/>
+    </references>
+    <pkglist>
+      <collection short="nginx non-modular collection">
+        <name>nginx non-modular component</name>
+        <package name="nginx" version="1.20.1" release="20.el9" epoch="2" arch="x86_64">
+          <filename>nginx-1.20.1-20.el9.x86_64.rpm</filename>
+        </package>
+        <package name="nginx-core" version="1.20.1" release="20.el9" epoch="2" arch="x86_64">
+          <filename>nginx-core-1.20.1-20.el9.x86_64.rpm</filename>
+        </package>
+        <package name="nginx-filesystem" version="1.20.1" release="20.el9" epoch="2" arch="noarch">
+          <filename>nginx-filesystem-1.20.1-20.el9.noarch.rpm</filename>
+        </package>
+      </collection>
+    </pkglist>
+  </update>
+</updates>


### PR DESCRIPTION
Add new scenario: updateinfo list should not show advisories for non-modular packages when modular version is installed

Assisted-by: Claude Sonnet 4.5