### PR TITLE
Do not set module_platform_id DNF options if modularity is disabled

### DIFF
--- a/dnf-behave-tests/dnf/environment.py
+++ b/dnf-behave-tests/dnf/environment.py
@@ -22,7 +22,7 @@ from behave.tag_matcher import ActiveTagMatcher
 from steps.lib.config import write_config
 from common.lib.cmd import print_last_command, run_in_context
 from common.lib.file import ensure_directory_exists
-from common.lib.os_version import detect_os_version
+from common.lib.os_version import detect_os_version, want_modularity
 from common.lib.tag_matcher import VersionedActiveTagMatcher
 
 
@@ -80,7 +80,8 @@ class DNFContext(object):
 
         self.dnf_command = userdata.get("dnf_command", DEFAULT_DNF_COMMAND)
         self.releasever = userdata.get("releasever", DEFAULT_RELEASEVER)
-        self.module_platform_id = userdata.get("module_platform_id", DEFAULT_PLATFORM_ID)
+        if want_modularity():
+            self.module_platform_id = userdata.get("module_platform_id", DEFAULT_PLATFORM_ID)
         self.fixturesdir = consts.FIXTURES_DIR
         self.disable_plugins = True
         self.disable_repos_option = "--disablerepo='*'"

--- a/dnf-behave-tests/dnf/list.feature
+++ b/dnf-behave-tests/dnf/list.feature
@@ -376,6 +376,19 @@ Scenario: dnf list obsoletes setup (when setup is not obsoleted)
       """
 
 
+# Modularity is disabled since RHEL 11
+@use.with_os=rhel__ge__11
+@1550560
+Scenario: dnf list available pkgs with long names piped to grep
+Given I use repository "dnf-ci-thirdparty"
+ When I execute dnf with args "clean all"
+ When I execute "eval {context.dnf.dnf_command} -y --releasever={context.dnf.releasever} --installroot={context.dnf.installroot} --disableplugin='*' list --available | grep 1" in "{context.dnf.installroot}"
+ Then the exit code is 0
+ Then stdout contains "forTestingPurposesWeEvenHaveReallyLongVersions.x86_64\s+1435347658326856238756823658aaaa-1\s+dnf-ci-thirdparty"
+
+
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @1550560
 Scenario: dnf list available pkgs with long names piped to grep
 Given I use repository "dnf-ci-thirdparty"

--- a/dnf-behave-tests/dnf/transaction-output.feature
+++ b/dnf-behave-tests/dnf/transaction-output.feature
@@ -1,6 +1,22 @@
 Feature: Test transasction output
 
+# Modularity is disabled since RHEL 11
+@use.with_os=rhel__ge__11
+@bz1794856
+Scenario: Check whitespace between columns with long values in transaction table
+Given I use repository "dnf-ci-thirdparty"
+ When I execute dnf with args "clean all"
+ # Piping to grep is forcing DNF to print into non standard terminal which is by default limited to 80 columns.
+  And I execute "eval dnf5 -y --releasever={context.dnf.releasever} --installroot={context.dnf.installroot} --disableplugin='*' install forTestingPurposesWeEvenHaveReallyLongVersions | grep -v xxxxxx" in "{context.dnf.installroot}"
+ Then the exit code is 0
+  And Transaction is following
+      | Action        | Package                                                                                    |
+      | install       | forTestingPurposesWeEvenHaveReallyLongVersions-0:1435347658326856238756823658aaaa-1.x86_64 |
+  And stdout contains "forTestingPurposesWeEvenHaveReallyLongVersions\s+x86_64\s+0:1435347658326856238756823658aaaa-1\s+dnf-ci-thirdparty\s+.*"
 
+
+# Modularity is disabled since RHEL 11
+@not.with_os=rhel__ge__11
 @bz1794856
 Scenario: Check whitespace between columns with long values in transaction table
 Given I use repository "dnf-ci-thirdparty"

--- a/dnf-behave-tests/draw-repos-graph
+++ b/dnf-behave-tests/draw-repos-graph
@@ -6,7 +6,13 @@ repos=$(echo $repos | sed "s/\ /\ --repo\ /g")
 # prepend --repo for the first repo, which does not have a space to substitute
 repos=$(echo "--repo $repos")
 
-options=" -y --setopt=reposdir=./fixtures/repos.d --releasever=29 --setopt=module_platform_id=platform:f29"
+module_plaform_options="--setopt=module_platform_id=platform:f29"
+if ! dnf ${module_plaform_options} --version >/dev/null 2>/dev/null; then
+    # Modularity not supported
+    module_plaform_options=""
+fi
+
+options=" -y --setopt=reposdir=./fixtures/repos.d --releasever=29 ${module_plaform_options}"
 
 DNF0=$(pwd)/fixtures dnf $options repograph $repos > out.dot
 


### PR DESCRIPTION
This is especialy needed when module_platform_id option is not supported and setting it triggers an error in every test case:

    Last Command: dnf5 -y --installroot=/tmp/dnf_ci_installroot_9nq5djho --releasever=29 --setopt=module_platform_id=platform:f29 --disable-plugin='*' --setopt=cachedir=/tmp/dnf_ci_installroot_9nq5djho/var/cache/dnf inthrone labirinto

    Last Command stderr:
    setopt: "module_platform_id=platform:f29": Option "module_platform_id" not found. Add "--help" for more information about the arguments.

For: https://github.com/rpm-software-management/dnf5/pull/2823