### PR TITLE
Allow vendor change in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN set -x && \
     dnf -y install dnf5 dnf5-plugins; \
     dnf5 -y copr enable rpmsoftwaremanagement/test-utils; \
     dnf5 -y copr enable rpmsoftwaremanagement/dnf-nightly; \
-    dnf5 -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*'
+    dnf5 --setopt=allow_vendor_change=true -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*'
 
 RUN set -x && \
     if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then \
@@ -45,7 +45,7 @@ COPY ./rpms/ /opt/ci/rpms/
 RUN set -x && \
     rm /opt/ci/rpms/*-{devel,debuginfo,debugsource}*.rpm; \
     if [ -n "$(find /opt/ci/rpms/ -maxdepth 1 -name '*.rpm' -print -quit)" ]; then \
-        dnf5 -y install /opt/ci/rpms/*.rpm --disableplugin=local && \
+        dnf5 --setopt=allow_vendor_change=true -y install /opt/ci/rpms/*.rpm --disableplugin=local && \
         dnf5 -y versionlock add $(rpm -qp --queryformat '%{NAME}\n' /opt/ci/rpms/*.rpm | sort | uniq); \
     fi
 
@@ -55,7 +55,8 @@ COPY ./dnf-behave-tests/ /opt/ci/dnf-behave-tests
 # install test suite dependencies
 # Temporarily exclude new libfaketime because it doesn't work: https://bugzilla.redhat.com/show_bug.cgi?id=2381595
 RUN set -x && \
-    dnf5 -y builddep /opt/ci/dnf-behave-tests/requirements.spec -x libfaketime-0.9.12-1.* && \
+    dnf5 --setopt=allow_vendor_change=true -y \
+        builddep /opt/ci/dnf-behave-tests/requirements.spec -x libfaketime-0.9.12-1.* && \
     pip3 install -r /opt/ci/dnf-behave-tests/requirements.txt
 
 # create directory for dbus daemon socket


### PR DESCRIPTION
Now when Fedora >= 45 forbids vendor change and we want to upgrade dnf5 package from Fedora build to Copr build, we need to allow the vendor change. Otherwise this error comes out:

    + dnf5 -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*' Updating and loading repositories:
     Copr repo for test-utils owned by rpms 100% |   4.6 KiB/s |   3.9 KiB |  00m01s
     Copr repo for dnf-nightly owned by rpm 100% | 161.2 KiB/s | 211.4 KiB |  00m01s
    Repositories loaded.
    Failed to resolve the transaction:
    Problem 1: problem with installed package
      - dnf5-5.4.2.1-10.fc45.x86_64 does not belong to a distupgrade repository