### PR TITLE
Dockerfile: respect TYPE=distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,10 @@ RUN set -x && \
     dnf -y install systemd --allowerasing; \
     dnf -y install dnf5 dnf5-plugins; \
     dnf5 -y copr enable rpmsoftwaremanagement/test-utils; \
-    dnf5 -y copr enable rpmsoftwaremanagement/dnf-nightly; \
-    dnf5 --setopt=allow_vendor_change=true -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*'
+    if [ "$TYPE" == "nightly" ]; then \
+        dnf5 -y copr enable rpmsoftwaremanagement/dnf-nightly; \
+        dnf5 --setopt=allow_vendor_change=true -y distro-sync --from-repo copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf-nightly '*'; \
+    fi
 
 RUN set -x && \
     if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then \


### PR DESCRIPTION
TYPE=distro has been non-functional for a long time (since 1f0cd758a). When it was removed, dnf5 was not present in Fedora repositories, so a "distro" build of the dnf5 testing container didn't make sense.

TYPE=distro is useful when preparing a Fedora release or downstream patch to make sure tests pass with the versions of librepo, libpkgmanifest, etc. currently released in Fedora.