### PR TITLE
Allow vendor change for testing pull requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN set -x && \
 RUN set -x && \
     if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then \
        dnf5 -y copr enable $COPR; \
-       dnf5 -y install $COPR_RPMS; \
+       dnf5 --setopt=allow_vendor_change=true -y install $COPR_RPMS; \
     fi
 
 # install local RPMs if available


### PR DESCRIPTION
Testing pull request installs packages from a distinct Copr user and that fails now because of a different vendor string:

    STEP 10/18: RUN set -x &&     if [ -n "$COPR" ] && [ -n "$COPR_RPMS" ]; then        dnf5 -y copr enable $COPR;        dnf5 -y install $COPR_RPMS;     fi
      - conflicting requests
    Skipping 4 packages due to vendor change restriction: "Fedora Copr - user rpmsoftwaremanagement" -> "Fedora Copr - user packit".

I forgot to cover this case in commit
6aa8ccbaaa4c6d5705c59132fece4ca6b9f7a202 ("Allow vendor change in the Dockerfile").