### PR TITLE
Tests for "--add-vendor-policy=" and "--clear-vendor-policies", updated hints (new hint "--add-vendor-policy")

### DIFF
--- a/dnf-behave-tests/dnf/stick-to-vendor-default.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor-default.feature
@@ -50,7 +50,8 @@ Scenario: Hint shown when vendor change blocked by default
        """
        Skipping 1 package due to vendor change restriction: "First Vendor" -> "Second Vendor".
        """
-   And stderr contains "--allow-vendor-change to allow changing package vendors"
+   And stderr contains "--add-vendor-policy to add specific vendor change rules"
+   And stderr contains "--allow-vendor-change to allow all vendor changes"
 
 
 Scenario: Override default with --setopt=allow_vendor_change=true

--- a/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor-policies.feature
@@ -43,6 +43,92 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
    And stdout contains "Vendor *: Second Vendor"
 
 
+Scenario: Upgrade with vendor policy - vendor change not allowed (policy from conf file cleared using --clear-vendor-policies)
+  Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Second Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--clear-vendor-policies upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.1-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: First Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second and Third Vendor (Third has newer version)
+  Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Third Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.3-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Third Vendor"
+
+
+Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (policy from conf file cleared using --clear-vendor-policies)
+  Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
+      """
+      version = '1.0'
+
+      [[outgoing_vendors]]
+      vendor = 'First Vendor'
+
+      [[incoming_vendors]]
+      vendor = 'Third Vendor'
+      """
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--clear-vendor-policies --add-vendor-policy=out:\"First\ Vendor\",in:\"Second\ Vendor\" upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
 Scenario: Upgrade with vendor policy - allow change from First Vendor to Second Vendor (conf file in /usr)
   Given I create file "/usr/share/dnf5/vendors.d/test-policy.conf" with
       """
@@ -76,7 +162,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
       vendor = 'First Vendor'
 
       [[incoming_vendors]]
-      vendor = 'Second Vendor'
+      vendor = 'Third Vendor'
       """
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
       """
@@ -86,7 +172,7 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
       vendor = 'First Vendor'
 
       [[incoming_vendors]]
-      vendor = 'Third Vendor'
+      vendor = 'Second Vendor'
       """
   Given I use repository "dnf-ci-vendor-1-updates"
   Given I use repository "dnf-ci-vendor-2-updates"
@@ -95,10 +181,10 @@ Scenario: Upgrade with vendor policy - allow change from First Vendor to Second 
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |
-       | upgrade | vendor-1.3-1.x86_64 |
+       | upgrade | vendor-1.2-1.x86_64 |
   Given I successfully execute rpm with args "-qi vendor"
    Then the exit code is 0
-   And stdout contains "Vendor *: Third Vendor"
+   And stdout contains "Vendor *: Second Vendor"
 
 
 Scenario: Upgrade with vendor policy - equivalent vendors (mutual change allowed)
@@ -116,6 +202,20 @@ Scenario: Upgrade with vendor policy - equivalent vendors (mutual change allowed
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - equivalent vendors (mutual change allowed, --add-vendor-policy, used optional '=')
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=eq:=\"First\ Vendor\",eq:\"Second\ Vendor\" upgrade vendor"
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |
@@ -174,6 +274,20 @@ Scenario: Upgrade with vendor policy - glob pattern matching
    And stdout contains "Vendor *: Third Vendor"
 
 
+Scenario: Upgrade with vendor policy - glob pattern matching (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=out:\"First\ Vendor\",in:=*\"*Ve*or\" upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.3-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Third Vendor"
+
+
 Scenario: Upgrade with vendor policy - case insensitive matching and starts with
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
       """
@@ -191,6 +305,20 @@ Scenario: Upgrade with vendor policy - case insensitive matching and starts with
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - case insensitive matching and starts with (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=out:i^\"first\",in:i=\"second\ vendor\" upgrade vendor"
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |
@@ -219,6 +347,20 @@ Scenario: Upgrade with vendor policy - using exclude to prevent specific vendor
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade vendor"
+   Then the exit code is 0
+   And Transaction is following
+       | Action  | Package             |
+       | upgrade | vendor-1.2-1.x86_64 |
+  Given I successfully execute rpm with args "-qi vendor"
+   Then the exit code is 0
+   And stdout contains "Vendor *: Second Vendor"
+
+
+Scenario: Upgrade with vendor policy - using exclude to prevent specific vendor (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=eq:e\"Third\ Vendor\",eq:*\"\" upgrade vendor"
    Then the exit code is 0
    And Transaction is following
        | Action  | Package             |

--- a/dnf-behave-tests/dnf/stick-to-vendor-policies1_1.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor-policies1_1.feature
@@ -50,6 +50,23 @@ Scenario: Upgrade with vendor policy - equivalent vendors and incoming vendors t
     """
 
 
+Scenario: Upgrade with vendor policy - equivalent vendors and incoming vendors together (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=eq:\"First\ Vendor\",eq:\"Second\ Vendor\",in:\"Third\ Vendor\" upgrade '*'"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.3-1 : Third Vendor
+    vendorpkg-1.12-1 : Third Vendor
+    vendordep-1.8-1 : Third Vendor
+    vendordep2-1.2-1 : Third Vendor
+    """
+
+
 Scenario: Upgrade with vendor policy - any vendor change to "Second vendor" is allowed
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
     """
@@ -62,6 +79,24 @@ Scenario: Upgrade with vendor policy - any vendor change to "Second vendor" is a
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade '*'"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.2-1 : Second Vendor
+    vendorpkg-1.10-1 : Second Vendor
+    vendordep-1.6-1 : First Vendor
+    vendordep2-1.1-1 : Second Vendor
+    vendordep3-1.2-1 : Third Vendor
+    """
+
+
+Scenario: Upgrade with vendor policy - any vendor change to "Second vendor" is allowed (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=in:\"Second\ Vendor\" upgrade '*'"
    Then the exit code is 0
   Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
    Then the exit code is 0
@@ -89,6 +124,23 @@ Scenario: Upgrade with vendor policy - Allow packages from the command-line repo
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade {context.dnf.fixturesdir}/repos/dnf-ci-vendor-2-updates/x86_64/vendor-1.2-1.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-vendor-3-updates/x86_64/vendorpkg-1.12-1.x86_64.rpm"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.2-1 : Second Vendor
+    vendorpkg-1.12-1 : Third Vendor
+    vendordep-1.0-1 : First Vendor
+    vendordep2-1.2-1 : Third Vendor
+    """
+
+
+Scenario: Upgrade with vendor policy - Allow packages from the command-line repo from any vendor (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=@in:[cmdline_repo=\"true\"] upgrade {context.dnf.fixturesdir}/repos/dnf-ci-vendor-2-updates/x86_64/vendor-1.2-1.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-vendor-3-updates/x86_64/vendorpkg-1.12-1.x86_64.rpm"
    Then the exit code is 0
   Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
    Then the exit code is 0
@@ -132,6 +184,22 @@ Scenario: Upgrade with vendor policy - Allow packages from the command-line repo
     """
 
 
+Scenario: Upgrade with vendor policy - Allow packages from the command-line repo from any vendor with exclusion packages whose name ends with "pkg" (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=@in:e[name$\"pkg\"],in:[cmdline_repo=\"1\"] upgrade {context.dnf.fixturesdir}/repos/dnf-ci-vendor-2-updates/x86_64/vendor-1.2-1.x86_64.rpm {context.dnf.fixturesdir}/repos/dnf-ci-vendor-3-updates/x86_64/vendorpkg-1.12-1.x86_64.rpm"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.2-1 : Second Vendor
+    vendorpkg-1.0-1 : First Vendor
+    vendordep-1.0-1 : First Vendor
+    """
+
+
 Scenario: Upgrade with vendor policy - all incoming packages whose source name starting "vend" and version is >= "1.8" to change vendor to "Third Vendor"
   Given I create file "/etc/dnf/vendors.d/test-policy.conf" with
     """
@@ -150,6 +218,23 @@ Scenario: Upgrade with vendor policy - all incoming packages whose source name s
   Given I use repository "dnf-ci-vendor-2-updates"
   Given I use repository "dnf-ci-vendor-3-updates"
    When I execute dnf with args "upgrade '*'"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    vendor-1.1-1 : First Vendor
+    vendorpkg-1.12-1 : Third Vendor
+    vendordep-1.8-1 : Third Vendor
+    vendordep2-1.2-1 : Third Vendor
+    """
+
+
+Scenario: Upgrade with vendor policy - all incoming packages whose source name starting "vend" and version is >= "1.8" to change vendor to "Third Vendor" (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=in:\"Third\ Vendor\"@in:[source_name^\"vend\",version\>=\"1.8\"] upgrade '*'"
    Then the exit code is 0
   Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -a"
    Then the exit code is 0

--- a/dnf-behave-tests/dnf/stick-to-vendor-policies1_2.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor-policies1_2.feature
@@ -55,3 +55,32 @@ Examples:
     | ^t.ird.*  | NOT_REGEX       | vendor-1.3-1 : Third Vendor   |
     | ^t.ird.*  | NOT_IREGEX      | vendor-1.2-1 : Second Vendor  |
     | ^p.ird.*  | NOT_IREGEX      | vendor-1.3-1 : Third Vendor   |
+
+
+Scenario Outline: Upgrade with vendor policy - <comparator> (--add-vendor-policy)
+  Given I use repository "dnf-ci-vendor-1-updates"
+  Given I use repository "dnf-ci-vendor-2-updates"
+  Given I use repository "dnf-ci-vendor-3-updates"
+   When I execute dnf with args "--add-vendor-policy=in:<comparator>\"<vendor>\" upgrade '*'"
+   Then the exit code is 0
+  Given I successfully execute rpm with args "--queryformat='%{{name}}-%{{version}}-%{{release}} : %{{vendor}}\n' -q -i vendor"
+   Then the exit code is 0
+    And stdout contains lines
+    """
+    <stdout_line>
+    """
+
+Examples:
+    | vendor     | comparator | stdout_line                   |
+    | Third      | !^         | vendor-1.2-1 : Second Vendor  |
+    | third      | !^         | vendor-1.3-1 : Third Vendor   |
+    | third      | !i^        | vendor-1.2-1 : Second Vendor  |
+    | five       | !i^        | vendor-1.3-1 : Third Vendor   |
+    | rd\ Vendor | !$         | vendor-1.2-1 : Second Vendor  |
+    | rd\ vendor | !$         | vendor-1.3-1 : Third Vendor   |
+    | rd\ vendor | !i$        | vendor-1.2-1 : Second Vendor  |
+    | five       | !i$        | vendor-1.3-1 : Third Vendor   |
+    | ^T.ird.*   | !=~        | vendor-1.2-1 : Second Vendor  |
+    | ^t.ird.*   | !=~        | vendor-1.3-1 : Third Vendor   |
+    | ^t.ird.*   | !i=~       | vendor-1.2-1 : Second Vendor  |
+    | ^p.ird.*   | !i=~       | vendor-1.3-1 : Third Vendor   |

--- a/dnf-behave-tests/dnf/stick-to-vendor.feature
+++ b/dnf-behave-tests/dnf/stick-to-vendor.feature
@@ -63,5 +63,6 @@ Scenario: Downgrade is unable to resolve transaction
          - conflicting requests
        You can try to add to command line:
          --skip-broken to skip uninstallable packages
-         --allow-vendor-change to allow changing package vendors
+         --add-vendor-policy to add specific vendor change rules
+         --allow-vendor-change to allow all vendor changes
        """


### PR DESCRIPTION
Requires https://github.com/rpm-software-management/dnf5/pull/2870


Please review and merge first https://github.com/rpm-software-management/dnf5/pull/2866 and https://github.com/rpm-software-management/ci-dnf-stack/pull/1933, then I rebase this.