### PR TITLE
Move relocated repo files so that they don't interfere with tests

### DIFF
--- a/dnf-behave-tests/dnf/environment.py
+++ b/dnf-behave-tests/dnf/environment.py
@@ -55,7 +55,7 @@ class DNFContext(object):
 
             # move the following original system setup files to a backup location,
             # so that they don't interfere and the tests start with a clean state
-            for path in ("/etc/dnf/dnf.conf", "/etc/yum.repos.d", "/var/lib/dnf/modulefailsafe"):
+            for path in ("/etc/dnf/dnf.conf", "/etc/yum.repos.d", "/var/lib/dnf/modulefailsafe", "/usr/share/dnf5/repos.d"):
                 backup_path = path + ".backup"
                 if os.path.exists(backup_path):
                     raise AssertionError(


### PR DESCRIPTION
Fedora >= 45 moved repo definitions to `/usr/share/dnf5/repos.d` we have to account for this change and move system repo files so that they don't interfere with tests (particularly no_installroot tests).

Resolves: https://github.com/rpm-software-management/ci-dnf-stack/issues/1936