### PR TITLE
Adjust tests for unified error reporting in query commands

### DIFF
--- a/dnf-behave-tests/dnf/info.feature
+++ b/dnf-behave-tests/dnf/info.feature
@@ -11,7 +11,7 @@ Scenario: dnf info nonexistentpkg
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
 
 
@@ -326,6 +326,7 @@ Scenario: dnf info installed setup basesystem (when basesystem is not installed)
  Then stderr is
       """
       <REPOSYNC>
+      No matches found for "basesystem".
       """
   And stdout matches line by line
       """
@@ -471,7 +472,7 @@ Given I use repository "dnf-ci-fedora-updates"
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
   And stdout is empty
 
@@ -521,7 +522,7 @@ Scenario: dnf info obsoletes setup (when setup is not obsoleted)
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
 
 

--- a/dnf-behave-tests/dnf/list-recent.feature
+++ b/dnf-behave-tests/dnf/list-recent.feature
@@ -51,5 +51,5 @@ Scenario: dnf list package that is not recently added
     And stderr is
         """
         <REPOSYNC>
-        No matching packages to list
+        No matches found.
         """

--- a/dnf-behave-tests/dnf/list-showduplicates.feature
+++ b/dnf-behave-tests/dnf/list-showduplicates.feature
@@ -104,6 +104,7 @@ Scenario: Test for list without --showduplicates when the package is not install
 
 @bz1655605
 Scenario: Test for list --available --showduplicates when package is installed and repository is disabled
+Given I use repository "simple-base"
  When I drop repository "dnf-ci-fedora"
   And I drop repository "dnf-ci-fedora-updates-testing"
   And I execute dnf with args "install flac-1.3.3-1.fc29.x86_64"
@@ -132,5 +133,5 @@ Scenario: Test for list --available --showduplicates when package is installed a
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """

--- a/dnf-behave-tests/dnf/list.feature
+++ b/dnf-behave-tests/dnf/list.feature
@@ -11,7 +11,7 @@ Scenario: dnf list nonexistentpkg
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
 
 
@@ -225,6 +225,7 @@ Scenario: dnf list installed setup basesystem (when basesystem is not installed)
  Then stderr is
       """
       <REPOSYNC>
+      No matches found for "basesystem".
       """
   And stdout matches line by line
       """
@@ -341,7 +342,7 @@ Given I use repository "dnf-ci-fedora-updates"
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
   And stdout is empty
 
@@ -372,7 +373,7 @@ Scenario: dnf list obsoletes setup (when setup is not obsoleted)
   And stderr is
       """
       <REPOSYNC>
-      No matching packages to list
+      No matches found.
       """
 
 

--- a/dnf-behave-tests/dnf/module/info-without-install.feature
+++ b/dnf-behave-tests/dnf/module/info-without-install.feature
@@ -255,7 +255,7 @@ Scenario: Get info for an enabled stream, module name and stream specified
     And stderr is
         """
         <REPOSYNC>
-        No matches found for "non-existing-module".
+        No matches found.
         """
 
 

--- a/dnf-behave-tests/dnf/module/platform.feature
+++ b/dnf-behave-tests/dnf/module/platform.feature
@@ -45,7 +45,7 @@ Scenario: I can't list info for the pseudo-module
   And stderr is
       """
       <REPOSYNC>
-      No matches found for "pseudoplatform".
+      No matches found.
       """
 
 

--- a/dnf-behave-tests/dnf/plugins-path.feature
+++ b/dnf-behave-tests/dnf/plugins-path.feature
@@ -7,7 +7,7 @@ Given I do not disable plugins
 
 
 Scenario: Redirect pluginpath and pluginconfpath
-Given I successfully execute dnf with args "repo list"
+Given I successfully execute dnf with args "repoquery --installed"
   And file "/var/log/dnf5.log" contains lines
       """
       .* Loaded libdnf plugin "actions" .*
@@ -15,7 +15,7 @@ Given I successfully execute dnf with args "repo list"
   And I configure dnf with
       | key        | value                                  |
       | pluginpath | {context.dnf.installroot}/test/plugins |
- When I execute dnf with args "repo list"
+ When I execute dnf with args "repoquery --installed"
  Then the exit code is 1
   And stdout is empty
   And stderr is
@@ -28,7 +28,7 @@ Given I delete file "/var/log/dnf5.log"
   And I configure dnf with
       | key            | value                                  |
       | pluginconfpath | {context.dnf.installroot}/test/plugins |
- When I execute dnf with args "repo list"
+ When I execute dnf with args "repoquery --installed"
  Then the exit code is 0
   And stdout is empty
   And stderr is empty
@@ -39,7 +39,7 @@ Given I delete file "/var/log/dnf5.log"
 
 
 Scenario: Test default pluginsconfpath
-Given I successfully execute dnf with args "repo list"
+Given I successfully execute dnf with args "repoquery --installed"
   And file "/var/log/dnf5.log" contains lines
       """
       .* Loaded libdnf plugin "actions" .*
@@ -51,7 +51,7 @@ Given I successfully execute dnf with args "repo list"
       enabled = 0
       """
  # pluginconfpath is not related to installroot, so actions are not disabled
- When I execute dnf with args "repo list"
+ When I execute dnf with args "repoquery --installed"
  Then the exit code is 0
   And stdout is empty
   And stderr is empty
@@ -62,7 +62,7 @@ Given I successfully execute dnf with args "repo list"
 
 
 Scenario: Redirect pluginsconfpath in dnf.conf
-Given I successfully execute dnf with args "repo list"
+Given I successfully execute dnf with args "repoquery --installed"
   And file "/var/log/dnf5.log" contains lines
       """
       .* Loaded libdnf plugin "actions" .*
@@ -78,7 +78,7 @@ Given I successfully execute dnf with args "repo list"
   # Remove the previous log which contains successfully loaded plugin actions msg
   And I delete file "/var/log/dnf5.log"
  # pluginconfpath is now set in installroot, so versionlock is disabled
- When I execute dnf with args "repo list"
+ When I execute dnf with args "repoquery --installed"
  Then the exit code is 0
   And stdout is empty
   And stderr is empty

--- a/dnf-behave-tests/dnf/provides.feature
+++ b/dnf-behave-tests/dnf/provides.feature
@@ -39,7 +39,8 @@ Scenario: dnf provides nonexistentprovide
     And stderr is
        """
        <REPOSYNC>
-       No matches found. If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
+       No matches found.
+       If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
        """
 
 Scenario: test order of provides "dnf provides webclient A B C"
@@ -50,9 +51,9 @@ Scenario: test order of provides "dnf provides webclient A B C"
     And stderr is
         """
         <REPOSYNC>
-        No matches found for A.
-        No matches found for B.
-        No matches found for C.
+        No matches found for "A".
+        No matches found for "B".
+        No matches found for "C".
         If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
         """
 
@@ -64,9 +65,9 @@ Scenario: test order of provides "dnf provides A webclient B C"
     And stderr is
         """
         <REPOSYNC>
-        No matches found for A.
-        No matches found for B.
-        No matches found for C.
+        No matches found for "A".
+        No matches found for "B".
+        No matches found for "C".
         If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
         """
 
@@ -78,9 +79,9 @@ Scenario: test order of provides "dnf provides A B C webclient"
     And stderr is
         """
         <REPOSYNC>
-        No matches found for A.
-        No matches found for B.
-        No matches found for C.
+        No matches found for "A".
+        No matches found for "B".
+        No matches found for "C".
         If searching for a file, try specifying the full path or using a wildcard prefix ("*/") at the beginning.
         """
 

--- a/dnf-behave-tests/dnf/query-no-matches.feature
+++ b/dnf-behave-tests/dnf/query-no-matches.feature
@@ -1,0 +1,457 @@
+Feature: Unified error reporting for query commands
+
+
+# https://github.com/rpm-software-management/dnf5/issues/1075
+# Query commands should report:
+# - when no repositories are enabled, a message about no repos (or an
+#   installroot hint when no repos are configured in the installroot)
+# - "No matches found for <spec>." when some arguments don't match
+# - Domain-specific messages when there are no candidates at all
+
+
+# ==================
+# group list / info
+# ==================
+
+Scenario: group list reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "group list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: group info reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "group info"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: group list with spec reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "group list test-group"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: group list --installed with no groups installed
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "group list --installed"
+  Then the exit code is 0
+   And stderr contains "No matches found: no groups are installed."
+
+
+# Use a repo without comps data so no groups come from repos.
+# The only groups are installed ones from system state (groups.toml).
+Scenario: group list --available with no groups available
+ Given I use repository "dnf-ci-fedora"
+   And I create file "/usr/lib/sysimage/libdnf5/groups.toml" with
+       """
+       version = "1.0"
+       [groups]
+       [groups.test-group]
+       userinstalled = true
+       """
+   And I successfully execute dnf with args "group list"
+  Then stdout is
+       """
+       <REPOSYNC>
+       ID                   Name Installed
+       test-group                      yes
+       """
+  When I execute dnf with args "group list --available"
+  Then the exit code is 0
+   And stderr contains "No matches found: no groups are available."
+
+
+Scenario: group list reports unmatched spec when some match
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "group list test-group nonexistent"
+  Then the exit code is 0
+   And stdout contains "test-group"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+Scenario: group list reports when all specs unmatched
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "group list nonexistent1 nonexistent2"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+Scenario: group info reports unmatched spec when some match
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "group info test-group nonexistent"
+  Then the exit code is 0
+   And stdout contains "test-group"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+# ========================
+# environment list / info
+# ========================
+
+Scenario: environment list reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "environment list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: environment info reports no repos when all repos disabled
+ Given I use repository "comps-group-list" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "environment info"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: environment list --installed with no environments installed
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "environment list --installed"
+  Then the exit code is 0
+   And stderr contains "No matches found: no environments are installed."
+
+
+# Use a repo without comps data so no environments come from repos.
+Scenario: environment list --available with no environments available
+ Given I use repository "dnf-ci-fedora"
+   And I create file "/usr/lib/sysimage/libdnf5/environments.toml" with
+       """
+       version = "1.0"
+       [environments]
+       test-environment = {groups = [], userinstalled = true}
+       """
+   And I successfully execute dnf with args "environment list"
+  Then stdout is
+       """
+       <REPOSYNC>
+       ID                   Name Installed
+       test-environment                yes
+       """
+  When I execute dnf with args "environment list --available"
+  Then the exit code is 0
+   And stderr contains "No matches found: no environments are available."
+
+
+Scenario: environment list reports unmatched spec when some match
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "environment list test-environment nonexistent"
+  Then the exit code is 0
+   And stdout contains "test-environment"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+Scenario: environment list reports when all specs unmatched
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "environment list nonexistent1 nonexistent2"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+Scenario: environment info reports unmatched spec when some match
+ Given I use repository "comps-group-list"
+  When I execute dnf with args "environment info test-environment nonexistent"
+  Then the exit code is 0
+   And stdout contains "test-environment"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+# ==================
+# repo list / info
+# ==================
+
+Scenario: repo list reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "repo list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: repo info reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "repo info"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: repo list reports unmatched spec when some match
+ Given I use repository "dnf-ci-fedora"
+   And I use repository "dnf-ci-fedora-updates"
+  When I execute dnf with args "repo list dnf-ci-fedora nonexistent"
+  Then the exit code is 0
+   And stdout contains "dnf-ci-fedora"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+Scenario: repo list reports when all specs unmatched
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "repo list nonexistent1 nonexistent2"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+Scenario: repo info reports unmatched spec when some match
+ Given I use repository "dnf-ci-fedora"
+   And I use repository "dnf-ci-fedora-updates"
+  When I execute dnf with args "repo info dnf-ci-fedora nonexistent"
+  Then the exit code is 0
+   And stdout contains "dnf-ci-fedora"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+# ==================
+# advisory list / info
+# ==================
+
+Scenario: advisory list reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "advisory list"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: advisory info reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "advisory info"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: advisory summary reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "advisory summary"
+  Then the exit code is 0
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+# ==================
+# repoquery
+# ==================
+
+Scenario: repoquery reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "repoquery"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: repoquery with spec reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "repoquery nonexistent"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: repoquery --installed does not report no repos enabled
+  When I execute dnf with args "repoquery --installed"
+  Then the exit code is 0
+   And stderr does not contain "no repositories are enabled"
+
+
+# ==================
+# list / info
+# ==================
+
+Scenario: list reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "list"
+  Then the exit code is 0
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: list with spec reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "list nonexistent"
+  Then the exit code is 1
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: list --installed does not report no repos enabled
+  When I execute dnf with args "list --installed"
+  Then the exit code is 0
+   And stderr does not contain "no repositories are enabled"
+
+
+Scenario: list reports unmatched spec when some match
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "list setup nonexistent"
+  Then the exit code is 0
+   And stdout contains "setup"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+Scenario: list reports when all specs unmatched
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "list nonexistent1 nonexistent2"
+  Then the exit code is 1
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+# ==================
+# module list / info
+# ==================
+
+@not.with_os=rhel__ge__11
+Scenario: module list reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora-modular" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "module list"
+  Then the exit code is 0
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+@not.with_os=rhel__ge__11
+Scenario: module list reports unmatched spec when some match
+ Given I use repository "dnf-ci-fedora-modular"
+  When I execute dnf with args "module list nodejs nonexistent"
+  Then the exit code is 0
+   And stdout contains "nodejs"
+   And stderr contains "No matches found for \"nonexistent\"."
+
+
+@not.with_os=rhel__ge__11
+Scenario: module list reports when all specs unmatched
+ Given I use repository "dnf-ci-fedora-modular"
+  When I execute dnf with args "module list nonexistent1 nonexistent2"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+@not.with_os=rhel__ge__11
+Scenario: module list reports no module streams exist
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "module list"
+  Then the exit code is 0
+   And stderr contains "No matches found: no module streams exist."
+
+
+# ==================
+# search
+# ==================
+
+Scenario: search reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "search nonexistent"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: search reports no matches found
+ Given I use repository "dnf-ci-fedora"
+  When I execute dnf with args "search nonexistent"
+  Then the exit code is 0
+   And stdout is empty
+   And stderr contains "No matches found."
+
+
+# ==================
+# provides
+# ==================
+
+Scenario: provides reports no repos when all repos disabled
+ Given I use repository "dnf-ci-fedora" with configuration
+       | key     | value |
+       | enabled | 0     |
+  When I execute dnf with args "provides webclient"
+  Then the exit code is 1
+   And stderr contains "No matches found: no repositories are enabled."
+
+
+Scenario: provides prints installroot hint when no repos configured
+  When I execute dnf with args "provides webclient"
+  Then the exit code is 1
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+# ==================
+# installroot hint
+# ==================
+
+Scenario: group list prints installroot hint when no repos configured
+  When I execute dnf with args "group list"
+  Then the exit code is 0
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: environment list prints installroot hint when no repos configured
+  When I execute dnf with args "environment list"
+  Then the exit code is 0
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: advisory list prints installroot hint when no repos configured
+  When I execute dnf with args "advisory list"
+  Then the exit code is 0
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: repoquery prints installroot hint when no repos configured
+  When I execute dnf with args "repoquery"
+  Then the exit code is 0
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: list prints installroot hint when no repos configured
+  When I execute dnf with args "list"
+  Then the exit code is 0
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: search prints installroot hint when no repos configured
+  When I execute dnf with args "search nonexistent"
+  Then the exit code is 0
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
+
+
+Scenario: copr list prints installroot hint when no repos configured
+  When I execute dnf with args "copr list"
+  Then the exit code is 0
+   And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."

--- a/dnf-behave-tests/dnf/repolist-disabled.feature
+++ b/dnf-behave-tests/dnf/repolist-disabled.feature
@@ -10,12 +10,14 @@ Scenario: Repolist without arguments
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout is empty
+    And stderr contains "No matches found: no repositories are enabled."
 
 
 Scenario: Repo list with "--enabled"
    When I execute dnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout is empty
+    And stderr contains "No matches found: no repositories are enabled."
 
 
 Scenario: Repo list with "--disabled"

--- a/dnf-behave-tests/dnf/repolist-no-repos.feature
+++ b/dnf-behave-tests/dnf/repolist-no-repos.feature
@@ -5,25 +5,25 @@ Scenario: Repolist without arguments
    When I execute dnf with args "repolist"
    Then the exit code is 0
     And stdout is empty
-    And stderr is empty
+    And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
 
 
 Scenario: Repo list with "--enabled"
    When I execute dnf with args "repo list --enabled"
    Then the exit code is 0
     And stdout is empty
-    And stderr is empty
+    And stderr contains "No repositories were loaded from the installroot. To use the configuration and repositories of the host system, pass --use-host-config."
 
 
 Scenario: Repo list with "--disabled"
    When I execute dnf with args "repo list --disabled"
    Then the exit code is 0
     And stdout is empty
-    And stderr is empty
+    And stderr contains "No matches found."
 
 
 Scenario: Repo list with "--all"
    When I execute dnf with args "repo list --all"
    Then the exit code is 0
     And stdout is empty
-    And stderr is empty
+    And stderr contains "No matches found."

--- a/dnf-behave-tests/dnf/repoquery/main.feature
+++ b/dnf-behave-tests/dnf/repoquery/main.feature
@@ -257,9 +257,11 @@ Given I successfully execute dnf with args "install bottom-a1"
       """
 
 Scenario: repoquery -C (with cache, but disabled repository)
+Given I use repository "dnf-ci-fedora"
 Given I successfully execute dnf with args "makecache"
 Given I drop repository "repoquery-main"
- When I execute dnf with args "repoquery --available -C"
+ # query a package only in the dropped repo to verify its cache is not used
+ When I execute dnf with args "repoquery --available -C top-a"
  Then the exit code is 0
   And stderr is
       """


### PR DESCRIPTION
Add new test scenarios and update existing ones to match the unified error messages introduced in dnf5 for query commands (group, environment, repo, advisory, repoquery, module, provides).

For: https://github.com/rpm-software-management/dnf5/issues/1075
Requires: https://github.com/rpm-software-management/dnf5/pull/2871