### PR TITLE
Dockerfile: Copy dnf5 repo configs for dnf4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,13 @@ RUN set -x && \
         dnf5 -y install dnf4; \
     fi
 
+# Make dnf5 repo configs available to dnf4 on systems where repos
+# have moved to /usr/share/dnf5/repos.d (Fedora 45+)
+RUN set -x && \
+    if [ -d /usr/share/dnf5/repos.d ]; then \
+        cp -n /usr/share/dnf5/repos.d/*.repo /etc/yum.repos.d/ 2>/dev/null || true; \
+    fi
+
 # enable the test-utils repo
 RUN set -x && \
     dnf4 -y --refresh upgrade; \


### PR DESCRIPTION
On systems where repo configs have moved to `/usr/share/dnf5/repos.d`, dnf4 cannot find them since it only looks in `/etc/yum.repos.d`. This causes the container build to fail with `There are no enabled repositories` when running on newer base images.

Copy the configs so the build steps that use dnf4 can find enabled repositories.

> Assisted-by: AI
> I am knowledgeable in this problem domain and reviewed it carefully.